### PR TITLE
Add common agent list to bootstrap message

### DIFF
--- a/synapse/agent_context.py
+++ b/synapse/agent_context.py
@@ -100,6 +100,8 @@ ROUTING: If message starts with @<agent>, forward WITHOUT processing yourself.
 REPLY: When you receive [A2A:id:sender], respond by default.
   python3 synapse/tools/a2a.py send --target <sender> "<response>"
 
+AGENTS: claude, gemini, codex
+
 LIST: python3 synapse/tools/a2a.py list"""
 
 

--- a/tests/test_agent_context.py
+++ b/tests/test_agent_context.py
@@ -187,6 +187,14 @@ class TestBuildBootstrapMessage:
         # Should reference the synapse-a2a skill
         assert "synapse-a2a" in msg
 
+    def test_message_lists_common_agents(self):
+        """Bootstrap message should list common agent types."""
+        msg = build_bootstrap_message("synapse-claude-8100", 8100).lower()
+
+        assert "claude" in msg
+        assert "gemini" in msg
+        assert "codex" in msg
+
     def test_different_ports(self):
         """Should use different port in message."""
         msg1 = build_bootstrap_message("synapse-claude-8100", 8100)


### PR DESCRIPTION
## Summary
- add common agent list (claude, gemini, codex) to bootstrap instructions
- add test to ensure the list is present (case-insensitive)

## Testing
- pytest tests/test_agent_context.py -v

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ブートストラップメッセージにエージェント情報（Claude、Gemini、Codex）を追加しました

* **テスト**
  * ブートストラップメッセージでのエージェント列挙機能の検証テストを追加しました

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->