### PR TITLE
feat: support agent ID in synapse stop command

### DIFF
--- a/tests/test_cli_extra.py
+++ b/tests/test_cli_extra.py
@@ -18,7 +18,7 @@ class TestCliExtra:
 
     def test_cmd_stop_all(self, mock_args):
         """Test stopping all agents with --all flag."""
-        mock_args.profile = "claude"
+        mock_args.target = "claude"
         mock_args.all = True
 
         running_infos = [

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -125,7 +125,7 @@ class TestCliMain:
 
         mock_cmd_stop.assert_called_once()
         args = mock_cmd_stop.call_args[0][0]
-        assert args.profile == "claude"
+        assert args.target == "claude"
 
     @patch("synapse.cli.cmd_logs")
     @patch("synapse.cli.install_skills")

--- a/tests/test_cli_refactor_spec.py
+++ b/tests/test_cli_refactor_spec.py
@@ -142,7 +142,7 @@ class TestCliRefactorSpec:
         Spec: 'stop' command must locate running agent via PortManager and kill PID.
         """
         # Arrange
-        mock_args.profile = "claude"
+        mock_args.target = "claude"
         mock_args.all = False
 
         mock_registry = MagicMock()

--- a/uv.lock
+++ b/uv.lock
@@ -1042,14 +1042,13 @@ wheels = [
 
 [[package]]
 name = "synapse-a2a"
-version = "0.2.0"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },
+    { name = "httpx" },
     { name = "pyyaml" },
     { name = "requests" },
-    { name = "types-pyyaml" },
-    { name = "types-requests" },
     { name = "uvicorn" },
 ]
 
@@ -1076,10 +1075,9 @@ grpc = [
 [package.metadata]
 requires-dist = [
     { name = "fastapi", specifier = ">=0.100.0" },
+    { name = "httpx", specifier = ">=0.24.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "requests", specifier = ">=2.31.0" },
-    { name = "types-pyyaml", specifier = ">=6.0.12.20250915" },
-    { name = "types-requests", specifier = ">=2.32.4.20250913" },
     { name = "uvicorn", specifier = ">=0.23.0" },
 ]
 


### PR DESCRIPTION
## Summary

- Allow stopping specific agent instances by their ID (e.g., `synapse-claude-8100`) in addition to profile names
- This enables precise control when multiple instances of the same agent type are running
- Enhanced `--help` text with detailed examples

## Changes

- Accept both profile names and agent IDs as stop target
- Add comprehensive help text with examples  
- Update tests for new argument name (`profile` -> `target`)
- Add tests for agent ID lookup

## Usage

```bash
# By profile name (existing behavior)
synapse stop claude                  # Stop oldest Claude instance
synapse stop gemini -a               # Stop all Gemini instances

# By agent ID (new feature)
synapse stop synapse-claude-8100     # Stop specific agent by ID
synapse stop synapse-codex-8120      # Stop specific Codex instance
```

## Test plan

- [x] Existing stop tests pass
- [x] New agent ID lookup tests pass
- [x] All 973 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Stop コマンドがプロファイル名またはエージェント ID の両方での停止に対応しました。特定のエージェント ID (例: synapse-claude-8100) を指定して個別に停止できるようになりました。

* **ドキュメント**
  * Stop コマンドのヘルプテキストをプロファイル名とエージェント ID の両方の停止方法を説明するように更新しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->