### PR TITLE
chore: bump version to 0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.3] - 2025-01-11
+
+### Added
+
+- `synapse --version` flag to display version information (#66)
+- `synapse stop` now accepts agent ID for precise control (#67)
+  - Example: `synapse stop synapse-claude-8100`
+
+### Documentation
+
+- Enhanced `synapse stop --help` with detailed examples and tips
+
 ## [0.2.2] - 2025-01-11
 
 ### Fixed
@@ -108,6 +120,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - External agent connectivity vision document
 - PyPI publishing instructions
 
+[0.2.3]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.1.0...v0.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synapse-a2a"
-version = "0.2.2"
+version = "0.2.3"
 description = "Agent-to-Agent communication protocol for CLI agents"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Bump version to 0.2.3 for release.

## Changes in v0.2.3

### Added
- `synapse --version` flag to display version information (#66)
- `synapse stop` now accepts agent ID for precise control (#67)

### Documentation
- Enhanced `synapse stop --help` with detailed examples and tips

🤖 Generated with [Claude Code](https://claude.com/claude-code)