### PR TITLE
fix: handle PermissionError correctly in is_process_running

### DIFF
--- a/synapse/registry.py
+++ b/synapse/registry.py
@@ -14,8 +14,10 @@ def is_process_running(pid: int) -> bool:
     try:
         os.kill(pid, 0)  # Signal 0 only checks existence
         return True
-    except (ProcessLookupError, PermissionError):
-        return False
+    except ProcessLookupError:
+        return False  # Process does not exist
+    except PermissionError:
+        return True  # Process exists but we don't have permission to signal it
 
 
 def is_port_open(host: str, port: int, timeout: float = 1.0) -> bool:

--- a/tests/test_registry_extended.py
+++ b/tests/test_registry_extended.py
@@ -35,9 +35,9 @@ class TestHelperFunctions:
 
     @patch("synapse.registry.os.kill")
     def test_is_process_running_permission_error(self, mock_kill):
-        """Should return False on PermissionError."""
+        """Should return True on PermissionError (process exists but no permission)."""
         mock_kill.side_effect = PermissionError
-        assert is_process_running(1) is False
+        assert is_process_running(1) is True
 
     def test_is_port_open_true(self):
         """Should return True for an open port."""


### PR DESCRIPTION
## Summary

- Fixed `is_process_running()` to correctly handle `PermissionError` from `os.kill(pid, 0)`
- `PermissionError` means the process exists but we don't have permission to signal it - this should return `True`, not `False`
- This bug caused agents to incorrectly delete other agents' registry files when running in different permission contexts

## Root Cause

When Codex tried to send a message to Claude, it checked if Claude's process (PID 21465) was running using `os.kill(pid, 0)`. Due to permission differences between the two agents' execution environments, this raised `PermissionError`. The old code treated this as "process not found" and proceeded to delete Claude's registry file.

## Test plan

- [x] Updated `test_is_process_running_permission_error` to expect `True` instead of `False`
- [x] All 961 tests pass (5 failures are unrelated async test issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * プロセス実行状態の判定精度を向上させました。アクセス権限の制限によってプロセス情報の確認ができない場合でも、そのプロセスが確実に実行中であると正しく認識されるようになりました。これにより、より信頼性の高いシステム監視が実現されます。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->