### PR TITLE
fix: add httpx to requirements 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fastapi
 uvicorn
 pyyaml
+httpx>=0.24.0


### PR DESCRIPTION
Summary:

  - Add httpx>=0.24.0 to requirements.txt to keep dependency manifests aligned

  Rationale:

  - synapse/a2a_client.py imports httpx and pyproject.toml already requires it, so requirements.txt must
    include it to avoid install mismatches

  Tests:

  - Not run (dependency manifest update only)
