### PR TITLE
chore: bump version to 0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.6] - 2025-01-12
+
+### Added
+
+- Unix Domain Socket (UDS) transport for local A2A communication (#81)
+  - Lower latency and overhead for same-machine agent communication
+  - Automatic fallback to HTTP when UDS unavailable
+
+### Fixed
+
+- PID-based lock management for stale lock detection (#80)
+  - Detect and clean up stale locks from crashed processes
+  - Improve file safety reliability in multi-agent scenarios
+- Enable history and file safety in default settings.json
+- Add httpx to requirements (#83)
+- Resolve AsyncMock RuntimeWarning in test_a2a_compat_extended (#84)
+- Fix deprecated `asyncio.get_event_loop_policy` usage in conftest (#84)
+- Fix deprecated `datetime.utcnow` usage in test_utils (#84)
+
+### Changed
+
+- Install gRPC dependency group to enable previously skipped tests (#84)
+- Achieve 100% test pass rate (985 tests)
+
+### Documentation
+
+- Update file-safety guide with PID-based lock management (#82)
+
 ## [0.2.5] - 2025-01-12
 
 ### Fixed
@@ -155,6 +183,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - External agent connectivity vision document
 - PyPI publishing instructions
 
+[0.2.6]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.2.5...v0.2.6
 [0.2.5]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.2.4...v0.2.5
 [0.2.4]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.2.3...v0.2.4
 [0.2.3]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.2.2...v0.2.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synapse-a2a"
-version = "0.2.5"
+version = "0.2.6"
 description = "Agent-to-Agent communication protocol for CLI agents"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- Bump version from 0.2.5 to 0.2.6
- Update CHANGELOG.md with all changes since v0.2.5

## Changes included in v0.2.6

### Added
- Unix Domain Socket (UDS) transport for local A2A communication (#81)

### Fixed
- PID-based lock management for stale lock detection (#80)
- Enable history and file safety in default settings.json
- Add httpx to requirements (#83)
- Resolve AsyncMock RuntimeWarning in test_a2a_compat_extended (#84)
- Fix deprecated `asyncio.get_event_loop_policy` usage in conftest (#84)
- Fix deprecated `datetime.utcnow` usage in test_utils (#84)

### Changed
- Install gRPC dependency group to enable previously skipped tests (#84)
- Achieve 100% test pass rate (985 tests)

### Documentation
- Update file-safety guide with PID-based lock management (#82)

## Test plan
- [x] All 985 tests pass
- [ ] Merge and tag v0.2.6
- [ ] Publish to PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バージョン 0.2.6 リリースノート

* **新機能**
  * Unix Domain Socket (UDS) トランスポートを追加
  * レイテンシの向上とHTTPフォールバック機能

* **バグ修正**
  * スタイルロック検出の改善
  * ファイル・履歴の安全性デフォルト値を修正
  * テスト/ランタイムの調整
  * 非推奨機能の修正

* **ドキュメント**
  * チェンジログを更新

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->