### PR TITLE
feat: Add synapse instructions command for manual instruction management

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,13 @@ synapse history list                      # Show recent task history
 synapse history list --agent claude       # Filter by agent
 synapse history show <task_id>            # Show task details
 
+# Instructions management (for --resume mode or recovery)
+synapse instructions show                 # Show default instruction
+synapse instructions show claude          # Show Claude-specific instruction
+synapse instructions files claude         # List instruction files for Claude
+synapse instructions send claude          # Send instructions to running Claude agent
+synapse instructions send claude --preview # Preview without sending
+
 # Low-level A2A tool
 python3 synapse/tools/a2a.py list
 python3 synapse/tools/a2a.py send --target claude --priority 1 "message"
@@ -85,6 +92,10 @@ synapse/
 ├── registry.py      # File-based agent discovery (~/.a2a/registry/)
 ├── agent_context.py # Initial instructions generation for agents
 ├── history.py       # Session history persistence using SQLite
+├── commands/        # CLI command implementations
+│   ├── instructions.py  # synapse instructions command
+│   ├── list.py          # synapse list command
+│   └── start.py         # synapse start command
 └── profiles/        # YAML configs per agent type (claude.yaml, codex.yaml, etc.)
 ```
 

--- a/README.md
+++ b/README.md
@@ -443,6 +443,9 @@ synapse claude -- --resume
 | `synapse list`                    | 実行中エージェント一覧 |
 | `synapse logs <profile>`          | ログ表示               |
 | `synapse send <target> <message>` | メッセージ送信         |
+| `synapse instructions show`       | インストラクション内容表示 |
+| `synapse instructions files`      | インストラクションファイル一覧 |
+| `synapse instructions send`       | 初期インストラクション再送信 |
 | `synapse history list`            | タスク履歴表示         |
 | `synapse history show <task_id>`  | タスク詳細表示         |
 | `synapse history search`          | キーワード検索         |
@@ -479,6 +482,31 @@ synapse codex -- resume --last
 - **Gemini**: `--resume`, `-r`
 - **Codex**: `resume`
 
+### インストラクション管理
+
+`--resume` モードで起動した場合など、初期インストラクションが送信されなかった場合に、手動で再送信できます。
+
+```bash
+# インストラクション内容を確認
+synapse instructions show claude
+
+# 利用されるインストラクションファイル一覧
+synapse instructions files claude
+
+# 実行中のエージェントに初期インストラクションを送信
+synapse instructions send claude
+
+# 送信前にプレビュー
+synapse instructions send claude --preview
+
+# 特定のエージェントIDを指定して送信
+synapse instructions send synapse-claude-8100
+```
+
+この機能は以下のケースで役立ちます：
+- `--resume` モードで起動後、A2A プロトコル情報が必要になった場合
+- エージェントがインストラクションを失った/忘れた場合のリカバリ
+- インストラクション内容の確認・デバッグ
 
 ### 外部エージェント管理
 

--- a/guides/references.md
+++ b/guides/references.md
@@ -25,7 +25,14 @@ flowchart TB
         list["list"]
         send["send"]
         logs["logs"]
+        instructions["instructions"]
         external["external"]
+    end
+
+    subgraph Instructions["instructions サブコマンド"]
+        inst_show["show"]
+        inst_files["files"]
+        inst_send["send"]
     end
 
     subgraph External["external サブコマンド"]
@@ -38,6 +45,7 @@ flowchart TB
 
     synapse --> Shortcuts
     synapse --> Commands
+    instructions --> Instructions
     external --> External
 ```
 
@@ -201,7 +209,97 @@ synapse logs gemini -n 100
 
 ---
 
-### 1.8 synapse external
+### 1.8 synapse instructions
+
+初期インストラクションを管理・送信します。
+
+```bash
+synapse instructions <command> [options]
+```
+
+#### 1.8.1 synapse instructions show
+
+エージェントのインストラクション内容を表示します。
+
+```bash
+synapse instructions show [agent_type]
+```
+
+| 引数 | 必須 | 説明 |
+|------|------|------|
+| `agent_type` | No | エージェントタイプ（claude, gemini, codex）。省略時はデフォルト設定を表示 |
+
+**例**:
+
+```bash
+synapse instructions show
+synapse instructions show claude
+synapse instructions show gemini
+```
+
+#### 1.8.2 synapse instructions files
+
+エージェントが読み込むインストラクションファイル一覧を表示します。
+
+```bash
+synapse instructions files [agent_type]
+```
+
+| 引数 | 必須 | 説明 |
+|------|------|------|
+| `agent_type` | No | エージェントタイプ。省略時はデフォルト設定を表示 |
+
+**例**:
+
+```bash
+synapse instructions files claude
+```
+
+**出力例**:
+
+```
+Instruction files for 'claude':
+  - .synapse/default.md
+  - .synapse/file-safety.md
+```
+
+#### 1.8.3 synapse instructions send
+
+実行中のエージェントに初期インストラクションを送信します。
+
+```bash
+synapse instructions send <target> [--preview]
+```
+
+| 引数 | 必須 | 説明 |
+|------|------|------|
+| `target` | Yes | 送信先（プロファイル名またはエージェントID） |
+| `--preview`, `-p` | No | 実際に送信せずプレビューのみ表示 |
+
+**例**:
+
+```bash
+# プロファイル名で送信
+synapse instructions send claude
+
+# エージェントIDで送信
+synapse instructions send synapse-claude-8100
+
+# プレビュー（送信しない）
+synapse instructions send claude --preview
+```
+
+**ユースケース**:
+
+| シチュエーション | コマンド |
+|----------------|----------|
+| `--resume` 後に A2A 機能が必要になった | `synapse instructions send claude` |
+| エージェントがインストラクションを忘れた | `synapse instructions send <agent>` |
+| 送信前に内容を確認したい | `synapse instructions send <agent> --preview` |
+
+---
+
+### 1.9 synapse external
 
 外部 Google A2A エージェントを管理します。
 

--- a/guides/usage.md
+++ b/guides/usage.md
@@ -129,6 +129,38 @@ synapse claude -- --resume=SESSION_ID
 
 ---
 
+### 1.4 インストラクション管理
+
+Resume Mode で起動した場合など、初期インストラクションが送信されなかった状況で、後からインストラクションを送信したい場合に使用します。
+
+```bash
+# インストラクション内容を確認
+synapse instructions show claude
+
+# 利用されるインストラクションファイル一覧
+synapse instructions files claude
+
+# 実行中のエージェントに初期インストラクションを送信
+synapse instructions send claude
+
+# 送信前にプレビュー（実際には送信しない）
+synapse instructions send claude --preview
+
+# 特定のエージェントIDを指定して送信
+synapse instructions send synapse-claude-8100
+```
+
+**ユースケース**:
+
+| シチュエーション | 対応 |
+|----------------|------|
+| `--resume` 後に A2A 機能が必要になった | `synapse instructions send <agent>` |
+| エージェントがインストラクションを忘れた | `synapse instructions send <agent>` |
+| インストラクション内容の確認 | `synapse instructions show <agent>` |
+| 設定ファイルの確認 | `synapse instructions files <agent>` |
+
+---
+
 ## 2. CLI コマンド
 
 ### 2.1 コマンド一覧
@@ -149,7 +181,14 @@ flowchart TB
         list["list"]
         send["send"]
         logs["logs"]
+        instructions["instructions"]
         external["external"]
+    end
+
+    subgraph Instructions["instructions サブコマンド"]
+        inst_show["show"]
+        inst_files["files"]
+        inst_send["send"]
     end
 
     subgraph External["external サブコマンド"]
@@ -162,6 +201,7 @@ flowchart TB
 
     synapse --> Shortcuts
     synapse --> Commands
+    instructions --> Instructions
     external --> External
 ```
 
@@ -174,6 +214,7 @@ flowchart TB
 | `synapse list` | 実行中エージェント一覧 |
 | `synapse send` | メッセージ送信 |
 | `synapse logs <profile>` | ログ表示 |
+| `synapse instructions` | インストラクション管理 |
 | `synapse external` | 外部エージェント管理 |
 
 ---

--- a/synapse/cli.py
+++ b/synapse/cli.py
@@ -538,6 +538,39 @@ def cmd_send(args: argparse.Namespace) -> None:
 
 
 # ============================================================
+# Instructions Commands
+# ============================================================
+
+
+def cmd_instructions_show(args: argparse.Namespace) -> None:
+    """Show instruction content for an agent type."""
+    from synapse.commands.instructions import InstructionsCommand
+
+    cmd = InstructionsCommand()
+    agent_type = getattr(args, "agent_type", None)
+    cmd.show(agent_type=agent_type)
+
+
+def cmd_instructions_files(args: argparse.Namespace) -> None:
+    """List instruction files for an agent type."""
+    from synapse.commands.instructions import InstructionsCommand
+
+    cmd = InstructionsCommand()
+    agent_type = getattr(args, "agent_type", None)
+    cmd.files(agent_type=agent_type)
+
+
+def cmd_instructions_send(args: argparse.Namespace) -> None:
+    """Send initial instructions to a running agent."""
+    from synapse.commands.instructions import InstructionsCommand
+
+    cmd = InstructionsCommand()
+    success = cmd.send(target=args.target, preview=args.preview)
+    if not success:
+        sys.exit(1)
+
+
+# ============================================================
 # File Safety Commands
 # ============================================================
 
@@ -1723,6 +1756,65 @@ Priority levels:
     )
     p_send.set_defaults(func=cmd_send)
 
+    # instructions - Manage and send initial instructions
+    p_instructions = subparsers.add_parser(
+        "instructions",
+        help="Manage and send initial instructions to agents",
+        description="""Manage and send initial instructions to running agents.
+
+Initial instructions are automatically sent when agents start, but can be
+re-sent manually using this command (useful for --resume mode or recovery).""",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""Examples:
+  synapse instructions show                   Show default instruction
+  synapse instructions show claude            Show Claude's instruction
+  synapse instructions files claude           List instruction files
+  synapse instructions send claude            Send instructions to Claude
+  synapse instructions send synapse-claude-8100  Send to specific agent
+  synapse instructions send claude --preview  Preview without sending""",
+    )
+    instructions_subparsers = p_instructions.add_subparsers(
+        dest="instructions_command", metavar="SUBCOMMAND"
+    )
+
+    # instructions show
+    p_inst_show = instructions_subparsers.add_parser(
+        "show", help="Show instruction content"
+    )
+    p_inst_show.add_argument(
+        "agent_type",
+        nargs="?",
+        help="Agent type (claude, gemini, codex). If omitted, shows default.",
+    )
+    p_inst_show.set_defaults(func=cmd_instructions_show)
+
+    # instructions files
+    p_inst_files = instructions_subparsers.add_parser(
+        "files", help="List instruction files"
+    )
+    p_inst_files.add_argument(
+        "agent_type",
+        nargs="?",
+        help="Agent type (claude, gemini, codex). If omitted, shows default.",
+    )
+    p_inst_files.set_defaults(func=cmd_instructions_files)
+
+    # instructions send
+    p_inst_send = instructions_subparsers.add_parser(
+        "send", help="Send instructions to a running agent"
+    )
+    p_inst_send.add_argument(
+        "target",
+        help="Target agent: profile name (claude, gemini, codex) or agent ID (synapse-claude-8100)",
+    )
+    p_inst_send.add_argument(
+        "--preview",
+        "-p",
+        action="store_true",
+        help="Preview instruction without sending",
+    )
+    p_inst_send.set_defaults(func=cmd_instructions_send)
+
     # history - Task history management
     p_history = subparsers.add_parser(
         "history",
@@ -2152,6 +2244,13 @@ Requires SYNAPSE_FILE_SAFETY_ENABLED=true to be set.""",
         not hasattr(args, "auth_command") or args.auth_command is None
     ):
         p_auth.print_help()
+        sys.exit(1)
+
+    # Handle instructions subcommand without action
+    if args.command == "instructions" and (
+        not hasattr(args, "instructions_command") or args.instructions_command is None
+    ):
+        p_instructions.print_help()
         sys.exit(1)
 
     # Handle file-safety subcommand without action (show status by default)

--- a/synapse/commands/instructions.py
+++ b/synapse/commands/instructions.py
@@ -1,0 +1,267 @@
+"""Instructions command implementation for Synapse CLI."""
+
+from __future__ import annotations
+
+import re
+import uuid
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+from synapse.port_manager import PORT_RANGES
+from synapse.registry import AgentRegistry
+from synapse.settings import SynapseSettings, get_settings
+
+if TYPE_CHECKING:
+    from synapse.a2a_client import A2AClient
+
+
+# Known profile names
+KNOWN_PROFILES = set(PORT_RANGES.keys())
+
+# Pattern to match agent IDs like "synapse-claude-8100"
+AGENT_ID_PATTERN = re.compile(r"^synapse-(\w+)-(\d+)$")
+
+
+class InstructionsCommand:
+    """Manage and send initial instructions to agents."""
+
+    def __init__(
+        self,
+        settings_factory: Callable[[], SynapseSettings] | None = None,
+        registry_factory: Callable[[], AgentRegistry] | None = None,
+        a2a_client_factory: Callable[[], A2AClient] | None = None,
+        print_func: Callable[[str], None] = print,
+    ) -> None:
+        """
+        Initialize InstructionsCommand.
+
+        Args:
+            settings_factory: Factory to create SynapseSettings instance.
+            registry_factory: Factory to create AgentRegistry instance.
+            a2a_client_factory: Factory to create A2AClient instance.
+            print_func: Function to use for output (for testing).
+        """
+        self._settings_factory = settings_factory or get_settings
+        self._registry_factory = registry_factory or AgentRegistry
+        self._a2a_client_factory = a2a_client_factory
+        self._print = print_func
+
+    def _get_a2a_client(self) -> A2AClient:
+        """Get or create A2A client."""
+        if self._a2a_client_factory:
+            return self._a2a_client_factory()
+        from synapse.a2a_client import get_client
+
+        return get_client()
+
+    def _parse_target(self, target: str) -> tuple[str | None, str | None]:
+        """
+        Parse target string to determine profile and agent_id.
+
+        Args:
+            target: Either a profile name (claude, gemini, codex) or
+                   an agent ID (synapse-claude-8100).
+
+        Returns:
+            Tuple of (profile, agent_id). If target is a profile name,
+            agent_id will be None. If target is invalid, both will be None.
+        """
+        # Check if it's a known profile name
+        if target in KNOWN_PROFILES:
+            return (target, None)
+
+        # Check if it's an agent ID pattern
+        match = AGENT_ID_PATTERN.match(target)
+        if match:
+            profile = match.group(1)
+            if profile in KNOWN_PROFILES:
+                return (profile, target)
+
+        return (None, None)
+
+    def _find_agent(
+        self, target: str
+    ) -> tuple[dict[str, Any] | None, str | None, str | None]:
+        """
+        Find a running agent matching the target.
+
+        Args:
+            target: Profile name or agent ID.
+
+        Returns:
+            Tuple of (agent_info, agent_id, profile). All None if not found.
+        """
+        registry = self._registry_factory()
+        agents = registry.list_agents()
+
+        profile, agent_id = self._parse_target(target)
+
+        if profile is None:
+            return (None, None, None)
+
+        # If specific agent ID was provided, look for it
+        if agent_id:
+            info = agents.get(agent_id)
+            if info:
+                return (info, agent_id, profile)
+            return (None, None, None)
+
+        # Find first agent of the given profile type
+        for aid, info in agents.items():
+            if info.get("agent_type") == profile:
+                return (info, aid, profile)
+
+        return (None, None, profile)
+
+    def show(self, agent_type: str | None = None) -> None:
+        """
+        Show instruction content for an agent type.
+
+        Args:
+            agent_type: Agent type (claude, gemini, codex). If None, shows default.
+        """
+        settings = self._settings_factory()
+        effective_type = agent_type or "default"
+
+        # For display purposes, use placeholder values
+        agent_id = f"synapse-{effective_type}-XXXX"
+        port = 0
+
+        instruction = settings.get_instruction(effective_type, agent_id, port)
+
+        if not instruction:
+            self._print(f"No instruction configured for '{effective_type}'.")
+            self._print("")
+            self._print("Configure instructions in .synapse/settings.json:")
+            self._print('  {"instructions": {"default": "default.md"}}')
+            return
+
+        self._print(f"Instruction for '{effective_type}':")
+        self._print("-" * 60)
+        self._print(instruction)
+        self._print("-" * 60)
+
+    def files(self, agent_type: str | None = None) -> None:
+        """
+        List instruction files for an agent type.
+
+        Args:
+            agent_type: Agent type (claude, gemini, codex). If None, shows default.
+        """
+        settings = self._settings_factory()
+        effective_type = agent_type or "default"
+
+        files = settings.get_instruction_files(effective_type)
+
+        if not files:
+            self._print(f"No instruction files configured for '{effective_type}'.")
+            self._print("")
+            self._print("Configure instructions in .synapse/settings.json:")
+            self._print('  {"instructions": {"default": "default.md"}}')
+            return
+
+        self._print(f"Instruction files for '{effective_type}':")
+        for f in files:
+            self._print(f"  - .synapse/{f}")
+
+    def send(self, target: str, preview: bool = False) -> bool:
+        """
+        Send initial instructions to a running agent.
+
+        Args:
+            target: Profile name (claude, gemini, codex) or agent ID.
+            preview: If True, show what would be sent without actually sending.
+
+        Returns:
+            True if successful (or preview), False otherwise.
+        """
+        # Find the target agent
+        agent_info, agent_id, profile = self._find_agent(target)
+
+        if profile is None:
+            self._print(f"Error: '{target}' is not a valid profile or agent ID.")
+            self._print(f"Valid profiles: {', '.join(sorted(KNOWN_PROFILES))}")
+            return False
+
+        if agent_info is None:
+            self._print(f"Error: No running agent found for '{target}'.")
+            self._print("")
+            self._print("Start an agent first:")
+            self._print(f"  synapse {profile}")
+            self._print("")
+            self._print("Or check running agents:")
+            self._print("  synapse list")
+            return False
+
+        # Get instruction content
+        settings = self._settings_factory()
+        port = agent_info.get("port", 0)
+        # profile and agent_id are guaranteed to be non-None here (checked above)
+        assert profile is not None
+        assert agent_id is not None
+        instruction = settings.get_instruction(profile, agent_id, port)
+
+        if not instruction:
+            self._print(f"Error: No instruction configured for '{profile}'.")
+            return False
+
+        # Get instruction files for the message prefix
+        files = settings.get_instruction_files(profile)
+
+        # Build the message (same format as controller._send_identity_instruction)
+        task_id = str(uuid.uuid4())[:8]
+        if files:
+            # Send compact message pointing to files
+            message = (
+                f"[SYNAPSE A2A AGENT CONFIGURATION]\n"
+                f"Agent: {agent_id} | Port: {port}\n\n"
+                f"IMPORTANT: Read your full instructions from these files:\n"
+            )
+            for f in files:
+                message += f"  - .synapse/{f}\n"
+            message += (
+                f"\nRead these files NOW to get your delegation rules, "
+                f"A2A protocol, and other guidelines.\n"
+                f"Replace {{{{agent_id}}}} with {agent_id} and "
+                f"{{{{port}}}} with {port} when following instructions."
+            )
+        else:
+            # Send full instruction content
+            message = instruction
+
+        if preview:
+            self._print("Preview mode - would send the following:")
+            self._print("-" * 60)
+            self._print(f"Target: {agent_id} (port {port})")
+            self._print(f"Task ID: {task_id}")
+            self._print("-" * 60)
+            self._print(message)
+            self._print("-" * 60)
+            return True
+
+        # Send via A2A protocol
+        endpoint = f"http://localhost:{port}"
+        client = self._get_a2a_client()
+
+        # Format with A2A prefix
+        prefixed_message = f"[A2A:{task_id}:synapse-system] {message}"
+
+        task = client.send_to_local(
+            endpoint=endpoint,
+            message=prefixed_message,
+            priority=3,  # Normal priority
+            sender_info={
+                "sender_id": "synapse-system",
+                "sender_type": "system",
+            },
+        )
+
+        if task:
+            self._print(f"Instructions sent to {agent_id} successfully.")
+            self._print(f"  Task ID: {task.id}")
+            return True
+        else:
+            self._print(f"Error: Failed to send instructions to {agent_id}.")
+            self._print("The agent may not be responding. Check with:")
+            self._print("  synapse list")
+            return False

--- a/tests/test_cmd_instructions.py
+++ b/tests/test_cmd_instructions.py
@@ -1,0 +1,471 @@
+"""Tests for synapse instructions command."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from synapse.commands.instructions import InstructionsCommand
+from synapse.registry import AgentRegistry
+from synapse.settings import SynapseSettings
+
+
+def create_settings_from_dir(synapse_dir: Path) -> SynapseSettings:
+    """Create SynapseSettings from a .synapse directory."""
+    return SynapseSettings.load(
+        user_path=synapse_dir / "settings.json",
+        project_path=synapse_dir / "settings.json",
+        local_path=synapse_dir / "settings.local.json",
+    )
+
+
+@pytest.fixture
+def temp_registry_dir(tmp_path: Path) -> Path:
+    """Create a temporary registry directory."""
+    registry_dir = tmp_path / "registry"
+    registry_dir.mkdir(parents=True, exist_ok=True)
+    return registry_dir
+
+
+@pytest.fixture
+def temp_synapse_dir(tmp_path: Path) -> Path:
+    """Create a temporary .synapse directory with settings."""
+    synapse_dir = tmp_path / ".synapse"
+    synapse_dir.mkdir(parents=True, exist_ok=True)
+
+    # Create default.md instruction file
+    default_md = synapse_dir / "default.md"
+    default_md.write_text(
+        "[SYNAPSE A2A AGENT CONFIGURATION]\n"
+        "Agent: {{agent_id}} | Port: {{port}}\n"
+        "\n"
+        "This is the default instruction."
+    )
+
+    # Create claude-specific instruction
+    claude_md = synapse_dir / "claude.md"
+    claude_md.write_text(
+        "[CLAUDE SPECIFIC INSTRUCTIONS]\n"
+        "Agent: {{agent_id}} | Port: {{port}}\n"
+        "\n"
+        "This is Claude-specific instruction."
+    )
+
+    # Create settings.json
+    settings = {
+        "instructions": {
+            "default": "default.md",
+            "claude": "claude.md",
+        }
+    }
+    settings_file = synapse_dir / "settings.json"
+    settings_file.write_text(json.dumps(settings))
+
+    return synapse_dir
+
+
+@pytest.fixture
+def temp_registry(temp_registry_dir: Path) -> AgentRegistry:
+    """Create a test registry with temp directory."""
+    reg = AgentRegistry()
+    reg.registry_dir = temp_registry_dir
+    return reg
+
+
+@pytest.fixture
+def mock_a2a_client() -> MagicMock:
+    """Create a mock A2A client."""
+    client = MagicMock()
+    client.send_to_local.return_value = MagicMock(
+        id="test-task-123",
+        status="submitted",
+    )
+    return client
+
+
+class TestInstructionsShow:
+    """Tests for 'synapse instructions show' command."""
+
+    def test_show_default_instruction(self, temp_synapse_dir: Path) -> None:
+        """Should show default instruction when no agent type specified."""
+        output_lines: list[str] = []
+
+        with patch("synapse.settings.Path.cwd", return_value=temp_synapse_dir.parent):
+            cmd = InstructionsCommand(
+                settings_factory=lambda: create_settings_from_dir(temp_synapse_dir),
+                registry_factory=lambda: MagicMock(spec=AgentRegistry),
+                a2a_client_factory=lambda: MagicMock(),
+                print_func=lambda s: output_lines.append(s),
+            )
+            cmd.show(agent_type=None)
+
+        output = "\n".join(output_lines)
+        assert "default.md" in output.lower() or "default instruction" in output.lower()
+
+    def test_show_agent_specific_instruction(self, temp_synapse_dir: Path) -> None:
+        """Should show agent-specific instruction when agent type specified."""
+        output_lines: list[str] = []
+
+        with patch("synapse.settings.Path.cwd", return_value=temp_synapse_dir.parent):
+            cmd = InstructionsCommand(
+                settings_factory=lambda: create_settings_from_dir(temp_synapse_dir),
+                registry_factory=lambda: MagicMock(spec=AgentRegistry),
+                a2a_client_factory=lambda: MagicMock(),
+                print_func=lambda s: output_lines.append(s),
+            )
+            cmd.show(agent_type="claude")
+
+        output = "\n".join(output_lines)
+        assert "claude" in output.lower()
+
+    def test_show_default_fallback_instruction(self, tmp_path: Path) -> None:
+        """Should show default instruction when no specific instruction is configured."""
+        synapse_dir = tmp_path / ".synapse"
+        synapse_dir.mkdir()
+        settings_file = synapse_dir / "settings.json"
+        # Even with empty instructions, defaults are loaded
+        settings_file.write_text(json.dumps({"instructions": {}}))
+
+        output_lines: list[str] = []
+
+        with patch("synapse.settings.Path.cwd", return_value=tmp_path):
+            cmd = InstructionsCommand(
+                settings_factory=lambda: create_settings_from_dir(synapse_dir),
+                registry_factory=lambda: MagicMock(spec=AgentRegistry),
+                a2a_client_factory=lambda: MagicMock(),
+                print_func=lambda s: output_lines.append(s),
+            )
+            cmd.show(agent_type="codex")
+
+        output = "\n".join(output_lines)
+        # Default instruction is loaded, so it shows instruction content
+        assert "instruction for" in output.lower() or "synapse" in output.lower()
+
+
+class TestInstructionsFiles:
+    """Tests for 'synapse instructions files' command."""
+
+    def test_files_lists_instruction_files(self, temp_synapse_dir: Path) -> None:
+        """Should list instruction files for agent type."""
+        output_lines: list[str] = []
+
+        with patch("synapse.settings.Path.cwd", return_value=temp_synapse_dir.parent):
+            cmd = InstructionsCommand(
+                settings_factory=lambda: create_settings_from_dir(temp_synapse_dir),
+                registry_factory=lambda: MagicMock(spec=AgentRegistry),
+                a2a_client_factory=lambda: MagicMock(),
+                print_func=lambda s: output_lines.append(s),
+            )
+            cmd.files(agent_type="claude")
+
+        output = "\n".join(output_lines)
+        assert "claude.md" in output
+
+    def test_files_shows_default_files(self, temp_synapse_dir: Path) -> None:
+        """Should list default instruction files when no agent type specified."""
+        output_lines: list[str] = []
+
+        with patch("synapse.settings.Path.cwd", return_value=temp_synapse_dir.parent):
+            cmd = InstructionsCommand(
+                settings_factory=lambda: create_settings_from_dir(temp_synapse_dir),
+                registry_factory=lambda: MagicMock(spec=AgentRegistry),
+                a2a_client_factory=lambda: MagicMock(),
+                print_func=lambda s: output_lines.append(s),
+            )
+            # For an agent type without specific config, it falls back to default
+            cmd.files(agent_type="gemini")
+
+        output = "\n".join(output_lines)
+        assert "default.md" in output
+
+    def test_files_no_files_configured(self, tmp_path: Path) -> None:
+        """Should show message when no files are configured."""
+        synapse_dir = tmp_path / ".synapse"
+        synapse_dir.mkdir()
+        settings_file = synapse_dir / "settings.json"
+        settings_file.write_text(json.dumps({"instructions": {}}))
+
+        output_lines: list[str] = []
+
+        with patch("synapse.settings.Path.cwd", return_value=tmp_path):
+            cmd = InstructionsCommand(
+                settings_factory=lambda: create_settings_from_dir(synapse_dir),
+                registry_factory=lambda: MagicMock(spec=AgentRegistry),
+                a2a_client_factory=lambda: MagicMock(),
+                print_func=lambda s: output_lines.append(s),
+            )
+            cmd.files(agent_type="codex")
+
+        output = "\n".join(output_lines)
+        assert "no instruction files" in output.lower() or "none" in output.lower()
+
+
+class TestInstructionsSend:
+    """Tests for 'synapse instructions send' command."""
+
+    def test_send_to_running_agent_by_profile(
+        self,
+        temp_synapse_dir: Path,
+        temp_registry: AgentRegistry,
+        mock_a2a_client: MagicMock,
+    ) -> None:
+        """Should send instructions to a running agent by profile name."""
+        # Register a running agent
+        temp_registry.register(
+            "synapse-claude-8100",
+            "claude",
+            8100,
+            status="READY",
+        )
+
+        output_lines: list[str] = []
+
+        with patch("synapse.settings.Path.cwd", return_value=temp_synapse_dir.parent):
+            cmd = InstructionsCommand(
+                settings_factory=lambda: create_settings_from_dir(temp_synapse_dir),
+                registry_factory=lambda: temp_registry,
+                a2a_client_factory=lambda: mock_a2a_client,
+                print_func=lambda s: output_lines.append(s),
+            )
+            result = cmd.send(target="claude", preview=False)
+
+        assert result is True
+        mock_a2a_client.send_to_local.assert_called_once()
+        output = "\n".join(output_lines)
+        assert "sent" in output.lower() or "success" in output.lower()
+
+    def test_send_to_running_agent_by_agent_id(
+        self,
+        temp_synapse_dir: Path,
+        temp_registry: AgentRegistry,
+        mock_a2a_client: MagicMock,
+    ) -> None:
+        """Should send instructions to a running agent by agent ID."""
+        # Register a running agent
+        temp_registry.register(
+            "synapse-claude-8100",
+            "claude",
+            8100,
+            status="READY",
+        )
+
+        output_lines: list[str] = []
+
+        with patch("synapse.settings.Path.cwd", return_value=temp_synapse_dir.parent):
+            cmd = InstructionsCommand(
+                settings_factory=lambda: create_settings_from_dir(temp_synapse_dir),
+                registry_factory=lambda: temp_registry,
+                a2a_client_factory=lambda: mock_a2a_client,
+                print_func=lambda s: output_lines.append(s),
+            )
+            result = cmd.send(target="synapse-claude-8100", preview=False)
+
+        assert result is True
+        mock_a2a_client.send_to_local.assert_called_once()
+
+    def test_send_fails_when_no_agent_running(
+        self,
+        temp_synapse_dir: Path,
+        temp_registry: AgentRegistry,
+        mock_a2a_client: MagicMock,
+    ) -> None:
+        """Should fail when target agent is not running."""
+        output_lines: list[str] = []
+
+        with patch("synapse.settings.Path.cwd", return_value=temp_synapse_dir.parent):
+            cmd = InstructionsCommand(
+                settings_factory=lambda: create_settings_from_dir(temp_synapse_dir),
+                registry_factory=lambda: temp_registry,
+                a2a_client_factory=lambda: mock_a2a_client,
+                print_func=lambda s: output_lines.append(s),
+            )
+            result = cmd.send(target="claude", preview=False)
+
+        assert result is False
+        mock_a2a_client.send_to_local.assert_not_called()
+        output = "\n".join(output_lines)
+        assert "no running agent" in output.lower()
+
+    def test_send_preview_mode(
+        self,
+        temp_synapse_dir: Path,
+        temp_registry: AgentRegistry,
+        mock_a2a_client: MagicMock,
+    ) -> None:
+        """Should show preview without sending when --preview is used."""
+        temp_registry.register(
+            "synapse-claude-8100",
+            "claude",
+            8100,
+            status="READY",
+        )
+
+        output_lines: list[str] = []
+
+        with patch("synapse.settings.Path.cwd", return_value=temp_synapse_dir.parent):
+            cmd = InstructionsCommand(
+                settings_factory=lambda: create_settings_from_dir(temp_synapse_dir),
+                registry_factory=lambda: temp_registry,
+                a2a_client_factory=lambda: mock_a2a_client,
+                print_func=lambda s: output_lines.append(s),
+            )
+            result = cmd.send(target="claude", preview=True)
+
+        assert result is True
+        # Should NOT have sent anything
+        mock_a2a_client.send_to_local.assert_not_called()
+        output = "\n".join(output_lines)
+        assert "preview" in output.lower()
+
+    def test_send_to_multiple_agents_of_same_type(
+        self,
+        temp_synapse_dir: Path,
+        temp_registry: AgentRegistry,
+        mock_a2a_client: MagicMock,
+    ) -> None:
+        """Should send to one of the agents when multiple agents of same type exist."""
+        # Register multiple claude agents
+        temp_registry.register(
+            "synapse-claude-8100",
+            "claude",
+            8100,
+            status="READY",
+        )
+        temp_registry.register(
+            "synapse-claude-8101",
+            "claude",
+            8101,
+            status="PROCESSING",
+        )
+
+        output_lines: list[str] = []
+
+        with patch("synapse.settings.Path.cwd", return_value=temp_synapse_dir.parent):
+            cmd = InstructionsCommand(
+                settings_factory=lambda: create_settings_from_dir(temp_synapse_dir),
+                registry_factory=lambda: temp_registry,
+                a2a_client_factory=lambda: mock_a2a_client,
+                print_func=lambda s: output_lines.append(s),
+            )
+            result = cmd.send(target="claude", preview=False)
+
+        assert result is True
+        # Should have sent to one of the agents (order is not guaranteed)
+        mock_a2a_client.send_to_local.assert_called_once()
+        call_args = mock_a2a_client.send_to_local.call_args
+        endpoint = call_args.kwargs.get(
+            "endpoint", call_args.args[0] if call_args.args else ""
+        )
+        assert "8100" in endpoint or "8101" in endpoint
+
+
+class TestInstructionsSendEdgeCases:
+    """Edge case tests for send command."""
+
+    def test_send_with_invalid_target(
+        self,
+        temp_synapse_dir: Path,
+        temp_registry: AgentRegistry,
+    ) -> None:
+        """Should fail gracefully with invalid target."""
+        output_lines: list[str] = []
+
+        with patch("synapse.settings.Path.cwd", return_value=temp_synapse_dir.parent):
+            cmd = InstructionsCommand(
+                settings_factory=lambda: create_settings_from_dir(temp_synapse_dir),
+                registry_factory=lambda: temp_registry,
+                a2a_client_factory=lambda: MagicMock(),
+                print_func=lambda s: output_lines.append(s),
+            )
+            result = cmd.send(target="invalid-agent-name", preview=False)
+
+        assert result is False
+        output = "\n".join(output_lines)
+        assert (
+            "not found" in output.lower()
+            or "invalid" in output.lower()
+            or "not running" in output.lower()
+        )
+
+    def test_send_handles_network_error(
+        self,
+        temp_synapse_dir: Path,
+        temp_registry: AgentRegistry,
+    ) -> None:
+        """Should handle network errors gracefully."""
+        temp_registry.register(
+            "synapse-claude-8100",
+            "claude",
+            8100,
+            status="READY",
+        )
+
+        mock_client = MagicMock()
+        mock_client.send_to_local.return_value = None  # Simulates failure
+
+        output_lines: list[str] = []
+
+        with patch("synapse.settings.Path.cwd", return_value=temp_synapse_dir.parent):
+            cmd = InstructionsCommand(
+                settings_factory=lambda: create_settings_from_dir(temp_synapse_dir),
+                registry_factory=lambda: temp_registry,
+                a2a_client_factory=lambda: mock_client,
+                print_func=lambda s: output_lines.append(s),
+            )
+            result = cmd.send(target="claude", preview=False)
+
+        assert result is False
+        output = "\n".join(output_lines)
+        assert "failed" in output.lower() or "error" in output.lower()
+
+
+class TestParseTarget:
+    """Tests for target parsing logic."""
+
+    def test_parse_profile_name(self, temp_synapse_dir: Path) -> None:
+        """Should correctly identify profile names."""
+        with patch("synapse.settings.Path.cwd", return_value=temp_synapse_dir.parent):
+            cmd = InstructionsCommand(
+                settings_factory=lambda: create_settings_from_dir(temp_synapse_dir),
+                registry_factory=lambda: MagicMock(spec=AgentRegistry),
+                a2a_client_factory=lambda: MagicMock(),
+                print_func=print,
+            )
+
+            assert cmd._parse_target("claude") == ("claude", None)
+            assert cmd._parse_target("gemini") == ("gemini", None)
+            assert cmd._parse_target("codex") == ("codex", None)
+
+    def test_parse_agent_id(self, temp_synapse_dir: Path) -> None:
+        """Should correctly identify agent IDs."""
+        with patch("synapse.settings.Path.cwd", return_value=temp_synapse_dir.parent):
+            cmd = InstructionsCommand(
+                settings_factory=lambda: create_settings_from_dir(temp_synapse_dir),
+                registry_factory=lambda: MagicMock(spec=AgentRegistry),
+                a2a_client_factory=lambda: MagicMock(),
+                print_func=print,
+            )
+
+            profile, agent_id = cmd._parse_target("synapse-claude-8100")
+            assert profile == "claude"
+            assert agent_id == "synapse-claude-8100"
+
+            profile, agent_id = cmd._parse_target("synapse-gemini-8110")
+            assert profile == "gemini"
+            assert agent_id == "synapse-gemini-8110"
+
+    def test_parse_unknown_target(self, temp_synapse_dir: Path) -> None:
+        """Should return None for unknown targets."""
+        with patch("synapse.settings.Path.cwd", return_value=temp_synapse_dir.parent):
+            cmd = InstructionsCommand(
+                settings_factory=lambda: create_settings_from_dir(temp_synapse_dir),
+                registry_factory=lambda: MagicMock(spec=AgentRegistry),
+                a2a_client_factory=lambda: MagicMock(),
+                print_func=print,
+            )
+
+            assert cmd._parse_target("unknown") == (None, None)
+            assert cmd._parse_target("random-string") == (None, None)


### PR DESCRIPTION
## Summary

- Add new CLI command `synapse instructions` with three subcommands for managing initial instructions
- Enable manual sending of initial instructions to running agents
- Useful for `--resume` mode recovery and instruction verification

## Changes

### New Command: `synapse instructions`

| Subcommand | Description |
|------------|-------------|
| `show [agent_type]` | Display instruction content for an agent |
| `files [agent_type]` | List instruction files used by an agent |
| `send <target> [--preview]` | Send initial instructions to a running agent |

### Use Cases

- **Resume mode recovery**: After starting with `--resume`, manually send A2A protocol instructions if needed
- **Instruction verification**: Preview instruction content before sending
- **Agent recovery**: Resend instructions if agent has lost/forgotten them

### Usage Examples

```bash
# Show instruction content
synapse instructions show claude

# List instruction files
synapse instructions files claude

# Send instructions to running agent
synapse instructions send claude

# Preview without sending
synapse instructions send claude --preview
```

## Implementation

- `synapse/commands/instructions.py`: New InstructionsCommand class
- `synapse/cli.py`: CLI integration with subcommand handlers
- `tests/test_cmd_instructions.py`: 16 test cases

## Documentation

- CLAUDE.md: Updated Commands and Architecture sections
- README.md: Added command table and usage section
- guides/usage.md: Added section 1.4 with mermaid diagrams
- guides/references.md: Added full CLI reference

## Test plan

- [x] All 16 test cases pass
- [x] Manual testing of `synapse instructions show/files/send`
- [x] Pre-commit hooks pass (ruff, ruff-format, mypy)

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * インストラクション管理コマンドを追加。`show`、`files`、`send` サブコマンドでエージェントの指示内容を表示、管理、送信可能に。Resume モードや指示の紛失時に活用できます。

* **ドキュメント**
  * インストラクション管理機能に関する新セクションを追加。使用例とワークフローを充実させました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->