### PR TITLE
fix: use package path for a2a.py in synapse send command (v0.2.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.10] - 2026-01-13
+
+### Fixed
+
+- `synapse send` command now works from any directory (#92)
+  - Use package-relative path instead of hardcoded relative path
+  - Remove unnecessary `PYTHONPATH` manipulation
+
 ## [0.2.9] - 2026-01-13
 
 ### Added
@@ -230,6 +238,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - External agent connectivity vision document
 - PyPI publishing instructions
 
+[0.2.10]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.2.9...v0.2.10
 [0.2.9]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.2.8...v0.2.9
 [0.2.8]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.2.7...v0.2.8
 [0.2.6]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.2.5...v0.2.6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synapse-a2a"
-version = "0.2.9"
+version = "0.2.10"
 description = "Agent-to-Agent communication protocol for CLI agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/synapse/cli.py
+++ b/synapse/cli.py
@@ -514,10 +514,15 @@ def cmd_send(args: argparse.Namespace) -> None:
     sender = getattr(args, "sender", None)
     wait_response = args.wait
 
-    # Use the existing a2a tool
+    # Get the a2a.py tool path from installed package
+    import synapse
+
+    package_dir = Path(synapse.__file__).parent
+    a2a_tool = package_dir / "tools" / "a2a.py"
+
     cmd = [
         sys.executable,
-        "synapse/tools/a2a.py",
+        str(a2a_tool),
         "send",
         "--target",
         target,
@@ -530,10 +535,7 @@ def cmd_send(args: argparse.Namespace) -> None:
     if sender:
         cmd.extend(["--from", sender])
 
-    env = os.environ.copy()
-    env["PYTHONPATH"] = "."
-
-    result = subprocess.run(cmd, env=env, capture_output=True, text=True)
+    result = subprocess.run(cmd, capture_output=True, text=True)
     print(result.stdout)
     if result.stderr:
         print(result.stderr, file=sys.stderr)


### PR DESCRIPTION
## Summary

Fixes #92 

The `synapse send` command was using a hardcoded relative path (`synapse/tools/a2a.py`) which only worked when running from the source directory.

## Changes

- Use `Path(synapse.__file__).parent / "tools" / "a2a.py"` to get the correct path
- Remove unnecessary `PYTHONPATH` manipulation
- Bump version to 0.2.10
- Update CHANGELOG.md

## Before
```python
cmd = [
    sys.executable,
    "synapse/tools/a2a.py",  # Hardcoded relative path
    ...
]
env["PYTHONPATH"] = "."  # Assumes CWD has the package
```

## After
```python
package_dir = Path(synapse.__file__).parent
a2a_tool = package_dir / "tools" / "a2a.py"
cmd = [
    sys.executable,
    str(a2a_tool),  # Package-relative path
    ...
]
```

## Test plan

- [x] `test_send_message` - passes
- [x] `test_send_with_wait_flag` - passes
- [x] `test_external_send_success` - passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)