### PR TITLE
fix: add reply-to handling for local A2A tasks

### DIFF
--- a/synapse/a2a_client.py
+++ b/synapse/a2a_client.py
@@ -208,6 +208,7 @@ class A2AClient:
         timeout: int = 60,
         sender_info: dict[str, str] | None = None,
         response_expected: bool = True,
+        in_reply_to: str | None = None,
         uds_path: str | None = None,
         local_only: bool = False,
     ) -> A2ATask | None:
@@ -225,6 +226,7 @@ class A2AClient:
             timeout: Timeout in seconds for waiting
             sender_info: Optional dict with sender_id, sender_type, sender_endpoint
             response_expected: Whether the sender expects a response from the target agent
+            in_reply_to: Optional task ID to attach a reply to
 
         Returns:
             A2ATask if successful, None otherwise
@@ -243,6 +245,8 @@ class A2AClient:
             metadata: dict[str, Any] = {"response_expected": response_expected}
             if sender_info:
                 metadata["sender"] = sender_info
+            if in_reply_to:
+                metadata["in_reply_to"] = in_reply_to
             payload["metadata"] = metadata
 
             task_data = None

--- a/synapse/cli.py
+++ b/synapse/cli.py
@@ -512,6 +512,7 @@ def cmd_send(args: argparse.Namespace) -> None:
     message = args.message
     priority = args.priority
     sender = getattr(args, "sender", None)
+    reply_to = getattr(args, "reply_to", None)
     wait_response = args.wait
 
     # Get the a2a.py tool path from installed package
@@ -534,6 +535,8 @@ def cmd_send(args: argparse.Namespace) -> None:
     # Add sender if specified
     if sender:
         cmd.extend(["--from", sender])
+    if reply_to:
+        cmd.extend(["--reply-to", reply_to])
 
     result = subprocess.run(cmd, capture_output=True, text=True)
     print(result.stdout)
@@ -1856,6 +1859,11 @@ Priority levels:
     )
     p_send.add_argument(
         "--from", "-f", dest="sender", help="Sender agent ID (for reply identification)"
+    )
+    p_send.add_argument(
+        "--reply-to",
+        dest="reply_to",
+        help="Reply to a specific task ID (attach response without sending to PTY)",
     )
     p_send.add_argument(
         "--return", "-r", dest="wait", action="store_true", help="Wait for response"

--- a/synapse/tools/a2a.py
+++ b/synapse/tools/a2a.py
@@ -256,6 +256,7 @@ def cmd_send(args: argparse.Namespace) -> None:
     settings = get_settings()
     flow = settings.get_a2a_flow()
     want_response = getattr(args, "want_response", None)
+    reply_to = getattr(args, "reply_to", None)
 
     if flow == "roundtrip":
         # Force response expected
@@ -276,6 +277,7 @@ def cmd_send(args: argparse.Namespace) -> None:
         timeout=60,
         sender_info=sender_info or None,
         response_expected=response_expected,
+        in_reply_to=reply_to,
         uds_path=uds_path if isinstance(uds_path, str) else None,
         local_only=local_only,
     )
@@ -327,6 +329,11 @@ def main() -> None:
         "--from",
         dest="sender",
         help="Sender Agent ID (auto-detected from env if not specified)",
+    )
+    p_send.add_argument(
+        "--reply-to",
+        dest="reply_to",
+        help="Reply to a specific task ID (attach response without sending to PTY)",
     )
     # Response control: mutually exclusive group
     response_group = p_send.add_mutually_exclusive_group()

--- a/tests/test_a2a_client.py
+++ b/tests/test_a2a_client.py
@@ -229,6 +229,25 @@ class TestA2AClientSendToLocal:
         assert request_body["message"]["parts"][0]["text"] == "Test message"
 
     @responses.activate
+    def test_send_to_local_includes_in_reply_to(self, a2a_client):
+        """Should include in_reply_to in metadata when provided."""
+        responses.add(
+            responses.POST,
+            "http://localhost:8001/tasks/send-priority?priority=1",
+            json={"task": {"id": "t-1", "status": "working"}},
+            status=200,
+        )
+
+        a2a_client.send_to_local(
+            endpoint="http://localhost:8001",
+            message="Reply message",
+            in_reply_to="task-123",
+        )
+
+        request_body = json.loads(responses.calls[0].request.body)
+        assert request_body["metadata"]["in_reply_to"] == "task-123"
+
+    @responses.activate
     def test_send_to_local_failure(self, a2a_client):
         """Should return None on failure."""
         responses.add(


### PR DESCRIPTION
## Summary\n- support reply-to metadata for local A2A messages\n- complete existing tasks and attach reply artifacts without sending to PTY\n- plumb --reply-to through CLI/tooling\n- add tests for reply-to flow\n\n## Testing\n- pytest tests/test_a2a_compat.py::TestA2ARouterEndpoints::test_tasks_send_reply_to_updates_existing_task -v\n- pytest tests/test_a2a_client.py::TestA2AClientSendToLocal::test_send_to_local_includes_in_reply_to -v\n- pytest tests/test_tools_a2a.py::TestCmdSend::test_cmd_send_passes_reply_to -v

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能
- `send` コマンドに新しい `--reply-to` オプションが追加されました
- 既存タスクへの返信機能に対応しました。返信時は既存タスクが更新され、返信内容が追加された後、タスクが完了状態にマークされます

## テスト
- 返信機能に関するテストケースが追加されました

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->