### PR TITLE
chore: bump version to 0.2.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.12] - 2026-01-14
+
+### Changed
+
+- Unify response option flags between `synapse send` and `a2a.py send` (#96)
+  - Replace `--return` flag with `--response/--no-response` flags
+  - Default behavior is now "do not wait for response" (safer)
+  - Both commands now have consistent flag names and defaults
+- Update shell.py and shell_hook.py to use `--response` flag instead of `--return`
+
+### Documentation
+
+- Update all guides, skills, and templates to use new `--response/--no-response` flags
+- Update `docs/universal-agent-communication-spec.md` with new flag names
+
 ## [0.2.11] - 2026-01-14
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synapse-a2a"
-version = "0.2.11"
+version = "0.2.12"
 description = "Agent-to-Agent communication protocol for CLI agents"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- バージョンを 0.2.11 → 0.2.12 に更新
- CHANGELOG.md に 0.2.12 のエントリを追加

## Changes

### pyproject.toml
- `version = "0.2.12"`

### CHANGELOG.md
- #96 の変更内容を記載
  - `synapse send` と `a2a.py send` のレスポンスフラグを統一
  - `--return` → `--response/--no-response` に変更
  - デフォルト動作を「待機しない」に統一

## Test plan

- [x] バージョン番号が正しく更新されている
- [x] CHANGELOG.md のフォーマットが正しい

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * synapse send と a2a.py send コマンド間でレスポンスフラグ処理を統一
  * --return フラグを --response/--no-response に置き換え
  * デフォルト動作をレスポンス待機なしに変更
  * 関連ドキュメントを更新

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->