### PR TITLE
feat: add transport display retention for watch mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.14] - 2026-01-15
+
+### Added
+
+- Transport display retention feature for `synapse list --watch` mode
+  - Communication events now persist for 3 seconds after completion
+  - Makes it possible to observe brief communication events in real-time
+  - New `registry.get_transport_display()` method with configurable retention period
+  - Stores `last_transport` and `transport_updated_at` for retention logic
+
 ## [0.2.13] - 2026-01-15
 
 ### Added
@@ -294,6 +304,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - External agent connectivity vision document
 - PyPI publishing instructions
 
+[0.2.14]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.2.13...v0.2.14
+[0.2.13]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.2.12...v0.2.13
+[0.2.12]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.2.11...v0.2.12
 [0.2.11]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.2.10...v0.2.11
 [0.2.10]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.2.9...v0.2.10
 [0.2.9]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.2.8...v0.2.9

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synapse-a2a"
-version = "0.2.13"
+version = "0.2.14"
 description = "Agent-to-Agent communication protocol for CLI agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/synapse/commands/list.py
+++ b/synapse/commands/list.py
@@ -125,7 +125,10 @@ class ListCommand:
                 (status, 12),
             ]
             if is_watch_mode:
-                transport = info.get("active_transport") or "-"
+                transport = (
+                    registry.get_transport_display(agent_id, retention_seconds=3.0)
+                    or "-"
+                )
                 row_values.append((transport, 10))
             row_values.extend(
                 [

--- a/tests/test_cmd_list_watch.py
+++ b/tests/test_cmd_list_watch.py
@@ -804,8 +804,12 @@ class TestTransportDisplay:
         # The line should contain a dash for transport (between STATUS and PID)
         assert "-" in data_lines[0]
 
-    def test_transport_cleared_shows_dash(self, temp_registry):
-        """Transport shows '-' after being cleared (None)."""
+    def test_transport_cleared_shows_retained_value(self, temp_registry):
+        """Transport shows retained value after being cleared (retention feature).
+
+        With the retention feature, cleared transport is still displayed
+        for 3 seconds to allow users to observe communication events.
+        """
         agent_id = "synapse-claude-8100"
         temp_registry.register(agent_id, "claude", 8100, status="READY")
         temp_registry.update_transport(agent_id, "UDS→")
@@ -814,8 +818,8 @@ class TestTransportDisplay:
         list_cmd = self._create_list_command()
         output = list_cmd._render_agent_table(temp_registry, is_watch_mode=True)
 
-        # Should not show UDS→ anymore
-        assert "UDS→" not in output
+        # Should still show UDS→ due to retention (within 3s)
+        assert "UDS→" in output
 
     def test_multiple_agents_with_different_transport(self, temp_registry):
         """Multiple agents can show different transport states."""

--- a/tests/test_transport_retention.py
+++ b/tests/test_transport_retention.py
@@ -1,0 +1,292 @@
+"""Tests for transport display retention feature.
+
+The transport display should persist for a configurable duration (default 3s)
+so that users can observe communication events in watch mode even though
+the actual communication completes in milliseconds.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from synapse.registry import AgentRegistry
+
+
+class TestTransportRetention:
+    """Tests for transport state retention in registry."""
+
+    @pytest.fixture
+    def registry(self, tmp_path: Path) -> AgentRegistry:
+        """Create a registry with a temporary directory."""
+        reg = AgentRegistry()
+        reg.registry_dir = tmp_path
+        return reg
+
+    @pytest.fixture
+    def agent_file(self, registry: AgentRegistry) -> Path:
+        """Create a test agent file."""
+        agent_id = "synapse-claude-8100"
+        file_path = registry.registry_dir / f"{agent_id}.json"
+        data = {
+            "agent_id": agent_id,
+            "agent_type": "claude",
+            "port": 8100,
+            "status": "READY",
+            "pid": 12345,
+            "working_dir": "/tmp",
+            "endpoint": "http://localhost:8100",
+        }
+        with open(file_path, "w") as f:
+            json.dump(data, f)
+        return file_path
+
+    def test_update_transport_stores_timestamp(
+        self, registry: AgentRegistry, agent_file: Path
+    ) -> None:
+        """update_transport should store both transport value and timestamp."""
+        agent_id = "synapse-claude-8100"
+
+        # Update transport
+        result = registry.update_transport(agent_id, "UDS→")
+        assert result is True
+
+        # Read the file and verify
+        with open(agent_file) as f:
+            data = json.load(f)
+
+        assert data.get("active_transport") == "UDS→"
+        assert "transport_updated_at" in data
+        # Timestamp should be recent (within last 1 second)
+        assert time.time() - data["transport_updated_at"] < 1.0
+
+    def test_clear_transport_keeps_timestamp(
+        self, registry: AgentRegistry, agent_file: Path
+    ) -> None:
+        """Clearing transport should keep the timestamp for retention display."""
+        agent_id = "synapse-claude-8100"
+
+        # Set transport first
+        registry.update_transport(agent_id, "TCP→")
+
+        # Small delay to make timestamps distinguishable
+        time.sleep(0.01)
+
+        # Clear transport (what happens after communication completes)
+        result = registry.update_transport(agent_id, None)
+        assert result is True
+
+        # Read and verify - transport cleared but timestamp remains
+        with open(agent_file) as f:
+            data = json.load(f)
+
+        assert data.get("active_transport") is None
+        assert "transport_updated_at" in data
+
+    def test_get_transport_display_within_retention(
+        self, registry: AgentRegistry, agent_file: Path
+    ) -> None:
+        """get_transport_display returns last transport within retention period."""
+        agent_id = "synapse-claude-8100"
+
+        # Set transport
+        registry.update_transport(agent_id, "UDS→")
+
+        # Immediately clear (simulating fast communication)
+        registry.update_transport(agent_id, None)
+
+        # Should still show "UDS→" within retention period
+        display = registry.get_transport_display(agent_id, retention_seconds=3.0)
+        assert display == "UDS→"
+
+    def test_get_transport_display_after_retention(
+        self, registry: AgentRegistry, agent_file: Path
+    ) -> None:
+        """get_transport_display returns None after retention period expires."""
+        agent_id = "synapse-claude-8100"
+
+        # Set transport with old timestamp
+        with open(agent_file) as f:
+            data = json.load(f)
+
+        data["active_transport"] = None
+        data["last_transport"] = "UDS→"
+        data["transport_updated_at"] = time.time() - 5.0  # 5 seconds ago
+
+        with open(agent_file, "w") as f:
+            json.dump(data, f)
+
+        # Should return None (retention period of 3s has passed)
+        display = registry.get_transport_display(agent_id, retention_seconds=3.0)
+        assert display is None
+
+    def test_get_transport_display_active_transport(
+        self, registry: AgentRegistry, agent_file: Path
+    ) -> None:
+        """get_transport_display returns active_transport when set."""
+        agent_id = "synapse-claude-8100"
+
+        # Set active transport
+        registry.update_transport(agent_id, "→TCP")
+
+        # Should return the active transport
+        display = registry.get_transport_display(agent_id, retention_seconds=3.0)
+        assert display == "→TCP"
+
+    def test_get_transport_display_no_transport_history(
+        self, registry: AgentRegistry, agent_file: Path
+    ) -> None:
+        """get_transport_display returns None when no transport ever set."""
+        agent_id = "synapse-claude-8100"
+
+        # No transport set
+        display = registry.get_transport_display(agent_id, retention_seconds=3.0)
+        assert display is None
+
+    def test_get_transport_display_agent_not_found(
+        self, registry: AgentRegistry
+    ) -> None:
+        """get_transport_display returns None for non-existent agent."""
+        display = registry.get_transport_display("nonexistent", retention_seconds=3.0)
+        assert display is None
+
+
+class TestListCommandTransportRetention:
+    """Tests for transport retention display in list command."""
+
+    def test_render_agent_table_uses_retention(self, tmp_path: Path) -> None:
+        """List command should use get_transport_display with retention."""
+        from synapse.commands.list import ListCommand
+
+        # Create mock registry
+        mock_registry = MagicMock(spec=AgentRegistry)
+        mock_registry.list_agents.return_value = {
+            "synapse-claude-8100": {
+                "agent_id": "synapse-claude-8100",
+                "agent_type": "claude",
+                "port": 8100,
+                "status": "READY",
+                "pid": 12345,
+                "working_dir": "/tmp",
+                "endpoint": "http://localhost:8100",
+            }
+        }
+        # Return retained transport
+        mock_registry.get_transport_display.return_value = "UDS→"
+
+        cmd = ListCommand(
+            registry_factory=lambda: mock_registry,
+            is_process_alive=lambda pid: True,
+            is_port_open=lambda *args, **kwargs: True,
+            clear_screen=lambda: None,
+            time_module=MagicMock(),
+            print_func=lambda x: None,
+        )
+
+        with patch("synapse.commands.list.FileSafetyManager") as mock_fs:
+            mock_fs.from_env.return_value.enabled = False
+            output = cmd._render_agent_table(mock_registry, is_watch_mode=True)
+
+        # Verify get_transport_display was called
+        mock_registry.get_transport_display.assert_called_once_with(
+            "synapse-claude-8100", retention_seconds=3.0
+        )
+
+        # Verify output contains the retained transport
+        assert "UDS→" in output
+
+    def test_render_agent_table_normal_mode_no_transport(self, tmp_path: Path) -> None:
+        """Normal mode (non-watch) should not call get_transport_display."""
+        from synapse.commands.list import ListCommand
+
+        mock_registry = MagicMock(spec=AgentRegistry)
+        mock_registry.list_agents.return_value = {
+            "synapse-claude-8100": {
+                "agent_id": "synapse-claude-8100",
+                "agent_type": "claude",
+                "port": 8100,
+                "status": "READY",
+                "pid": 12345,
+                "working_dir": "/tmp",
+                "endpoint": "http://localhost:8100",
+            }
+        }
+
+        cmd = ListCommand(
+            registry_factory=lambda: mock_registry,
+            is_process_alive=lambda pid: True,
+            is_port_open=lambda *args, **kwargs: True,
+            clear_screen=lambda: None,
+            time_module=MagicMock(),
+            print_func=lambda x: None,
+        )
+
+        with patch("synapse.commands.list.FileSafetyManager") as mock_fs:
+            mock_fs.from_env.return_value.enabled = False
+            output = cmd._render_agent_table(mock_registry, is_watch_mode=False)
+
+        # Verify get_transport_display was NOT called
+        mock_registry.get_transport_display.assert_not_called()
+
+        # Verify TRANSPORT column is not in output
+        assert "TRANSPORT" not in output
+
+
+class TestTransportRetentionIntegration:
+    """Integration tests for transport retention with real registry."""
+
+    @pytest.fixture
+    def registry(self, tmp_path: Path) -> AgentRegistry:
+        """Create a registry with a temporary directory."""
+        reg = AgentRegistry()
+        reg.registry_dir = tmp_path
+        return reg
+
+    def test_full_communication_cycle(self, registry: AgentRegistry) -> None:
+        """Test a full send/receive cycle with retention."""
+        agent_id = "synapse-claude-8100"
+
+        # Register agent
+        registry.register(agent_id, "claude", 8100, "READY")
+
+        # Simulate communication start (sender)
+        registry.update_transport(agent_id, "UDS→")
+
+        # Verify active transport
+        display = registry.get_transport_display(agent_id, retention_seconds=3.0)
+        assert display == "UDS→"
+
+        # Simulate communication end (sender clears)
+        registry.update_transport(agent_id, None)
+
+        # Should still show due to retention
+        display = registry.get_transport_display(agent_id, retention_seconds=3.0)
+        assert display == "UDS→"
+
+    def test_multiple_communications_updates_display(
+        self, registry: AgentRegistry
+    ) -> None:
+        """Multiple communications should update the displayed transport."""
+        agent_id = "synapse-claude-8100"
+
+        # Register agent
+        registry.register(agent_id, "claude", 8100, "READY")
+
+        # First communication (UDS)
+        registry.update_transport(agent_id, "UDS→")
+        registry.update_transport(agent_id, None)
+
+        display = registry.get_transport_display(agent_id, retention_seconds=3.0)
+        assert display == "UDS→"
+
+        # Second communication (TCP fallback)
+        registry.update_transport(agent_id, "TCP→")
+        registry.update_transport(agent_id, None)
+
+        # Should show latest transport
+        display = registry.get_transport_display(agent_id, retention_seconds=3.0)
+        assert display == "TCP→"


### PR DESCRIPTION
## Summary

- Transport display in `synapse list --watch` now persists for 3 seconds after communication completes
- Makes it possible to observe brief communication events that previously disappeared instantly
- Adds `get_transport_display()` method to registry with configurable retention period

## Changes

- `synapse/registry.py`: Add `last_transport`, `transport_updated_at` fields and `get_transport_display()` method
- `synapse/commands/list.py`: Use retention-aware transport display in watch mode
- `tests/test_transport_retention.py`: Comprehensive tests for the retention feature
- `tests/test_cmd_list_watch.py`: Update existing test for new retention behavior

## Test plan

- [x] Run `pytest tests/test_transport_retention.py -v` - all 11 tests pass
- [x] Run `pytest tests/test_registry.py tests/test_cmd_list_watch.py -v` - all existing tests pass
- [x] Code quality checks (ruff, mypy) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * synapse list --watchモードで、トランスポート表示の保持機能を追加。接続を切断した後も、最後のトランスポート値が3秒間表示され、その後クリアされます。これにより、短時間のイベントをリアルタイムで観察できます。

* **ドキュメント**
  * バージョン0.2.14のCHANGELOGを更新。

* **テスト**
  * トランスポート保持ロジックの包括的なテストを追加・更新。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->