### PR TITLE
fix: resolve EDITING FILE display bug in synapse list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.16] - 2026-01-15
+
+### Added
+
+- Critical Write Protocol (Read-After-Write verification) in `.synapse/file-safety.md`
+  - Agents must verify their writes by reading the file back immediately
+  - Retry mechanism for failed or incorrect writes
+  - New enforcement rule: "EVERY WRITE NEEDS VERIFICATION. NO EXCEPTIONS."
+
+### Fixed
+
+- Fix "EDITING FILE" not displaying in `synapse list` for some agents
+  - `synapse file-safety lock` now correctly passes `agent_id` and `agent_type` to database
+  - Support short agent names (e.g., "claude") by looking up live agents via `get_live_agents()`
+  - Extract `agent_type` from agent_id format (`synapse-{type}-{port}`) as fallback
+  - Refactored agent lookup logic into `_resolve_agent_info()` helper function
+
 ## [0.2.15] - 2026-01-15
 
 ### Fixed
@@ -312,6 +329,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - External agent connectivity vision document
 - PyPI publishing instructions
 
+[0.2.16]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.2.15...v0.2.16
 [0.2.15]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.2.14...v0.2.15
 [0.2.14]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.2.13...v0.2.14
 [0.2.13]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.2.12...v0.2.13

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synapse-a2a"
-version = "0.2.15"
+version = "0.2.16"
 description = "Agent-to-Agent communication protocol for CLI agents"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Fix "EDITING FILE" not displaying in `synapse list` for some agents
- `synapse file-safety lock` now correctly passes `agent_id` and `agent_type` to database
- Support short agent names (e.g., "claude") by looking up live agents via `get_live_agents()`
- Extract `agent_type` from agent_id format (`synapse-{type}-{port}`) as fallback
- Refactored agent lookup logic into `_resolve_agent_info()` helper function
- Bump version to 0.2.16

## Test plan
- [x] All 24 file-safety CLI tests pass
- [x] New tests added for short name lookup and agent_type extraction
- [x] Ruff and mypy checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Critical Write Protocolを導入し、書き込み後の検証機能を追加しました。

* **バグ修正**
  * ファイル編集ステータスの表示と検索に関する複数の問題を修正しました。
  * エージェント情報の伝播と検索ロジックを改善しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->