### PR TITLE
fix: add type-port shorthand support for synapse send command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.19] - 2026-01-17
+
+### Fixed
+
+- Add type-port shorthand support for `synapse send` command
+  - When multiple agents of the same type are running, use `claude-8100` format to target specific instances
+  - Target resolution priority: Full ID > Type-port > Agent type
+  - Show helpful hints when ambiguous target is detected
+
+### Documentation
+
+- Clarify `/tasks/send-priority` naming convention in API docs
+  - Document that endpoint path intentionally omits `x-` prefix for URL readability
+  - Note that `x-` prefix is used for metadata fields (`x-sender`, `x-response-expected`)
+- Sync target format documentation across all files
+  - README.md, CLAUDE.md, guides/references.md, skill files, templates
+
 ## [0.2.18] - 2026-01-17
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synapse-a2a"
-version = "0.2.18"
+version = "0.2.19"
 description = "Agent-to-Agent communication protocol for CLI agents"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- 同じタイプのエージェントが複数起動している場合に、`synapse send` コマンドで特定のインスタンスを指定できるようにtype-port形式（例: `claude-8100`）をサポート
- 曖昧なターゲット指定時にヒントを表示するように改善
- ドキュメントを更新して一貫性を確保

## 背景

synapse-claude-8100からメッセージを受信したsynapse-claude-8101が返信しようとした際、`synapse send claude` では特定のインスタンスを指定できず、エラーになっていた。

## 変更内容

### コード
- `synapse/tools/a2a.py`: type-port形式のターゲット解決ロジックを追加
- `tests/test_tools_a2a.py`: 新しいテストケース4件を追加

### ターゲット解決の優先順位
1. **フルID**: `synapse-claude-8100` (常に動作)
2. **タイプ-ポート**: `claude-8100` (同タイプが複数ある場合) ← **新規**
3. **エージェントタイプ**: `claude` (単一インスタンスの場合のみ)

### ドキュメント
- `README.md`: ターゲット指定方法のテーブルと使用例を追加
- `CLAUDE.md`: コマンドセクションにターゲット形式の説明を追加
- `guides/references.md`: ターゲット形式のドキュメントを追加
- `synapse/templates/.synapse/default.md`, `gemini.md`: テンプレート更新
- `.claude/skills/synapse-a2a/references/commands.md`: ターゲット形式のテーブルを追加
- `.claude/skills/synapse-a2a/references/api.md`: `/tasks/send-priority` 命名規則の説明を追加
- `plugins/synapse-a2a/skills/`: スキルファイルを同期

### リリース
- バージョン: 0.2.18 → 0.2.19

## Test plan

- [x] `pytest tests/test_tools_a2a.py -v` - 全44テストがパス
- [ ] `synapse send claude-8100 "test"` で特定インスタンスに送信できることを確認
- [ ] 同タイプが複数ある場合に `synapse send claude` でヒントが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)