### PR TITLE
chore: add plugin.json version update to release skill

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: release
-description: Update version in pyproject.toml and add changelog entry. This skill should be used when the user wants to bump the version number and update CHANGELOG.md. Triggered by /release or /version commands.
+description: Update version in pyproject.toml, plugin.json, and add changelog entry. This skill should be used when the user wants to bump the version number and update CHANGELOG.md. Triggered by /release or /version commands.
 ---
 
 # Release Version Update
 
-This skill updates the project version and changelog.
+This skill updates the project version, plugin version, and changelog.
 
 ## Usage
 
@@ -52,6 +52,16 @@ Edit `pyproject.toml`:
 ```toml
 version = "NEW_VERSION"
 ```
+
+### Step 3.5: Update plugin.json
+
+Edit `plugins/synapse-a2a/.claude-plugin/plugin.json`:
+
+```json
+"version": "NEW_VERSION",
+```
+
+**Important:** Keep plugin version in sync with pyproject.toml version.
 
 ### Step 4: Analyze Changes for Changelog
 
@@ -126,6 +136,7 @@ Display:
 ## File Locations
 
 - Version: `pyproject.toml` (line with `version = "..."`)
+- Plugin Version: `plugins/synapse-a2a/.claude-plugin/plugin.json` (line with `"version": "..."`)
 - Changelog: `CHANGELOG.md`
 
 ## Changelog Format


### PR DESCRIPTION
## Summary
- Add Step 3.5 to update `plugin.json` version during release
- Add `plugin.json` path to File Locations section
- Keep plugin version in sync with `pyproject.toml`

## Problem
The `/release` skill was only updating `pyproject.toml` version, leaving `plugin.json` out of sync.

## Changes
- Updated `.claude/skills/release/SKILL.md` to include plugin.json version update step

## Test plan
- [ ] Run `/release patch` and verify both `pyproject.toml` and `plugin.json` are updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)