### PR TITLE
release: v0.2.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.23] - 2026-01-18
+
+### Added
+
+- Support prefix match for `--reply-to` short task IDs
+  - Add `TaskStore.get_by_prefix()` method for case-insensitive prefix matching
+  - PTY displays 8-char short IDs (e.g., `[A2A:54241e7e:sender]`)
+  - `--reply-to 54241e7e` now works with short IDs displayed in PTY
+  - Return 400 error for ambiguous prefixes (multiple matches)
+
+### Documentation
+
+- Sync .codex/skills with plugins and fix metadata field naming
+
 ## [0.2.22] - 2026-01-18
 
 ### Fixed

--- a/plugins/synapse-a2a/.claude-plugin/plugin.json
+++ b/plugins/synapse-a2a/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synapse-a2a",
-  "version": "0.2.22",
+  "version": "0.2.23",
   "description": "Complete plugin for Synapse A2A multi-agent framework including inter-agent communication, task delegation, file safety, and history management",
   "author": {
     "name": "s-hiraoku",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synapse-a2a"
-version = "0.2.22"
+version = "0.2.23"
 description = "Agent-to-Agent communication protocol for CLI agents"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- Bump version 0.2.22 → 0.2.23
- Update CHANGELOG.md

### Changes in v0.2.23

#### Added
- Support prefix match for `--reply-to` short task IDs
  - Add `TaskStore.get_by_prefix()` method for case-insensitive prefix matching
  - PTY displays 8-char short IDs (e.g., `[A2A:54241e7e:sender]`)
  - `--reply-to 54241e7e` now works with short IDs displayed in PTY
  - Return 400 error for ambiguous prefixes (multiple matches)

#### Documentation
- Sync .codex/skills with plugins and fix metadata field naming

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * --reply-to オプションでショートタスク ID のプリフィックスマッチングに対応しました。
  * PTY で 8 文字のショートタスク ID が表示されるようになりました。
  * 曖昧なプリフィックスの場合は 400 エラーを返すようになりました。

* **その他**
  * ドキュメントを更新しました。
  * バージョンを 0.2.23 に更新しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->