### PR TITLE
fix: support legacy reply_to key for backward compatibility

### DIFF
--- a/synapse/a2a_compat.py
+++ b/synapse/a2a_compat.py
@@ -526,7 +526,8 @@ def create_a2a_router(
             raise HTTPException(status_code=400, detail="No text content in message")
 
         metadata = request.metadata or {}
-        in_reply_to = metadata.get("in_reply_to")
+        # Support both "in_reply_to" (current) and "reply_to" (legacy) keys
+        in_reply_to = metadata.get("in_reply_to") or metadata.get("reply_to")
 
         if in_reply_to:
             # Support prefix match for short IDs from PTY display


### PR DESCRIPTION
## Summary
- Gemini (and other agents using older synapse versions) was sending `metadata["reply_to"]` instead of `metadata["in_reply_to"]`
- The server now accepts both keys to ensure backward compatibility
- This fixes the issue where `--reply-to` from older clients would create new tasks instead of attaching to existing ones

## Test plan
- [x] ruff check passed
- [x] mypy passed
- [x] pytest tests/test_a2a_compat.py passed (48 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * メタデータキー形式の互換性を向上。システムが従来と新しい両方のキー形式に対応するようになりました。既存の機能と動作は保持されます。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->