### PR TITLE
release: v0.2.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.26] - 2026-01-18
+
+### Fixed
+
+- Display response artifacts in `synapse send --response` mode
+  - Response content from `task.artifacts` was not displayed to the user
+  - Now shows response content with proper indentation for multiline output
+
 ## [0.2.25] - 2026-01-18
 
 ### Added

--- a/plugins/synapse-a2a/.claude-plugin/plugin.json
+++ b/plugins/synapse-a2a/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synapse-a2a",
-  "version": "0.2.25",
+  "version": "0.2.26",
   "description": "Complete plugin for Synapse A2A multi-agent framework including inter-agent communication, task delegation, file safety, and history management",
   "author": {
     "name": "s-hiraoku",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synapse-a2a"
-version = "0.2.25"
+version = "0.2.26"
 description = "Agent-to-Agent communication protocol for CLI agents"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Bump version to 0.2.26

## Changelog

### Fixed
- Display response artifacts in `synapse send --response` mode
  - Response content from `task.artifacts` was not displayed to the user
  - Now shows response content with proper indentation for multiline output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * synapse send --responseモードでレスポンスアーティファクトが表示されるようになりました。複数行の出力がインデント処理され、読みやすさが向上しました。

* **その他**
  * バージョンを0.2.26に更新しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->