### PR TITLE
docs: create bilingual README (English/Japanese)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -466,7 +466,7 @@ synapse claude -- --resume
 # 履歴付きで Gemini を再開
 synapse gemini -- --resume=5
 
-# フラグは settings.json でカスタマイズ可能
+# Codex は 'resume' をサブコマンドとして使用（--resume フラグではない）
 synapse codex -- resume --last
 ```
 
@@ -1035,7 +1035,7 @@ if not validation["allowed"]:
 
 ## テスト
 
-218 のテストケースで A2A プロトコル準拠を検証：
+包括的なテストスイートで A2A プロトコル準拠を検証：
 
 ```bash
 # 全テスト

--- a/README.md
+++ b/README.md
@@ -466,7 +466,7 @@ synapse claude -- --resume
 # Resume Gemini with history
 synapse gemini -- --resume=5
 
-# Flags are customizable in settings.json
+# Codex uses 'resume' as a subcommand (not --resume flag)
 synapse codex -- resume --last
 ```
 
@@ -1035,7 +1035,7 @@ See [docs/file-safety.md](docs/file-safety.md) for details.
 
 ## Testing
 
-218 test cases verify A2A protocol compliance:
+Comprehensive test suite verifies A2A protocol compliance:
 
 ```bash
 # All tests


### PR DESCRIPTION
## Summary

- Convert README.md to English as the main documentation
- Create README.ja.md with Japanese translation
- Add language switcher links at the top of both files

Users can now easily switch between English and Japanese versions using the language switcher:

```
**🌐 Language: [English](README.md) | [日本語](README.ja.md)**
```

## Test plan

- [ ] Verify language switcher links work correctly
- [ ] Verify all content is properly translated
- [ ] Verify Mermaid diagrams render correctly in both versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * 日本語版READMEを追加しました — プロジェクト概要、使い方、API/CLI、構成や図表を含む完全な日本語ローカライズです。
  * 英語版READMEを全面的に英文化して更新しました — 見出し、目次、説明、例、表記を英語で統一し可読性と一貫性を向上しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->