### PR TITLE
docs: update skill installation method to use skills.sh

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -60,7 +60,7 @@ flowchart LR
 - [前提条件](#前提条件)
 - [クイックスタート](#クイックスタート)
 - [ユースケース](#ユースケース)
-- [Claude Code プラグイン](#claude-code-プラグイン)
+- [スキル](#スキル)
 - [ドキュメント](#ドキュメント)
 - [アーキテクチャ](#アーキテクチャ)
 - [CLI コマンド](#cli-コマンド)
@@ -128,19 +128,18 @@ uv sync
 pip install -e .
 ```
 
-### 2. Claude Code プラグインのインストール（推奨）
+### 2. スキルのインストール（推奨）
 
-**Synapse A2A を最大限に活用するには、プラグインのインストールを強く推奨します。**
+**Synapse A2A を最大限に活用するには、スキルのインストールを強く推奨します。**
 
-プラグインにより、Claude は Synapse A2A の機能を自動的に理解します：@agent メッセージング、タスク委譲、File Safety など。
+スキルにより、Claude は Synapse A2A の機能を自動的に理解します：@agent メッセージング、タスク委譲、File Safety など。
 
 ```bash
-# Claude Code 内で実行
-/plugin marketplace add s-hiraoku/synapse-a2a
-/plugin install synapse-a2a@s-hiraoku/synapse-a2a
+# skills.sh 経由でインストール（https://skills.sh/）
+npx skills add s-hiraoku/synapse-a2a
 ```
 
-詳しくは [Claude Code プラグイン](#claude-code-プラグイン) を参照。
+詳しくは [スキル](#スキル) を参照。
 
 ### 3. エージェントの起動
 
@@ -278,13 +277,13 @@ legacy_api.js を読んで TypeScript の型定義を作成して
 
 ---
 
-## Claude Code プラグイン
+## スキル
 
-**Claude Code で Synapse A2A を使用する場合、プラグインのインストールを強く推奨します。**
+**Claude Code で Synapse A2A を使用する場合、スキルのインストールを強く推奨します。**
 
-### プラグインをインストールする理由
+### スキルをインストールする理由
 
-プラグインをインストールすると、Claude は自動的に以下を理解して実行します：
+スキルをインストールすると、Claude は自動的に以下を理解して実行します：
 
 - **synapse send**: `synapse send codex "Fix this" --from claude` でエージェント間通信
 - **@agent パターン**: `@codex Fix this` でユーザー入力から直接送信
@@ -296,9 +295,8 @@ legacy_api.js を読んで TypeScript の型定義を作成して
 ### インストール
 
 ```bash
-# Claude Code 内で実行
-/plugin marketplace add s-hiraoku/synapse-a2a
-/plugin install synapse-a2a@s-hiraoku/synapse-a2a
+# skills.sh 経由でインストール（https://skills.sh/）
+npx skills add s-hiraoku/synapse-a2a
 ```
 
 ### 含まれるスキル

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ flowchart LR
 - [Prerequisites](#prerequisites)
 - [Quick Start](#quick-start)
 - [Use Cases](#use-cases)
-- [Claude Code Plugin](#claude-code-plugin)
+- [Skills](#skills)
 - [Documentation](#documentation)
 - [Architecture](#architecture)
 - [CLI Commands](#cli-commands)
@@ -129,19 +129,18 @@ uv sync
 pip install -e .
 ```
 
-### 2. Install Claude Code Plugin (Recommended)
+### 2. Install Skills (Recommended)
 
-**Installing the plugin is strongly recommended to get the most out of Synapse A2A.**
+**Installing skills is strongly recommended to get the most out of Synapse A2A.**
 
-The plugin helps Claude automatically understand Synapse A2A features: @agent messaging, task delegation, File Safety, and more.
+Skills help Claude automatically understand Synapse A2A features: @agent messaging, task delegation, File Safety, and more.
 
 ```bash
-# Run inside Claude Code
-/plugin marketplace add s-hiraoku/synapse-a2a
-/plugin install synapse-a2a@s-hiraoku/synapse-a2a
+# Install via skills.sh (https://skills.sh/)
+npx skills add s-hiraoku/synapse-a2a
 ```
 
-See [Claude Code Plugin](#claude-code-plugin) for details.
+See [Skills](#skills) for details.
 
 ### 3. Start Agents
 
@@ -283,13 +282,13 @@ Read legacy_api.js and create TypeScript type definitions
 
 ---
 
-## Claude Code Plugin
+## Skills
 
-**Installing the plugin is strongly recommended** when using Synapse A2A with Claude Code.
+**Installing skills is strongly recommended** when using Synapse A2A with Claude Code.
 
-### Why Install the Plugin?
+### Why Install Skills?
 
-With the plugin installed, Claude automatically understands and executes:
+With skills installed, Claude automatically understands and executes:
 
 - **synapse send**: Inter-agent communication via `synapse send codex "Fix this" --from claude`
 - **@agent pattern**: Direct sending from user input via `@codex Fix this`
@@ -301,9 +300,8 @@ With the plugin installed, Claude automatically understands and executes:
 ### Installation
 
 ```bash
-# Run inside Claude Code
-/plugin marketplace add s-hiraoku/synapse-a2a
-/plugin install synapse-a2a@s-hiraoku/synapse-a2a
+# Install via skills.sh (https://skills.sh/)
+npx skills add s-hiraoku/synapse-a2a
 ```
 
 ### Included Skills

--- a/guides/settings.md
+++ b/guides/settings.md
@@ -172,19 +172,18 @@ Synapse A2A の機能をエージェントに教え込むための「スキル�
 
 ### Claude Code
 
-Claude Code の場合、**プラグイン marketplace からのインストールを強く推奨します**。これにより、最新のスキルと機能（File Safety, Delegation など）が自動的に適用されます。
+Claude Code の場合、**skills.sh 経由でのインストールを強く推奨します**。これにより、最新のスキルと機能（File Safety, Delegation など）が自動的に適用されます。
 
 ```bash
-# Claude Code 内で実行
-/plugin marketplace add s-hiraoku/synapse-a2a
-/plugin install synapse-a2a@s-hiraoku/synapse-a2a
+# skills.sh 経由でインストール（https://skills.sh/）
+npx skills add s-hiraoku/synapse-a2a
 ```
 
 ### Legacy Skills (手動インストール)
 
 `synapse` コマンド起動時に、`~/.claude/skills/` に基本的なスキルファイルが自動的に配置される場合があります。これは旧バージョンとの互換性のための動作です。
 
-> **Note**: `synapse init` は現在、個別のプロジェクトディレクトリへのスキルファイルのコピーは行いません。プロジェクト単位でスキルを管理したい場合は、プラグイン機能を使用してください。
+> **Note**: `synapse init` は現在、個別のプロジェクトディレクトリへのスキルファイルのコピーは行いません。プロジェクト単位でスキルを管理したい場合は、skills.sh を使用してください。
 
 ### Gemini
 

--- a/plugins/synapse-a2a/README.md
+++ b/plugins/synapse-a2a/README.md
@@ -1,15 +1,12 @@
-# Synapse A2A Plugin
+# Synapse A2A Skills
 
-Claude Code plugin for [Synapse A2A](https://github.com/s-hiraoku/synapse-a2a) - a multi-agent communication framework.
+Skills for [Synapse A2A](https://github.com/s-hiraoku/synapse-a2a) - a multi-agent communication framework.
 
 ## Installation
 
 ```bash
-# Add the marketplace
-/plugin marketplace add s-hiraoku/synapse-a2a
-
-# Install the plugin
-/plugin install synapse-a2a@s-hiraoku/synapse-a2a
+# Install via skills.sh (https://skills.sh/)
+npx skills add s-hiraoku/synapse-a2a
 ```
 
 ## Skills Included

--- a/synapse/cli.py
+++ b/synapse/cli.py
@@ -1314,9 +1314,8 @@ def _copy_claude_skills_to_codex(base_dir: Path, force: bool = False) -> list[st
     """
     Copy synapse-a2a skills from .claude to .codex directory.
 
-    Claude Code supports plugins, so skills are installed via:
-        /plugin marketplace add s-hiraoku/synapse-a2a
-        /plugin install synapse-a2a@s-hiraoku/synapse-a2a
+    Claude Code supports skills via skills.sh:
+        npx skills add s-hiraoku/synapse-a2a
 
     Codex does not support plugins, so this function copies the skills
     from .claude/skills/synapse-a2a to .codex/skills/synapse-a2a.


### PR DESCRIPTION
## Summary

- スキルのインストール方法を `/plugin marketplace add` + `/plugin install` から `npx skills add s-hiraoku/synapse-a2a` (skills.sh) に変更
- 「Claude Code Plugin」セクションを「Skills」に名称変更

## Changed Files

| File | Changes |
|------|---------|
| `README.md` | Quick Start とSkillsセクションを更新 |
| `README.ja.md` | 同上（日本語版） |
| `plugins/synapse-a2a/README.md` | タイトルとインストール方法を更新 |
| `guides/settings.md` | スキルインストール手順を更新 |
| `synapse/cli.py` | docstring内のコメントを更新 |

## Test plan

- [ ] READMEのインストール手順が正しく表示されることを確認
- [ ] skills.shへのリンクが有効であることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメンテーション**
  * インストール手順を更新：プラグインコマンドから `npx skills add` コマンドへ変更
  * ドキュメント全体で用語を「プラグイン」から「スキル」に統一
  * README およびガイドで Claude A2A の機能説明をスキルベースの説明に更新
  * インストール方法を Plugin Marketplace から skills.sh へ変更

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->