### PR TITLE
chore: release v0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.4] - 2026-01-23
+
+### Documentation
+
+- Update skill installation method to use skills.sh (`npx skills add s-hiraoku/synapse-a2a`)
+- Rename "Claude Code Plugin" section to "Skills" in README
+- Add skills.sh reference links (https://skills.sh/)
+
 ## [0.3.3] - 2026-01-23
 
 ### Added

--- a/plugins/synapse-a2a/.claude-plugin/plugin.json
+++ b/plugins/synapse-a2a/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synapse-a2a",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Complete plugin for Synapse A2A multi-agent framework including inter-agent communication, task delegation, file safety, and history management",
   "author": {
     "name": "s-hiraoku",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synapse-a2a"
-version = "0.3.3"
+version = "0.3.4"
 description = "Agent-to-Agent communication protocol for CLI agents"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- Version bump: 0.3.3 → 0.3.4

## Changes in this release

### Documentation

- Update skill installation method to use skills.sh (`npx skills add s-hiraoku/synapse-a2a`)
- Rename "Claude Code Plugin" section to "Skills" in README
- Add skills.sh reference links (https://skills.sh/)

## Test plan

- [ ] Verify version updated in pyproject.toml
- [ ] Verify version updated in plugin.json
- [ ] Verify CHANGELOG.md updated

🤖 Generated with [Claude Code](https://claude.ai/code)