### PR TITLE
feat: auto-detect --from using SYNAPSE_AGENT_ID environment variable

### DIFF
--- a/tests/test_a2a_tool.py
+++ b/tests/test_a2a_tool.py
@@ -2,7 +2,7 @@ import argparse
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from synapse.tools.a2a import cmd_send
+from synapse.tools.a2a import build_sender_info, cmd_send
 
 
 class TestA2AToolSend:
@@ -52,3 +52,100 @@ class TestA2AToolSend:
         # local_only=False to allow HTTP fallback if UDS fails
         assert call_kwargs.get("local_only") is False
         mock_port_open.assert_not_called()
+
+
+class TestBuildSenderInfoFromEnv:
+    """Tests for SYNAPSE_AGENT_ID environment variable auto-detection (#128)."""
+
+    def test_env_var_takes_priority_over_pid_matching(self, monkeypatch):
+        """Environment variable should be checked before PID matching."""
+        # Setup mock registry with the agent
+        mock_agent = {
+            "agent_id": "synapse-claude-8100",
+            "agent_type": "claude",
+            "port": 8100,
+            "endpoint": "http://localhost:8100",
+            "uds_path": "/tmp/claude.sock",
+        }
+        mock_registry = MagicMock()
+        mock_registry.list_agents.return_value = {"synapse-claude-8100": mock_agent}
+
+        monkeypatch.setattr("synapse.tools.a2a.AgentRegistry", lambda: mock_registry)
+        # Set the environment variable
+        monkeypatch.setenv("SYNAPSE_AGENT_ID", "synapse-claude-8100")
+
+        result = build_sender_info()
+
+        assert result["sender_id"] == "synapse-claude-8100"
+        assert result["sender_type"] == "claude"
+        assert result["sender_endpoint"] == "http://localhost:8100"
+        assert result["sender_uds_path"] == "/tmp/claude.sock"
+
+    def test_env_var_not_in_registry_falls_back_to_pid(self, monkeypatch):
+        """If env var agent not in registry, fall back to PID matching."""
+        # Setup mock registry without the env agent
+        mock_registry = MagicMock()
+        mock_registry.list_agents.return_value = {}
+
+        monkeypatch.setattr("synapse.tools.a2a.AgentRegistry", lambda: mock_registry)
+        monkeypatch.setenv("SYNAPSE_AGENT_ID", "synapse-nonexistent-9999")
+
+        # PID matching should also fail, returning empty dict
+        result = build_sender_info()
+
+        assert result == {}
+
+    def test_explicit_from_still_takes_priority(self, monkeypatch):
+        """Explicit --from flag should take priority over env var."""
+        mock_agent_claude = {
+            "agent_id": "synapse-claude-8100",
+            "agent_type": "claude",
+            "port": 8100,
+            "endpoint": "http://localhost:8100",
+        }
+        mock_agent_gemini = {
+            "agent_id": "synapse-gemini-8110",
+            "agent_type": "gemini",
+            "port": 8110,
+            "endpoint": "http://localhost:8110",
+        }
+        mock_registry = MagicMock()
+        mock_registry.list_agents.return_value = {
+            "synapse-claude-8100": mock_agent_claude,
+            "synapse-gemini-8110": mock_agent_gemini,
+        }
+
+        monkeypatch.setattr("synapse.tools.a2a.AgentRegistry", lambda: mock_registry)
+        # Set env var to claude
+        monkeypatch.setenv("SYNAPSE_AGENT_ID", "synapse-claude-8100")
+
+        # But explicit --from is gemini
+        result = build_sender_info("gemini")
+
+        assert result["sender_id"] == "synapse-gemini-8110"
+        assert result["sender_type"] == "gemini"
+
+    def test_no_env_var_uses_pid_matching(self, monkeypatch):
+        """Without env var, should fall back to PID matching."""
+        mock_agent = {
+            "agent_id": "synapse-codex-8120",
+            "agent_type": "codex",
+            "port": 8120,
+            "endpoint": "http://localhost:8120",
+            "pid": 12345,
+        }
+        mock_registry = MagicMock()
+        mock_registry.list_agents.return_value = {"synapse-codex-8120": mock_agent}
+
+        monkeypatch.setattr("synapse.tools.a2a.AgentRegistry", lambda: mock_registry)
+        # Ensure env var is not set
+        monkeypatch.delenv("SYNAPSE_AGENT_ID", raising=False)
+        # Mock PID matching to succeed
+        monkeypatch.setattr(
+            "synapse.tools.a2a.is_descendant_of", lambda child, ancestor: True
+        )
+
+        result = build_sender_info()
+
+        assert result["sender_id"] == "synapse-codex-8120"
+        assert result["sender_type"] == "codex"


### PR DESCRIPTION
## Summary

- Add SYNAPSE_AGENT_ID environment variable detection to `build_sender_info()` function
- Simplifies `synapse send` command by eliminating the need for `--from` flag in most cases

## Changes

Priority order for sender detection:
1. Explicit `--from` flag (highest priority)
2. `SYNAPSE_AGENT_ID` environment variable
3. Registry PID matching (fallback)

## Test Plan

- [x] Added 4 new tests for environment variable detection
- [x] All existing tests pass
- [x] Verified priority order: explicit > env var > PID matching

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)