### PR TITLE
feat: add process kill action in synapse list TUI

### DIFF
--- a/synapse/commands/renderers/rich_renderer.py
+++ b/synapse/commands/renderers/rich_renderer.py
@@ -229,10 +229,13 @@ class RichRenderer:
             footer.append(f"1-{agent_count}", style="bold cyan")
             footer.append(" to view details, ", style="dim")
 
-            # Show jump hint if available and row selected
-            if jump_available and has_selection:
-                footer.append("Enter/j", style="bold green")
-                footer.append(" to jump, ", style="dim")
+            # Show action hints if row is selected
+            if has_selection:
+                if jump_available:
+                    footer.append("Enter/j", style="bold green")
+                    footer.append(" to jump, ", style="dim")
+                footer.append("k", style="bold red")
+                footer.append(" to kill, ", style="dim")
 
             footer.append("ESC", style="bold cyan")
             footer.append(" to close, ", style="dim")


### PR DESCRIPTION
## Summary

Add 'k' key binding to kill selected agent in the interactive `synapse list` TUI mode.

## Changes

- **New key binding**: Press 'k' to kill the selected agent (with confirmation prompt)
- **Stop agent function**: Added `stop_agent()` to `list.py` for terminating agents
- **Updated footer**: Shows 'k to kill' hint when an agent row is selected

## Key Bindings

| Key | Action |
|-----|--------|
| `1-9` | Select agent row |
| `Enter` / `j` | Jump to terminal (existing) |
| `k` | Kill selected agent (new) |
| `ESC` | Clear selection |
| `q` / `Ctrl+C` | Exit |

## Test Plan

- [x] Added 8 new tests for kill action functionality
- [x] Tested kill with valid PID sends SIGTERM
- [x] Tested kill with no PID just unregisters
- [x] Tested kill confirmation prompt (y/n)
- [x] All existing tests pass

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)