### PR TITLE
feat: add --context and --files options for a2a send command

### DIFF
--- a/tests/test_a2a_tool.py
+++ b/tests/test_a2a_tool.py
@@ -52,3 +52,129 @@ class TestA2AToolSend:
         # local_only=False to allow HTTP fallback if UDS fails
         assert call_kwargs.get("local_only") is False
         mock_port_open.assert_not_called()
+
+
+class TestContextOption:
+    """Tests for --context option in send command (#24)."""
+
+    def _setup_mocks(self, monkeypatch):
+        """Set up common mocks for send command tests."""
+        target_agent = {
+            "agent_id": "synapse-gemini-8110",
+            "agent_type": "gemini",
+            "port": 8110,
+            "endpoint": "http://localhost:8110",
+            "pid": 456,
+        }
+        sender_agent = {
+            "agent_id": "synapse-claude-8100",
+            "agent_type": "claude",
+            "port": 8100,
+            "endpoint": "http://localhost:8100",
+            "working_dir": "/path/to/project",
+        }
+
+        mock_registry = MagicMock()
+        mock_registry.list_agents.return_value = {
+            "synapse-gemini-8110": target_agent,
+            "synapse-claude-8100": sender_agent,
+        }
+
+        mock_client = MagicMock()
+        mock_client.send_to_local.return_value = MagicMock(
+            id="task-1", status="working", artifacts=[]
+        )
+
+        monkeypatch.setattr("synapse.tools.a2a.AgentRegistry", lambda: mock_registry)
+        monkeypatch.setattr("synapse.tools.a2a.A2AClient", lambda: mock_client)
+        monkeypatch.setattr("synapse.tools.a2a.is_process_running", lambda pid: True)
+        monkeypatch.setattr(
+            "synapse.tools.a2a.is_port_open", lambda *args, **kwargs: True
+        )
+        monkeypatch.setattr(
+            "synapse.tools.a2a._record_sent_message", lambda **kwargs: None
+        )
+
+        return mock_client, sender_agent
+
+    def test_context_flag_adds_context_to_message(self, monkeypatch):
+        """--context should prepend context information to the message."""
+        mock_client, sender_agent = self._setup_mocks(monkeypatch)
+
+        args = argparse.Namespace(
+            target="gemini",
+            priority=1,
+            sender="claude",
+            want_response=None,
+            reply_to=None,
+            context=True,
+            files=None,
+            message="What is this error?",
+        )
+
+        cmd_send(args)
+
+        mock_client.send_to_local.assert_called_once()
+        call_kwargs = mock_client.send_to_local.call_args.kwargs
+        message = call_kwargs.get("message")
+
+        # Message should contain context prefix
+        assert "【コンテキスト】" in message or "[Context]" in message
+        assert "synapse-claude-8100" in message
+        assert "/path/to/project" in message
+        assert "What is this error?" in message
+
+    def test_context_flag_off_sends_raw_message(self, monkeypatch):
+        """Without --context, message should be sent as-is."""
+        mock_client, _ = self._setup_mocks(monkeypatch)
+
+        args = argparse.Namespace(
+            target="gemini",
+            priority=1,
+            sender="claude",
+            want_response=None,
+            reply_to=None,
+            context=False,
+            files=None,
+            message="Simple message",
+        )
+
+        cmd_send(args)
+
+        mock_client.send_to_local.assert_called_once()
+        call_kwargs = mock_client.send_to_local.call_args.kwargs
+        message = call_kwargs.get("message")
+
+        # Message should be raw, no context prefix
+        assert "【コンテキスト】" not in message
+        assert "[Context]" not in message
+        assert message == "Simple message"
+
+    def test_context_with_files_includes_file_info(self, monkeypatch, tmp_path):
+        """--context with --files should include file information."""
+        mock_client, _ = self._setup_mocks(monkeypatch)
+
+        # Create a test file
+        test_file = tmp_path / "test.py"
+        test_file.write_text("def hello():\n    print('Hello')\n")
+
+        args = argparse.Namespace(
+            target="gemini",
+            priority=1,
+            sender="claude",
+            want_response=None,
+            reply_to=None,
+            context=True,
+            files=str(test_file),
+            message="Review this code",
+        )
+
+        cmd_send(args)
+
+        mock_client.send_to_local.assert_called_once()
+        call_kwargs = mock_client.send_to_local.call_args.kwargs
+        message = call_kwargs.get("message")
+
+        # Message should include file content or reference
+        assert "test.py" in message
+        assert "Review this code" in message


### PR DESCRIPTION
## Summary

Add `--context` and `--files` options to the `a2a send` command to provide richer context when communicating between agents.

## New Options

| Option | Description |
|--------|-------------|
| `--context` | Prepend sender info (agent ID, type, working directory) to message |
| `--files PATH` | Include file contents in the context (comma-separated paths) |

## Usage Examples

```bash
# Send with context
python -m synapse.tools.a2a send --target gemini --context "Review this code"

# Send with context and file contents
python -m synapse.tools.a2a send --target gemini --context --files src/main.py,README.md "Fix the bug"
```

## Message Format

When `--context` is enabled, the message is formatted as:

```
【コンテキスト】
- Agent: synapse-claude-8100
- Type: claude
- Working Directory: /path/to/project
- Endpoint: http://localhost:8100
- Files:
--- main.py ---
(file contents truncated to 2000 chars)

【メッセージ】
(original message)
```

## Test Plan

- [x] Context adds agent info to message
- [x] Without context, message is sent as-is
- [x] Files option includes file contents
- [x] All existing tests pass

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)