### PR TITLE
chore: release v0.3.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.22] - 2026-02-06
+
+### Fixed
+
+- **Extra newline in CLI output** - `synapse send` / `synapse broadcast` no longer print double newlines
+- **Error propagation** - `synapse send` and `synapse broadcast` now exit with non-zero code on failure (consistent with `synapse reply`)
+
+### Changed
+
+- **Refactor CLI a2a commands** - Extract shared helpers (`_get_a2a_tool_path`, `_run_a2a_command`, `_build_a2a_cmd`) to reduce duplication
+
+### Documentation
+
+- Add complete flags (`--from`, `--response`, `--no-response`) to broadcast command reference
+- Fix inconsistent `DIR` → `WORKING_DIR` naming in skill documentation
+
 ## [0.3.21] - 2026-02-06
 
 ### Added

--- a/plugins/synapse-a2a/.claude-plugin/plugin.json
+++ b/plugins/synapse-a2a/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synapse-a2a",
-  "version": "0.3.21",
+  "version": "0.3.22",
   "description": "Complete plugin for Synapse A2A multi-agent framework including inter-agent communication, file safety, and history management",
   "author": {
     "name": "s-hiraoku",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synapse-a2a"
-version = "0.3.21"
+version = "0.3.22"
 description = "Agent-to-Agent communication protocol for CLI agents"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Release v0.3.22 - CLI fixes and refactoring.

## Changes

- Fix extra newline in `synapse send` / `synapse broadcast` output
- Propagate error exit codes from a2a.py subprocess
- Refactor CLI a2a command helpers
- Fix broadcast command docs and WORKING_DIR naming consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)