### PR TITLE
fix(docs): correct synapse reply --from usage

### DIFF
--- a/.agents/skills/synapse-a2a/SKILL.md
+++ b/.agents/skills/synapse-a2a/SKILL.md
@@ -15,9 +15,9 @@ Inter-agent communication framework via Google A2A Protocol.
 | Send message | `synapse send <target> "<message>" --from <sender>` |
 | Broadcast to cwd agents | `synapse broadcast "<message>" --from <sender>` |
 | Wait for reply | `synapse send <target> "<message>" --response --from <sender>` |
-| Reply to last message | `synapse reply "<response>" --from <agent>` |
-| Reply to specific sender | `synapse reply "<response>" --from <agent> --to <sender_id>` |
-| List reply targets | `synapse reply --list-targets --from <agent>` |
+| Reply to last message | `synapse reply "<response>"` |
+| Reply to specific sender | `synapse reply "<response>" --to <sender_id>` |
+| List reply targets | `synapse reply --list-targets` |
 | Emergency stop | `synapse send <target> "STOP" --priority 5 --from <sender>` |
 | Stop agent | `synapse stop <profile\|id>` |
 | Kill agent | `synapse kill <target>` (with confirmation, use `-f` to force) |
@@ -88,8 +88,8 @@ For request-response patterns:
 # Sender: Wait for response (blocks until reply received)
 synapse send gemini "Analyze this data" --response --from synapse-claude-8100
 
-# Receiver: Reply to sender
-synapse reply "Analysis result: ..." --from synapse-gemini-8110
+# Receiver: Reply to sender (auto-routes via reply tracking)
+synapse reply "Analysis result: ..."
 ```
 
 The `--response` flag makes the sender wait. The receiver should reply using the `synapse reply` command.
@@ -130,19 +130,21 @@ If `[REPLY EXPECTED]` marker is present, you **MUST** reply using `synapse reply
 **Replying to messages:**
 
 ```bash
-# Use the reply command
-# --from: Use your agent ID (synapse-<type>-<port>)
-synapse reply "Here is my analysis..." --from <your_agent_id>
+# Use the reply command (auto-routes to last sender)
+synapse reply "Here is my analysis..."
 
 # When multiple senders are pending, inspect and choose target
-synapse reply --list-targets --from <your_agent_id>
-synapse reply "Here is my analysis..." --from <your_agent_id> --to <sender_id>
+synapse reply --list-targets
+synapse reply "Here is my analysis..." --to <sender_id>
+
+# In sandboxed environments (like Codex), specify your agent ID
+synapse reply "Here is my analysis..." --from <your_agent_id>
 ```
 
 **Example - Question received (MUST reply):**
 ```
 Received: A2A: [REPLY EXPECTED] What is the project structure?
-Reply:    synapse reply "The project has src/, tests/..." --from synapse-codex-8121
+Reply:    synapse reply "The project has src/, tests/..."
 ```
 
 **Example - Delegation received (no reply needed):**

--- a/.agents/skills/synapse-a2a/references/api.md
+++ b/.agents/skills/synapse-a2a/references/api.md
@@ -18,9 +18,9 @@ A2A: <message content>
 Use `synapse reply` to respond:
 
 ```bash
-synapse reply "<your response>" --from <your_agent_id>
-synapse reply --list-targets --from <your_agent_id>
-synapse reply "<your response>" --from <your_agent_id> --to <sender_id>
+synapse reply "<your response>"
+synapse reply --list-targets
+synapse reply "<your response>" --to <sender_id>
 ```
 
 The framework automatically handles routing - you don't need to know where the message came from.

--- a/.agents/skills/synapse-a2a/references/commands.md
+++ b/.agents/skills/synapse-a2a/references/commands.md
@@ -177,14 +177,17 @@ If `[REPLY EXPECTED]` marker is present, you **MUST** reply using `synapse reply
 **Replying to messages:**
 
 ```bash
-# Use the reply command (--from is required in sandboxed environments)
+# Use the reply command (auto-routes to last sender)
+synapse reply "<your reply>"
+
+# In sandboxed environments (like Codex), specify your agent ID
 synapse reply "<your reply>" --from <your_agent_id>
 ```
 
 **Example - Question received (MUST reply):**
 ```
 Received: A2A: [REPLY EXPECTED] What is the project structure?
-Reply:    synapse reply "The project has src/, tests/..." --from synapse-codex-8121
+Reply:    synapse reply "The project has src/, tests/..."
 ```
 
 **Example - Delegation received (no reply needed):**
@@ -259,19 +262,19 @@ synapse send codex "STOP" --priority 5 --from synapse-claude-8100
 Reply to the last received message:
 
 ```bash
-synapse reply "<message>" --from <your_agent_id>
+synapse reply "<message>"
 ```
 
-Synapse automatically knows who to reply to based on tracked senders. The `--from` flag is required in sandboxed environments (like Codex).
+Synapse automatically knows who to reply to based on tracked senders. The `--from` flag is only needed in sandboxed environments (like Codex).
 
 If multiple senders are pending, list and choose explicitly:
 
 ```bash
 # Show tracked sender IDs
-synapse reply --list-targets --from <your_agent_id>
+synapse reply --list-targets
 
 # Reply to a specific sender
-synapse reply "<message>" --from <your_agent_id> --to <sender_id>
+synapse reply "<message>" --to <sender_id>
 ```
 
 ### Broadcast Command
@@ -313,9 +316,9 @@ For advanced use cases or external scripts:
 ```bash
 python -m synapse.tools.a2a send --target <AGENT> [--priority <1-5>] "<MESSAGE>"
 python -m synapse.tools.a2a broadcast [--priority <1-5>] [--from <AGENT>] [--response | --no-response] "<MESSAGE>"  # Broadcast to cwd agents
-python -m synapse.tools.a2a reply "<MESSAGE>" --from <AGENT>  # Reply to last received message
-python -m synapse.tools.a2a reply --list-targets --from <AGENT>
-python -m synapse.tools.a2a reply "<MESSAGE>" --from <AGENT> --to <SENDER_ID>
+python -m synapse.tools.a2a reply "<MESSAGE>"  # Reply to last received message
+python -m synapse.tools.a2a reply --list-targets
+python -m synapse.tools.a2a reply "<MESSAGE>" --to <SENDER_ID>
 python -m synapse.tools.a2a list                # List agents
 python -m synapse.tools.a2a cleanup             # Cleanup stale entries
 ```

--- a/.agents/skills/synapse-a2a/references/examples.md
+++ b/.agents/skills/synapse-a2a/references/examples.md
@@ -102,7 +102,7 @@ Options:
 synapse send codex "Please review the changes in src/feature.py" --response --from synapse-claude-8100
 
 # Terminal 2 (Codex): Reply after reviewing
-synapse reply "LGTM. Two suggestions: ..." --from synapse-codex-8120
+synapse reply "LGTM. Two suggestions: ..."
 ```
 
 ### Parallel Research

--- a/.codex/skills/synapse-a2a/SKILL.md
+++ b/.codex/skills/synapse-a2a/SKILL.md
@@ -15,9 +15,9 @@ Inter-agent communication framework via Google A2A Protocol.
 | Send message | `synapse send <target> "<message>" --from <sender>` |
 | Broadcast to cwd agents | `synapse broadcast "<message>" --from <sender>` |
 | Wait for reply | `synapse send <target> "<message>" --response --from <sender>` |
-| Reply to last message | `synapse reply "<response>" --from <agent>` |
-| Reply to specific sender | `synapse reply "<response>" --from <agent> --to <sender_id>` |
-| List reply targets | `synapse reply --list-targets --from <agent>` |
+| Reply to last message | `synapse reply "<response>"` |
+| Reply to specific sender | `synapse reply "<response>" --to <sender_id>` |
+| List reply targets | `synapse reply --list-targets` |
 | Emergency stop | `synapse send <target> "STOP" --priority 5 --from <sender>` |
 | Stop agent | `synapse stop <profile\|id>` |
 | Kill agent | `synapse kill <target>` (with confirmation, use `-f` to force) |
@@ -88,8 +88,8 @@ For request-response patterns:
 # Sender: Wait for response (blocks until reply received)
 synapse send gemini "Analyze this data" --response --from synapse-claude-8100
 
-# Receiver: Reply to sender
-synapse reply "Analysis result: ..." --from synapse-gemini-8110
+# Receiver: Reply to sender (auto-routes via reply tracking)
+synapse reply "Analysis result: ..."
 ```
 
 The `--response` flag makes the sender wait. The receiver should reply using the `synapse reply` command.
@@ -130,19 +130,21 @@ If `[REPLY EXPECTED]` marker is present, you **MUST** reply using `synapse reply
 **Replying to messages:**
 
 ```bash
-# Use the reply command
-# --from: Use your agent ID (synapse-<type>-<port>)
-synapse reply "Here is my analysis..." --from <your_agent_id>
+# Use the reply command (auto-routes to last sender)
+synapse reply "Here is my analysis..."
 
 # When multiple senders are pending, inspect and choose target
-synapse reply --list-targets --from <your_agent_id>
-synapse reply "Here is my analysis..." --from <your_agent_id> --to <sender_id>
+synapse reply --list-targets
+synapse reply "Here is my analysis..." --to <sender_id>
+
+# In sandboxed environments (like Codex), specify your agent ID
+synapse reply "Here is my analysis..." --from <your_agent_id>
 ```
 
 **Example - Question received (MUST reply):**
 ```
 Received: A2A: [REPLY EXPECTED] What is the project structure?
-Reply:    synapse reply "The project has src/, tests/..." --from synapse-codex-8121
+Reply:    synapse reply "The project has src/, tests/..."
 ```
 
 **Example - Delegation received (no reply needed):**

--- a/.codex/skills/synapse-a2a/references/api.md
+++ b/.codex/skills/synapse-a2a/references/api.md
@@ -18,9 +18,9 @@ A2A: <message content>
 Use `synapse reply` to respond:
 
 ```bash
-synapse reply "<your response>" --from <your_agent_id>
-synapse reply --list-targets --from <your_agent_id>
-synapse reply "<your response>" --from <your_agent_id> --to <sender_id>
+synapse reply "<your response>"
+synapse reply --list-targets
+synapse reply "<your response>" --to <sender_id>
 ```
 
 The framework automatically handles routing - you don't need to know where the message came from.

--- a/.codex/skills/synapse-a2a/references/commands.md
+++ b/.codex/skills/synapse-a2a/references/commands.md
@@ -177,14 +177,17 @@ If `[REPLY EXPECTED]` marker is present, you **MUST** reply using `synapse reply
 **Replying to messages:**
 
 ```bash
-# Use the reply command (--from is required in sandboxed environments)
+# Use the reply command (auto-routes to last sender)
+synapse reply "<your reply>"
+
+# In sandboxed environments (like Codex), specify your agent ID
 synapse reply "<your reply>" --from <your_agent_id>
 ```
 
 **Example - Question received (MUST reply):**
 ```
 Received: A2A: [REPLY EXPECTED] What is the project structure?
-Reply:    synapse reply "The project has src/, tests/..." --from synapse-codex-8121
+Reply:    synapse reply "The project has src/, tests/..."
 ```
 
 **Example - Delegation received (no reply needed):**
@@ -259,19 +262,19 @@ synapse send codex "STOP" --priority 5 --from synapse-claude-8100
 Reply to the last received message:
 
 ```bash
-synapse reply "<message>" --from <your_agent_id>
+synapse reply "<message>"
 ```
 
-Synapse automatically knows who to reply to based on tracked senders. The `--from` flag is required in sandboxed environments (like Codex).
+Synapse automatically knows who to reply to based on tracked senders. The `--from` flag is only needed in sandboxed environments (like Codex).
 
 If multiple senders are pending, list and choose explicitly:
 
 ```bash
 # Show tracked sender IDs
-synapse reply --list-targets --from <your_agent_id>
+synapse reply --list-targets
 
 # Reply to a specific sender
-synapse reply "<message>" --from <your_agent_id> --to <sender_id>
+synapse reply "<message>" --to <sender_id>
 ```
 
 ### Broadcast Command
@@ -313,9 +316,9 @@ For advanced use cases or external scripts:
 ```bash
 python -m synapse.tools.a2a send --target <AGENT> [--priority <1-5>] "<MESSAGE>"
 python -m synapse.tools.a2a broadcast [--priority <1-5>] [--from <AGENT>] [--response | --no-response] "<MESSAGE>"  # Broadcast to cwd agents
-python -m synapse.tools.a2a reply "<MESSAGE>" --from <AGENT>  # Reply to last received message
-python -m synapse.tools.a2a reply --list-targets --from <AGENT>
-python -m synapse.tools.a2a reply "<MESSAGE>" --from <AGENT> --to <SENDER_ID>
+python -m synapse.tools.a2a reply "<MESSAGE>"  # Reply to last received message
+python -m synapse.tools.a2a reply --list-targets
+python -m synapse.tools.a2a reply "<MESSAGE>" --to <SENDER_ID>
 python -m synapse.tools.a2a list                # List agents
 python -m synapse.tools.a2a cleanup             # Cleanup stale entries
 ```

--- a/.codex/skills/synapse-a2a/references/examples.md
+++ b/.codex/skills/synapse-a2a/references/examples.md
@@ -102,7 +102,7 @@ Options:
 synapse send codex "Please review the changes in src/feature.py" --response --from synapse-claude-8100
 
 # Terminal 2 (Codex): Reply after reviewing
-synapse reply "LGTM. Two suggestions: ..." --from synapse-codex-8120
+synapse reply "LGTM. Two suggestions: ..."
 ```
 
 ### Parallel Research

--- a/.gemini/skills/synapse-a2a/SKILL.md
+++ b/.gemini/skills/synapse-a2a/SKILL.md
@@ -15,9 +15,9 @@ Inter-agent communication framework via Google A2A Protocol.
 | Send message | `synapse send <target> "<message>" --from <sender>` |
 | Broadcast to cwd agents | `synapse broadcast "<message>" --from <sender>` |
 | Wait for reply | `synapse send <target> "<message>" --response --from <sender>` |
-| Reply to last message | `synapse reply "<response>" --from <agent>` |
-| Reply to specific sender | `synapse reply "<response>" --from <agent> --to <sender_id>` |
-| List reply targets | `synapse reply --list-targets --from <agent>` |
+| Reply to last message | `synapse reply "<response>"` |
+| Reply to specific sender | `synapse reply "<response>" --to <sender_id>` |
+| List reply targets | `synapse reply --list-targets` |
 | Emergency stop | `synapse send <target> "STOP" --priority 5 --from <sender>` |
 | Stop agent | `synapse stop <profile\|id>` |
 | Kill agent | `synapse kill <target>` (with confirmation, use `-f` to force) |
@@ -88,8 +88,8 @@ For request-response patterns:
 # Sender: Wait for response (blocks until reply received)
 synapse send gemini "Analyze this data" --response --from synapse-claude-8100
 
-# Receiver: Reply to sender
-synapse reply "Analysis result: ..." --from synapse-gemini-8110
+# Receiver: Reply to sender (auto-routes via reply tracking)
+synapse reply "Analysis result: ..."
 ```
 
 The `--response` flag makes the sender wait. The receiver should reply using the `synapse reply` command.
@@ -130,19 +130,21 @@ If `[REPLY EXPECTED]` marker is present, you **MUST** reply using `synapse reply
 **Replying to messages:**
 
 ```bash
-# Use the reply command
-# --from: Use your agent ID (synapse-<type>-<port>)
-synapse reply "Here is my analysis..." --from <your_agent_id>
+# Use the reply command (auto-routes to last sender)
+synapse reply "Here is my analysis..."
 
 # When multiple senders are pending, inspect and choose target
-synapse reply --list-targets --from <your_agent_id>
-synapse reply "Here is my analysis..." --from <your_agent_id> --to <sender_id>
+synapse reply --list-targets
+synapse reply "Here is my analysis..." --to <sender_id>
+
+# In sandboxed environments (like Codex), specify your agent ID
+synapse reply "Here is my analysis..." --from <your_agent_id>
 ```
 
 **Example - Question received (MUST reply):**
 ```
 Received: A2A: [REPLY EXPECTED] What is the project structure?
-Reply:    synapse reply "The project has src/, tests/..." --from synapse-codex-8121
+Reply:    synapse reply "The project has src/, tests/..."
 ```
 
 **Example - Delegation received (no reply needed):**

--- a/.gemini/skills/synapse-a2a/references/api.md
+++ b/.gemini/skills/synapse-a2a/references/api.md
@@ -18,9 +18,9 @@ A2A: <message content>
 Use `synapse reply` to respond:
 
 ```bash
-synapse reply "<your response>" --from <your_agent_id>
-synapse reply --list-targets --from <your_agent_id>
-synapse reply "<your response>" --from <your_agent_id> --to <sender_id>
+synapse reply "<your response>"
+synapse reply --list-targets
+synapse reply "<your response>" --to <sender_id>
 ```
 
 The framework automatically handles routing - you don't need to know where the message came from.

--- a/.gemini/skills/synapse-a2a/references/commands.md
+++ b/.gemini/skills/synapse-a2a/references/commands.md
@@ -177,14 +177,17 @@ If `[REPLY EXPECTED]` marker is present, you **MUST** reply using `synapse reply
 **Replying to messages:**
 
 ```bash
-# Use the reply command (--from is required in sandboxed environments)
+# Use the reply command (auto-routes to last sender)
+synapse reply "<your reply>"
+
+# In sandboxed environments (like Codex), specify your agent ID
 synapse reply "<your reply>" --from <your_agent_id>
 ```
 
 **Example - Question received (MUST reply):**
 ```
 Received: A2A: [REPLY EXPECTED] What is the project structure?
-Reply:    synapse reply "The project has src/, tests/..." --from synapse-codex-8121
+Reply:    synapse reply "The project has src/, tests/..."
 ```
 
 **Example - Delegation received (no reply needed):**
@@ -259,19 +262,19 @@ synapse send codex "STOP" --priority 5 --from synapse-claude-8100
 Reply to the last received message:
 
 ```bash
-synapse reply "<message>" --from <your_agent_id>
+synapse reply "<message>"
 ```
 
-Synapse automatically knows who to reply to based on tracked senders. The `--from` flag is required in sandboxed environments (like Codex).
+Synapse automatically knows who to reply to based on tracked senders. The `--from` flag is only needed in sandboxed environments (like Codex).
 
 If multiple senders are pending, list and choose explicitly:
 
 ```bash
 # Show tracked sender IDs
-synapse reply --list-targets --from <your_agent_id>
+synapse reply --list-targets
 
 # Reply to a specific sender
-synapse reply "<message>" --from <your_agent_id> --to <sender_id>
+synapse reply "<message>" --to <sender_id>
 ```
 
 ### Broadcast Command
@@ -313,9 +316,9 @@ For advanced use cases or external scripts:
 ```bash
 python -m synapse.tools.a2a send --target <AGENT> [--priority <1-5>] "<MESSAGE>"
 python -m synapse.tools.a2a broadcast [--priority <1-5>] [--from <AGENT>] [--response | --no-response] "<MESSAGE>"  # Broadcast to cwd agents
-python -m synapse.tools.a2a reply "<MESSAGE>" --from <AGENT>  # Reply to last received message
-python -m synapse.tools.a2a reply --list-targets --from <AGENT>
-python -m synapse.tools.a2a reply "<MESSAGE>" --from <AGENT> --to <SENDER_ID>
+python -m synapse.tools.a2a reply "<MESSAGE>"  # Reply to last received message
+python -m synapse.tools.a2a reply --list-targets
+python -m synapse.tools.a2a reply "<MESSAGE>" --to <SENDER_ID>
 python -m synapse.tools.a2a list                # List agents
 python -m synapse.tools.a2a cleanup             # Cleanup stale entries
 ```

--- a/.gemini/skills/synapse-a2a/references/examples.md
+++ b/.gemini/skills/synapse-a2a/references/examples.md
@@ -102,7 +102,7 @@ Options:
 synapse send codex "Please review the changes in src/feature.py" --response --from synapse-claude-8100
 
 # Terminal 2 (Codex): Reply after reviewing
-synapse reply "LGTM. Two suggestions: ..." --from synapse-codex-8120
+synapse reply "LGTM. Two suggestions: ..."
 ```
 
 ### Parallel Research

--- a/.serena/memories/suggested_commands.md
+++ b/.serena/memories/suggested_commands.md
@@ -29,9 +29,9 @@ synapse list -w -i 1                      # Watch mode with 1s interval
 
 ## Agent Communication
 ```bash
-synapse send claude "message" --from <your-agent>                           # Send message to agent
-synapse send claude "message" --priority 3 --from codex                     # With priority
-synapse send codex "STOP" --priority 5 --from claude                        # Emergency interrupt
+synapse send claude "message"                                               # Send message to agent
+synapse send claude "message" --priority 3                                  # With priority
+synapse send codex "STOP" --priority 5                                      # Emergency interrupt
 ```
 
 ## Code Quality

--- a/.synapse/default.md
+++ b/.synapse/default.md
@@ -41,17 +41,17 @@ HOW TO REPLY:
 Use `synapse reply` to respond to the last received message:
 
 ```bash
-synapse reply "<your reply>" --from <agent_type>
+synapse reply "<your reply>"
 ```
 
 Synapse automatically tracks senders who expect a reply (messages with `[REPLY EXPECTED]` marker).
-- `--from`: Your agent type (e.g., `claude`, `codex`, `gemini`, `opencode`, `copilot`)
-- Required in sandboxed environments (like Codex)
+- `--from`: Your agent ID - only needed in sandboxed environments (like Codex)
+- `--to`: Reply to a specific sender when multiple are pending
 
 Example - Question received:
   A2A: What is the project structure?
 Reply with:
-  synapse reply "The project has src/, tests/, docs/ directories..." --from codex
+  synapse reply "The project has src/, tests/, docs/ directories..."
 
 Example - Delegation received:
   A2A: Run the tests and fix any failures
@@ -70,7 +70,7 @@ Target formats (in priority order):
 - Agent type: `gemini` (only when single instance exists)
 
 Parameters:
-- `--from, -f`: Your agent type (e.g., `claude`, `codex`) - **always include this**
+- `--from, -f`: Your agent ID (format: `synapse-<type>-<port>`) - auto-detected in most environments
 - `--priority, -p`: 1-4 normal, 5 = emergency interrupt (sends SIGINT first)
 - `--response`: Roundtrip mode - sender waits, receiver MUST reply
 - `--no-response`: Oneway mode - fire and forget, no reply expected
@@ -81,28 +81,28 @@ Analyze the message content and determine if a reply is expected.
 - If the message is purely informational with no reply needed → use `--no-response`
 - **If unsure, use `--response`** (safer default)
 
-IMPORTANT: Always use `--from` with your agent type (e.g., `claude`, `codex`) or agent ID (e.g., `synapse-claude-8100`). Do NOT use custom names for `--from`.
+IMPORTANT: `--from` requires agent ID format (`synapse-<type>-<port>`). Do NOT use agent types or custom names. In most environments, `--from` is auto-detected and can be omitted.
 
 Examples:
 ```bash
 # Question - needs reply (default behavior)
-synapse send gemini "What is the best practice for error handling?" --response --from claude
+synapse send gemini "What is the best practice for error handling?" --response
 
 # Status check - needs reply
-synapse send codex "What is your current status?" --response --from claude
+synapse send codex "What is your current status?" --response
 
 # Notification - explicitly no reply needed
-synapse send gemini "FYI: Build completed" --no-response --from claude
+synapse send gemini "FYI: Build completed" --no-response
 
 # Fire-and-forget task - no reply needed
-synapse send codex "Run the test suite and commit if all tests pass" --no-response --from claude
+synapse send codex "Run the test suite and commit if all tests pass" --no-response
 
 # Parallel tasks - no reply needed
-synapse send gemini "Research React best practices" --no-response --from claude
-synapse send codex "Refactor the auth module" --no-response --from claude
+synapse send gemini "Research React best practices" --no-response
+synapse send codex "Refactor the auth module" --no-response
 
 # Emergency interrupt
-synapse send codex "STOP" --priority 5 --from claude
+synapse send codex "STOP" --priority 5
 ```
 
 AVAILABLE AGENTS: claude, gemini, codex, opencode, copilot

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,8 +96,14 @@ synapse send codex "Process this" --from synapse-claude-8100 --no-response
 # Send to specific instance when multiple agents of same type exist
 synapse send claude-8100 "Hello" --from synapse-claude-8101
 
-# Reply to a received message
-synapse reply "Result here" --from synapse-gemini-8110
+# Reply to a received message (auto-routes to sender via reply tracking)
+synapse reply "Result here"
+
+# Reply with explicit sender ID (for sandboxed environments like Codex)
+synapse reply "Result here" --from synapse-codex-8121
+
+# Reply to a specific sender when multiple are pending
+synapse reply "Result here" --to synapse-claude-8100
 
 # Low-level A2A tool
 python -m synapse.tools.a2a list

--- a/README.es.md
+++ b/README.es.md
@@ -722,10 +722,10 @@ synapse send gemini "Analiza esto" --response --from synapse-claude-8100
 Responder al último mensaje recibido:
 
 ```bash
-synapse reply "<mensaje>" --from <tu_id_de_agente>
+synapse reply "<mensaje>"
 ```
 
-La bandera `--from` es requerida en entornos sandbox (como Codex).
+La bandera `--from` solo es necesaria en entornos sandbox (como Codex). Sin `--from`, Synapse detecta automaticamente el remitente.
 
 ### Herramienta A2A de Bajo Nivel
 
@@ -876,7 +876,7 @@ A2A: <contenido del mensaje>
 Synapse gestiona automáticamente el enrutamiento de respuestas. Los agentes simplemente usan `synapse reply`:
 
 ```bash
-synapse reply "Aquí esta mi respuesta" --from <tu_id_de_agente>
+synapse reply "Aquí esta mi respuesta"
 ```
 
 El framework rastrea internamente la información del remitente y enruta las respuestas automáticamente.

--- a/README.fr.md
+++ b/README.fr.md
@@ -722,10 +722,10 @@ synapse send gemini "Analyze this" --response --from synapse-claude-8100
 Répondre au dernier message reçu :
 
 ```bash
-synapse reply "<message>" --from <your_agent_id>
+synapse reply "<message>"
 ```
 
-Le drapeau `--from` est requis dans les environnements sandboxés (comme Codex).
+Le drapeau `--from` n'est necessaire que dans les environnements sandboxes (comme Codex). Sans `--from`, Synapse detecte automatiquement l'expediteur.
 
 ### Outil A2A Bas Niveau
 
@@ -876,7 +876,7 @@ A2A: <contenu du message>
 Synapse gère automatiquement le routage des réponses. Les agents utilisent simplement `synapse reply` :
 
 ```bash
-synapse reply "Here is my response" --from <your_agent_id>
+synapse reply "Here is my response"
 ```
 
 Le framework suit internement les informations de l'expéditeur et route automatiquement les réponses.

--- a/README.ja.md
+++ b/README.ja.md
@@ -680,10 +680,10 @@ synapse send gemini "これを分析して" --response --from synapse-claude-810
 受信したメッセージに返信：
 
 ```bash
-synapse reply "<message>" --from <your_agent_id>
+synapse reply "<message>"
 ```
 
-`--from` フラグはサンドボックス環境（Codex 等）で必須。
+`--from` フラグはサンドボックス環境（Codex 等）でのみ必要。通常はプロセス系統から自動検出されます。
 
 ### 低レベル A2A ツール
 
@@ -824,7 +824,7 @@ A2A: <message content>
 Synapse が返信ルーティングを自動管理します。エージェントは単に `synapse reply` を使用：
 
 ```bash
-synapse reply "返信メッセージ" --from <your_agent_id>
+synapse reply "返信メッセージ"
 ```
 
 フレームワークが送信者情報を内部的に追跡し、返信を自動ルーティングします。

--- a/README.ko.md
+++ b/README.ko.md
@@ -722,10 +722,10 @@ synapse send gemini "이것을 분석해줘" --response --from synapse-claude-81
 마지막으로 수신한 메시지에 응답합니다:
 
 ```bash
-synapse reply "<message>" --from <your_agent_id>
+synapse reply "<message>"
 ```
 
-`--from` 플래그는 샌드박스 환경(Codex 등)에서 필수입니다.
+`--from` 플래그는 샌드박스 환경(Codex 등)에서만 필요합니다. 통상적으로는 프로세스 계통에서 자동 감지됩니다.
 
 ### 저수준 A2A 도구
 
@@ -876,7 +876,7 @@ A2A: <message content>
 Synapse가 응답 라우팅을 자동으로 관리합니다. 에이전트는 단순히 `synapse reply`를 사용합니다:
 
 ```bash
-synapse reply "여기에 응답 내용" --from <your_agent_id>
+synapse reply "여기에 응답 내용"
 ```
 
 프레임워크가 발신자 정보를 내부적으로 추적하고 응답을 자동 라우팅합니다.

--- a/README.md
+++ b/README.md
@@ -722,10 +722,10 @@ synapse send gemini "Analyze this" --response --from synapse-claude-8100
 Reply to the last received message:
 
 ```bash
-synapse reply "<message>" --from <your_agent_id>
+synapse reply "<message>"
 ```
 
-The `--from` flag is required in sandboxed environments (like Codex).
+The `--from` flag is only needed in sandboxed environments (like Codex). Without `--from`, Synapse auto-detects the sender via process ancestry.
 
 ### Low-Level A2A Tool
 
@@ -876,7 +876,7 @@ A2A: <message content>
 Synapse automatically manages reply routing. Agents simply use `synapse reply`:
 
 ```bash
-synapse reply "Here is my response" --from <your_agent_id>
+synapse reply "Here is my response"
 ```
 
 The framework internally tracks sender information and routes replies automatically.

--- a/README.zh.md
+++ b/README.zh.md
@@ -722,10 +722,10 @@ synapse send gemini "Analyze this" --response --from synapse-claude-8100
 回复最近收到的消息：
 
 ```bash
-synapse reply "<message>" --from <your_agent_id>
+synapse reply "<message>"
 ```
 
-在沙盒环境（如 Codex）中 `--from` 标志是必需的。
+`--from` 标志仅在沙盒环境（如 Codex）中需要。通常情况下，Synapse 通过进程谱系自动检测发送者。
 
 ### 低级 A2A 工具
 
@@ -876,7 +876,7 @@ A2A: <消息内容>
 Synapse 自动管理回复路由。智能体只需使用 `synapse reply`：
 
 ```bash
-synapse reply "Here is my response" --from <your_agent_id>
+synapse reply "Here is my response"
 ```
 
 框架内部追踪发送者信息并自动路由回复。

--- a/docs/TASK_OWNERSHIP_DESIGN.md
+++ b/docs/TASK_OWNERSHIP_DESIGN.md
@@ -25,7 +25,7 @@ synapse send codex "分析して" --response --from synapse-claude-8100
 # [A2A:abc12345:synapse-claude-8100] 分析して
 
 # Codex で返信しようとすると失敗:
-synapse reply "結果です" --from synapse-codex-8120
+synapse reply "結果です"
 # Error: Task abc12345 not found  ← 常に失敗！
 ```
 
@@ -71,7 +71,7 @@ POST /tasks/send-priority to target
 3. Codex の PTY に表示:
    [A2A:abc12345:synapse-claude-8100] msg
     ↓
-4. synapse reply "reply" --from synapse-codex-8120
+4. synapse reply "reply"
     ↓
 5. POST /tasks/send to Claude's server
    → metadata に in_reply_to=abc12345 を含める（synapse reply が自動付与）

--- a/guides/a2a-communication.md
+++ b/guides/a2a-communication.md
@@ -126,10 +126,10 @@ A2A: <message>
 `synapse reply` コマンドを使用して返信します：
 
 ```bash
-synapse reply "<your reply>" --from <your_agent_id>
+synapse reply "<your reply>"
 ```
 
-**返信追跡:** Synapseは`[REPLY EXPECTED]`マーカー付きメッセージの送信者情報を自動的に追跡します。`synapse reply`を使うと、返信を期待しているエージェントに自動的に返信されます。
+**返信追跡:** Synapseは`[REPLY EXPECTED]`マーカー付きメッセージの送信者情報を自動的に追跡します。`synapse reply`を使うと、返信を期待しているエージェントに自動的に返信されます。`--from` オプションはサンドボックス環境でのみ必要です。
 
 ### 受信・返信の例
 
@@ -142,7 +142,7 @@ A2A: このコードをレビューして
 
 返信：
 ```bash
-synapse reply "レビュー結果です..." --from synapse-gemini-8110
+synapse reply "レビュー結果です..."
 ```
 
 **例2: タスク委任を受信した場合**

--- a/guides/references.md
+++ b/guides/references.md
@@ -281,13 +281,13 @@ synapse reply [message] [--from AGENT_ID] [--to SENDER_ID] [--list-targets]
 
 ```bash
 # 最新の送信者に返信（デフォルト LIFO）
-synapse reply "分析結果です..." --from synapse-codex-8121
+synapse reply "分析結果です..."
 
 # 特定の送信者に返信
-synapse reply "タスク完了しました" --from synapse-gemini-8110 --to synapse-claude-8100
+synapse reply "タスク完了しました" --to synapse-claude-8100
 
 # 返信可能なターゲットを確認
-synapse reply --list-targets --from synapse-codex-8121
+synapse reply --list-targets
 ```
 
 **動作**:

--- a/guides/usage.md
+++ b/guides/usage.md
@@ -435,7 +435,7 @@ synapse send codex "結果を教えて" --response --from synapse-claude-8100
 ### 2.5 メッセージへの返信
 
 ```bash
-synapse reply "返信メッセージ" --from <your_agent_id> [--to SENDER_ID] [--list-targets]
+synapse reply "返信メッセージ" [--from <your_agent_id>] [--to SENDER_ID] [--list-targets]
 ```
 
 Synapseは返信を期待する送信者情報を自動的に追跡し、適切な送信者に返信します。
@@ -452,13 +452,13 @@ Synapseは返信を期待する送信者情報を自動的に追跡し、適切�
 
 ```bash
 # 最新の送信者に返信（デフォルト）
-synapse reply "分析結果です..." --from synapse-codex-8121
+synapse reply "分析結果です..."
 
 # 特定の送信者に返信
-synapse reply "タスク完了しました" --from synapse-gemini-8110 --to synapse-claude-8100
+synapse reply "タスク完了しました" --to synapse-claude-8100
 
 # 返信可能なターゲットを確認
-synapse reply --list-targets --from synapse-codex-8121
+synapse reply --list-targets
 ```
 
 ---

--- a/plugins/synapse-a2a/skills/synapse-a2a/SKILL.md
+++ b/plugins/synapse-a2a/skills/synapse-a2a/SKILL.md
@@ -15,9 +15,9 @@ Inter-agent communication framework via Google A2A Protocol.
 | Send message | `synapse send <target> "<message>" --from <sender>` |
 | Broadcast to cwd agents | `synapse broadcast "<message>" --from <sender>` |
 | Wait for reply | `synapse send <target> "<message>" --response --from <sender>` |
-| Reply to last message | `synapse reply "<response>" --from <agent>` |
-| Reply to specific sender | `synapse reply "<response>" --from <agent> --to <sender_id>` |
-| List reply targets | `synapse reply --list-targets --from <agent>` |
+| Reply to last message | `synapse reply "<response>"` |
+| Reply to specific sender | `synapse reply "<response>" --to <sender_id>` |
+| List reply targets | `synapse reply --list-targets` |
 | Emergency stop | `synapse send <target> "STOP" --priority 5 --from <sender>` |
 | Stop agent | `synapse stop <profile\|id>` |
 | Kill agent | `synapse kill <target>` (with confirmation, use `-f` to force) |
@@ -88,8 +88,8 @@ For request-response patterns:
 # Sender: Wait for response (blocks until reply received)
 synapse send gemini "Analyze this data" --response --from synapse-claude-8100
 
-# Receiver: Reply to sender
-synapse reply "Analysis result: ..." --from synapse-gemini-8110
+# Receiver: Reply to sender (auto-routes via reply tracking)
+synapse reply "Analysis result: ..."
 ```
 
 The `--response` flag makes the sender wait. The receiver should reply using the `synapse reply` command.
@@ -130,19 +130,21 @@ If `[REPLY EXPECTED]` marker is present, you **MUST** reply using `synapse reply
 **Replying to messages:**
 
 ```bash
-# Use the reply command
-# --from: Use your agent ID (synapse-<type>-<port>)
-synapse reply "Here is my analysis..." --from <your_agent_id>
+# Use the reply command (auto-routes to last sender)
+synapse reply "Here is my analysis..."
 
 # When multiple senders are pending, inspect and choose target
-synapse reply --list-targets --from <your_agent_id>
-synapse reply "Here is my analysis..." --from <your_agent_id> --to <sender_id>
+synapse reply --list-targets
+synapse reply "Here is my analysis..." --to <sender_id>
+
+# In sandboxed environments (like Codex), specify your agent ID
+synapse reply "Here is my analysis..." --from <your_agent_id>
 ```
 
 **Example - Question received (MUST reply):**
 ```
 Received: A2A: [REPLY EXPECTED] What is the project structure?
-Reply:    synapse reply "The project has src/, tests/..." --from synapse-codex-8121
+Reply:    synapse reply "The project has src/, tests/..."
 ```
 
 **Example - Delegation received (no reply needed):**

--- a/plugins/synapse-a2a/skills/synapse-a2a/references/api.md
+++ b/plugins/synapse-a2a/skills/synapse-a2a/references/api.md
@@ -18,9 +18,9 @@ A2A: <message content>
 Use `synapse reply` to respond:
 
 ```bash
-synapse reply "<your response>" --from <your_agent_id>
-synapse reply --list-targets --from <your_agent_id>
-synapse reply "<your response>" --from <your_agent_id> --to <sender_id>
+synapse reply "<your response>"
+synapse reply --list-targets
+synapse reply "<your response>" --to <sender_id>
 ```
 
 The framework automatically handles routing - you don't need to know where the message came from.

--- a/plugins/synapse-a2a/skills/synapse-a2a/references/commands.md
+++ b/plugins/synapse-a2a/skills/synapse-a2a/references/commands.md
@@ -177,14 +177,17 @@ If `[REPLY EXPECTED]` marker is present, you **MUST** reply using `synapse reply
 **Replying to messages:**
 
 ```bash
-# Use the reply command (--from is required in sandboxed environments)
+# Use the reply command (auto-routes to last sender)
+synapse reply "<your reply>"
+
+# In sandboxed environments (like Codex), specify your agent ID
 synapse reply "<your reply>" --from <your_agent_id>
 ```
 
 **Example - Question received (MUST reply):**
 ```
 Received: A2A: [REPLY EXPECTED] What is the project structure?
-Reply:    synapse reply "The project has src/, tests/..." --from synapse-codex-8121
+Reply:    synapse reply "The project has src/, tests/..."
 ```
 
 **Example - Delegation received (no reply needed):**
@@ -259,19 +262,19 @@ synapse send codex "STOP" --priority 5 --from synapse-claude-8100
 Reply to the last received message:
 
 ```bash
-synapse reply "<message>" --from <your_agent_id>
+synapse reply "<message>"
 ```
 
-Synapse automatically knows who to reply to based on tracked senders. The `--from` flag is required in sandboxed environments (like Codex).
+Synapse automatically knows who to reply to based on tracked senders. The `--from` flag is only needed in sandboxed environments (like Codex).
 
 If multiple senders are pending, list and choose explicitly:
 
 ```bash
 # Show tracked sender IDs
-synapse reply --list-targets --from <your_agent_id>
+synapse reply --list-targets
 
 # Reply to a specific sender
-synapse reply "<message>" --from <your_agent_id> --to <sender_id>
+synapse reply "<message>" --to <sender_id>
 ```
 
 ### Broadcast Command
@@ -313,9 +316,9 @@ For advanced use cases or external scripts:
 ```bash
 python -m synapse.tools.a2a send --target <AGENT> [--priority <1-5>] "<MESSAGE>"
 python -m synapse.tools.a2a broadcast [--priority <1-5>] [--from <AGENT>] [--response | --no-response] "<MESSAGE>"  # Broadcast to cwd agents
-python -m synapse.tools.a2a reply "<MESSAGE>" --from <AGENT>  # Reply to last received message
-python -m synapse.tools.a2a reply --list-targets --from <AGENT>
-python -m synapse.tools.a2a reply "<MESSAGE>" --from <AGENT> --to <SENDER_ID>
+python -m synapse.tools.a2a reply "<MESSAGE>"  # Reply to last received message
+python -m synapse.tools.a2a reply --list-targets
+python -m synapse.tools.a2a reply "<MESSAGE>" --to <SENDER_ID>
 python -m synapse.tools.a2a list                # List agents
 python -m synapse.tools.a2a cleanup             # Cleanup stale entries
 ```

--- a/plugins/synapse-a2a/skills/synapse-a2a/references/examples.md
+++ b/plugins/synapse-a2a/skills/synapse-a2a/references/examples.md
@@ -102,7 +102,7 @@ Options:
 synapse send codex "Please review the changes in src/feature.py" --response --from synapse-claude-8100
 
 # Terminal 2 (Codex): Reply after reviewing
-synapse reply "LGTM. Two suggestions: ..." --from synapse-codex-8120
+synapse reply "LGTM. Two suggestions: ..."
 ```
 
 ### Parallel Research

--- a/synapse/templates/.synapse/default.md
+++ b/synapse/templates/.synapse/default.md
@@ -41,17 +41,17 @@ HOW TO REPLY:
 Use `synapse reply` to respond to the last received message:
 
 ```bash
-synapse reply "<your reply>" --from <agent_type>
+synapse reply "<your reply>"
 ```
 
 Synapse automatically tracks senders who expect a reply (messages with `[REPLY EXPECTED]` marker).
-- `--from`: Your agent type (e.g., `claude`, `codex`, `gemini`, `opencode`, `copilot`)
-- Required in sandboxed environments (like Codex)
+- `--from`: Your agent ID - only needed in sandboxed environments (like Codex)
+- `--to`: Reply to a specific sender when multiple are pending
 
 Example - Question received:
   A2A: What is the project structure?
 Reply with:
-  synapse reply "The project has src/, tests/, docs/ directories..." --from codex
+  synapse reply "The project has src/, tests/, docs/ directories..."
 
 Example - Delegation received:
   A2A: Run the tests and fix any failures
@@ -70,7 +70,7 @@ Target formats (in priority order):
 - Agent type: `gemini` (only when single instance exists)
 
 Parameters:
-- `--from, -f`: Your agent type (e.g., `claude`, `codex`) - **always include this**
+- `--from, -f`: Your agent ID (format: `synapse-<type>-<port>`) - auto-detected in most environments
 - `--priority, -p`: 1-4 normal, 5 = emergency interrupt (sends SIGINT first)
 - `--response`: Roundtrip mode - sender waits, receiver MUST reply
 - `--no-response`: Oneway mode - fire and forget, no reply expected
@@ -81,28 +81,28 @@ Analyze the message content and determine if a reply is expected.
 - If the message is purely informational with no reply needed → use `--no-response`
 - **If unsure, use `--response`** (safer default)
 
-IMPORTANT: Always use `--from` with your agent type (e.g., `claude`, `codex`) or agent ID (e.g., `synapse-claude-8100`). Do NOT use custom names for `--from`.
+IMPORTANT: `--from` requires agent ID format (`synapse-<type>-<port>`). Do NOT use agent types or custom names. In most environments, `--from` is auto-detected and can be omitted.
 
 Examples:
 ```bash
 # Question - needs reply (default behavior)
-synapse send gemini "What is the best practice for error handling?" --response --from claude
+synapse send gemini "What is the best practice for error handling?" --response
 
 # Status check - needs reply
-synapse send codex "What is your current status?" --response --from claude
+synapse send codex "What is your current status?" --response
 
 # Notification - explicitly no reply needed
-synapse send gemini "FYI: Build completed" --no-response --from claude
+synapse send gemini "FYI: Build completed" --no-response
 
 # Fire-and-forget task - no reply needed
-synapse send codex "Run the test suite and commit if all tests pass" --no-response --from claude
+synapse send codex "Run the test suite and commit if all tests pass" --no-response
 
 # Parallel tasks - no reply needed
-synapse send gemini "Research React best practices" --no-response --from claude
-synapse send codex "Refactor the auth module" --no-response --from claude
+synapse send gemini "Research React best practices" --no-response
+synapse send codex "Refactor the auth module" --no-response
 
 # Emergency interrupt
-synapse send codex "STOP" --priority 5 --from claude
+synapse send codex "STOP" --priority 5
 ```
 
 AVAILABLE AGENTS: claude, gemini, codex, opencode, copilot


### PR DESCRIPTION
## Summary
- `synapse reply` の `--from` フラグがドキュメント上で必須のように記載されていた問題を修正
- 実際には `--from` はサンドボックス環境（Codex等）でのみ必要。通常はPID系統マッチングで自動検出される
- `synapse/templates/.synapse/default.md` で `--from claude` のようにagent typeを指定していた箇所を修正（`--from` は `synapse-<type>-<port>` 形式のagent IDのみ受け付ける）

## Test plan
- [x] 全テスト通過確認（1484 passed, 24 skipped）
- [ ] `synapse reply "test"` が `--from` なしで動作することを確認
- [ ] `synapse reply "test" --from claude` がエラーになることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)