### PR TITLE
chore: bump version to 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2026-02-11
+
+### Added
+
+- **zellij support for `synapse team start`**
+  - Added pane creation command generation for zellij environments
+  - Added `--layout` mapping for zellij (`horizontal` -> right, `vertical` -> down, `split` -> balanced alternating splits)
+
+### Changed
+
+- Updated team-start terminal support messaging to include zellij
+
+### Documentation
+
+- Added/updated `synapse team start` references in `guides/usage.md` and `guides/references.md`
+
+### Tests
+
+- Added zellij coverage in `tests/test_auto_spawn.py` for pane generation, layout direction handling, and team-start execution path
+
 ## [0.4.0] - 2026-02-10
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synapse-a2a"
-version = "0.4.0"
+version = "0.4.1"
 description = "Agent-to-Agent communication protocol for CLI agents"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -111,4 +111,3 @@ ignore_errors = true
 [[tool.mypy.overrides]]
 module = ["grpc", "grpc.*"]
 ignore_missing_imports = true
-


### PR DESCRIPTION
## Summary
- bump package version from 0.4.0 to 0.4.1 in pyproject.toml
- add 0.4.1 release notes for zellij team-start support in CHANGELOG.md

## Testing
- pytest tests/test_auto_spawn.py -v

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * Zelijターミナルマルチプレクサーのサポートを追加しました。
  * Zeiljのパネル作成コマンド生成とレイアウトマッピング機能を実装しました。

* **Documentation**
  * チームスタートガイドドキュメントを追加しました。

* **Tests**
  * Zeiljのパネル生成、レイアウト処理、チームスタート実行パスのテストカバレッジを拡充しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->