### PR TITLE
fix(ci): pin setuptools<81 for homebrew-pypi-poet compatibility

### DIFF
--- a/.github/workflows/update-installers.yml
+++ b/.github/workflows/update-installers.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           python3 -m venv /tmp/poet-env
-          /tmp/poet-env/bin/pip install "synapse-a2a==${VERSION}" homebrew-pypi-poet
+          /tmp/poet-env/bin/pip install "setuptools<81" "synapse-a2a==${VERSION}" homebrew-pypi-poet
           /tmp/poet-env/bin/poet -f synapse-a2a > /tmp/poet-output.rb
           python scripts/patch_homebrew_formula.py "${VERSION}" /tmp/poet-output.rb
 


### PR DESCRIPTION
## Summary

- Pin `setuptools<81` in the poet venv to fix `ModuleNotFoundError: No module named 'pkg_resources'`

## Root Cause

`homebrew-pypi-poet` imports `pkg_resources` which was removed from `setuptools` 82.0+. The CI installed `setuptools` 82.0 automatically, causing the poet command to fail.

## Test plan

- [x] Verified `homebrew-pypi-poet` works with `setuptools<81` locally
- [ ] Re-run `update-installers.yml` after merge (re-tag or workflow_dispatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **その他**
  * インストーラー生成ワークフローの環境設定を最適化し、ツール依存性の互換性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->