### PR TITLE
fix(ci): checkout main branch for tag-triggered workflow

### DIFF
--- a/.github/workflows/update-installers.yml
+++ b/.github/workflows/update-installers.yml
@@ -13,6 +13,8 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: main
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -62,6 +64,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:
+          base: main
           branch: chore/update-installers-v${{ steps.version.outputs.version }}
           commit-message: "chore: update Homebrew formula and Scoop manifest for v${{ steps.version.outputs.version }}"
           title: "chore: update Homebrew formula and Scoop manifest for v${{ steps.version.outputs.version }}"


### PR DESCRIPTION
## Summary

- Add `ref: main` to `actions/checkout` so tag-triggered workflows check out the main branch instead of detached HEAD
- Add `base: main` to `peter-evans/create-pull-request` to explicitly specify the PR target

## Root Cause

When a `v*` tag triggers the workflow, `actions/checkout` defaults to the tag commit (detached HEAD). `peter-evans/create-pull-request` requires a branch ref, not a commit SHA, to determine the base for the PR.

## Test plan

- [ ] Re-tag v0.5.0 after merge to verify the full workflow succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

このプルリクエストに含まれるのは、内部ワークフロー処理に関する技術的な改善です。エンドユーザー向けの新機能、バグ修正、またはその他の機能変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->