### PR TITLE
chore: bump version to 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2026-02-14
+
+### Added
+
+- **Vim-style navigation**: `hjkl` key bindings for `synapse list` interactive selection (Enter=jump, K=kill confirmation)
+- **SSL/TLS options**: `--ssl-cert` and `--ssl-key` for `synapse start` command
+- **File safety wait options**: `--wait-interval` for `synapse file-safety lock`
+
+### Changed
+
+- **Installation docs**: Unified macOS/Linux/WSL2 install section across all 6 language READMEs with pipx as recommended method
+- **Homebrew formula**: Added Rust build dependency, `preserve_rpath`, and resource marker insertion
+- **Config TUI**: Added `--no-rich` flag to use legacy questionary-based interface
+- **History cleanup**: Added `--dry-run` and `--no-vacuum` options
+
+### Fixed
+
+- **Homebrew formula**: Switched to pip+venv pattern for reliable installation (#216)
+
+### Documentation
+
+- Synced plugin skill references (commands.md, file-safety.md) across all 3 scopes
+- Updated footer hints in `synapse list` for new key bindings
+
 ## [0.5.0] - 2026-02-13
 
 ### Added

--- a/plugins/synapse-a2a/.claude-plugin/plugin.json
+++ b/plugins/synapse-a2a/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synapse-a2a",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Complete plugin for Synapse A2A multi-agent framework including inter-agent communication, file safety, and history management",
   "author": {
     "name": "s-hiraoku",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synapse-a2a"
-version = "0.5.0"
+version = "0.5.1"
 description = "Agent-to-Agent communication protocol for CLI agents"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- Bump version `0.5.0` → `0.5.1` in pyproject.toml and plugin.json
- Add CHANGELOG.md entry for v0.5.1

### Changes in v0.5.1

#### Added
- **Vim-style navigation**: `hjkl` key bindings for `synapse list` interactive selection
- **SSL/TLS options**: `--ssl-cert` and `--ssl-key` for `synapse start`
- **File safety wait options**: `--wait-interval` for `synapse file-safety lock`

#### Changed
- Unified macOS/Linux/WSL2 install section across all 6 language READMEs
- Homebrew formula: Added Rust build dependency, `preserve_rpath`
- Config TUI: Added `--no-rich` flag
- History cleanup: Added `--dry-run` and `--no-vacuum` options

#### Fixed
- Homebrew formula: Switched to pip+venv pattern (#216)

#### Documentation
- Synced plugin skill references across all 3 scopes

## Test plan

- [ ] `pytest` passes
- [ ] Version string correct in pyproject.toml, plugin.json
- [ ] CHANGELOG.md entry formatted correctly
- [ ] After merge, create tag `v0.5.1` and push

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート v0.5.1

* **新機能**
  * SSL設定オプションを追加
  * セーフティ待機オプションを追加

* **改善**
  * UI/ナビゲーション機能を強化

* **ドキュメント**
  * インストール手順とREADMEを更新

<!-- end of auto-generated comment: release notes by coderabbit.ai -->