### PR TITLE
fix: spawn/start argparse.REMAINDER & NUL byte bugs

### DIFF
--- a/synapse/commands/start.py
+++ b/synapse/commands/start.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import subprocess
 import sys
@@ -31,10 +32,7 @@ class StartCommand:
             print("Error: Both --ssl-cert and --ssl-key must be provided together")
             sys.exit(1)
 
-        # Extract tool args (filter out -- if present at start)
         tool_args = getattr(args, "tool_args", [])
-        if tool_args and tool_args[0] == "--":
-            tool_args = tool_args[1:]
 
         # Auto-select port if not specified
         if port is None:
@@ -61,10 +59,10 @@ class StartCommand:
         if ssl_cert and ssl_key:
             cmd.extend(["--ssl-cert", ssl_cert, "--ssl-key", ssl_key])
 
-        # Set up environment with tool args (null-separated for safe parsing)
+        # Set up environment with tool args (JSON-encoded for safe parsing)
         env = os.environ.copy()
         if tool_args:
-            env["SYNAPSE_TOOL_ARGS"] = "\x00".join(tool_args)
+            env["SYNAPSE_TOOL_ARGS"] = json.dumps(tool_args)
 
         protocol = "https" if ssl_cert else "http"
         mode = "foreground" if foreground else "background"

--- a/synapse/server.py
+++ b/synapse/server.py
@@ -1,4 +1,5 @@
 import argparse
+import json
 import os
 import sys
 import threading
@@ -55,9 +56,9 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     agent_port = int(os.environ.get("SYNAPSE_PORT", str(agent_port)))
     agent_profile = profile_name
 
-    # Get tool args from environment (null-separated)
+    # Get tool args from environment (JSON-encoded)
     tool_args_str = os.environ.get("SYNAPSE_TOOL_ARGS", "")
-    tool_args = tool_args_str.split("\x00") if tool_args_str else []
+    tool_args = json.loads(tool_args_str) if tool_args_str else []
 
     profile = load_profile(profile_name)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -123,13 +123,14 @@ class TestCmdStart:
         assert "Both --ssl-cert and --ssl-key must be provided" in captured.out
 
     def test_tool_args_filter_separator(self, mock_args):
-        """Should filter -- from tool_args start."""
+        """Tool args should be pre-extracted (no leading --)."""
         mock_args.profile = "claude"
         mock_args.port = 8100
         mock_args.foreground = True
         mock_args.ssl_cert = None
         mock_args.ssl_key = None
-        mock_args.tool_args = ["--", "--model", "opus"]
+        # tool_args are pre-extracted by main() — no leading '--'
+        mock_args.tool_args = ["--model", "opus"]
 
         with (
             patch("synapse.commands.start.subprocess.run") as mock_run,
@@ -140,7 +141,7 @@ class TestCmdStart:
         # Check that tool args were passed via environment
         call_args = mock_run.call_args
         env = call_args.kwargs.get("env", {})
-        assert env.get("SYNAPSE_TOOL_ARGS") == "--model\x00opus"
+        assert env.get("SYNAPSE_TOOL_ARGS") == '["--model", "opus"]'
 
     def test_auto_port_selection(self, mock_args, temp_registry):
         """Should auto-select port when not specified."""

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -140,20 +140,24 @@ class TestStartCommandToolArgs:
         assert tool_args == ["--model", "opus"]
 
     def test_environment_variable_encoding(self):
-        """Tool args should be null-separated for environment variable."""
+        """Tool args should be JSON-encoded for environment variable."""
+        import json
+
         tool_args = ["--model", "opus", "--foo", "bar"]
-        encoded = "\x00".join(tool_args)
-        decoded = encoded.split("\x00")
+        encoded = json.dumps(tool_args)
+        decoded = json.loads(encoded)
 
         assert decoded == tool_args
 
     def test_environment_variable_empty(self):
         """Empty tool args should result in empty string."""
+        import json
+
         tool_args: list[str] = []
-        encoded = "\x00".join(tool_args) if tool_args else ""
+        encoded = json.dumps(tool_args) if tool_args else ""
 
         # Decode
-        decoded = encoded.split("\x00") if encoded else []
+        decoded = json.loads(encoded) if encoded else []
 
         assert decoded == []
 

--- a/tests/test_cli_refactor_spec.py
+++ b/tests/test_cli_refactor_spec.py
@@ -71,7 +71,7 @@ class TestCliRefactorSpec:
 
             # Environment should contain tool args
             env = mock_run.call_args.kwargs["env"]
-            assert env["SYNAPSE_TOOL_ARGS"] == "--verbose"
+            assert env["SYNAPSE_TOOL_ARGS"] == '["--verbose"]'
 
     def test_start_command_ssl_logic(self, mock_args):
         """

--- a/tests/test_server_lifespan.py
+++ b/tests/test_server_lifespan.py
@@ -22,7 +22,7 @@ class TestServerLifespan:
             env = {
                 "SYNAPSE_PROFILE": "dummy",
                 "SYNAPSE_PORT": "8199",
-                "SYNAPSE_TOOL_ARGS": "arg1\x00arg2",
+                "SYNAPSE_TOOL_ARGS": '["arg1", "arg2"]',
             }
             return env.get(key, default)
 


### PR DESCRIPTION
## Summary

- **Bug 1**: `synapse spawn copilot --name X --role Y` — `argparse.REMAINDER` swallowed all tokens after the `profile` positional arg, making `--name`, `--role`, `--terminal`, `--skill-set` always `None`. Fix: pre-extract tool_args from `sys.argv` via `_extract_tool_args()` before `parse_args()`.
- **Bug 2**: `SYNAPSE_TOOL_ARGS` env var used `"\x00"` (NUL byte) as separator, but POSIX env vars reject NUL bytes, causing `ValueError: embedded null byte` in `subprocess.Popen`. Fix: use `json.dumps()`/`json.loads()`.

## Test plan

- [x] New tests: `test_spawn_name_role_not_eaten_by_tool_args`, `test_spawn_tool_args_after_separator`
- [x] Updated NUL byte assertions to JSON in `test_cli.py`, `test_server_lifespan.py`, `test_cli_refactor_spec.py`, `test_cli_args.py`
- [x] Live verification: `synapse spawn claude --name BugFixTest --role "spawn-bug-verifier"` → name/role correctly in registry
- [x] Live verification: `synapse spawn codex --name BugTest --role "bug-fix-verifier"` → send → response → kill flow
- [x] Full test suite: 1867 passed, 24 skipped
- [x] ruff / mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * CLI コマンド（start、spawn、team start）のツール引数の処理を改善しました。ツール引数の処理がより効率的になり、コマンドラインでの引数指定がシンプルになりました。
  * ツール引数のエンコーディング形式を更新し、環境変数での受け渡しをより信頼性の高い方式に統一しました。

* **Tests**
  * ツール引数の処理に対応するためテストケースを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->