### PR TITLE
fix: synapse spawn fails on iTerm2 (AppleScript targets tab instead of session)

### DIFF
--- a/synapse/terminal_jump.py
+++ b/synapse/terminal_jump.py
@@ -602,7 +602,7 @@ def create_iterm2_panes(
         lines = [
             'tell application "iTerm2"',
             "  tell current window",
-            "    tell current tab",
+            "    tell current session of current tab",
         ]
         for agent_spec in agents:
             full_cmd = _build_agent_command(


### PR DESCRIPTION
## Summary

- Fix `synapse spawn` failing on iTerm2 with error `-1708` ("split vertically with default profile" not recognized)
- Root cause: `all_new=True` path used `tell current tab` but `split vertically` is a **session** method, not a tab method
- The `all_new=False` (handoff) path was already correct

## Changes

- `synapse/terminal_jump.py`: `tell current tab` → `tell current session of current tab` (1 line)
- `tests/test_auto_spawn.py`: Added `TestITerm2AppleScriptTarget` class with 3 tests

## Test plan

- [x] 3 new tests pass (`TestITerm2AppleScriptTarget`)
- [x] All 128 spawn-related tests pass
- [x] Manual verification on iTerm2 3.6.6 — spawn succeeds, new pane opens

Closes #248

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * iTerm2でのウィンドウペーン作成時のセッション対象指定を改善し、実行精度を向上させました。

* **テスト**
  * ウィンドウペーン作成における複数シナリオをカバーする統合テストスイートを新たに追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->