### PR TITLE
chore: release v0.6.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.7] - 2026-02-23
+
+### Documentation
+
+- **Worktree/tool_args accuracy**: Corrected documentation that incorrectly claimed Synapse filters `--worktree` by agent type — Synapse forwards all `tool_args` to every agent; only Claude Code acts on `--worktree`
+- **Safe worktree examples**: Added Claude-only alternative (`synapse team start claude -- --worktree`) alongside multi-agent examples to prevent errors on non-Claude CLIs
+- **Worktree cleanup guidance**: Added branch merge/delete instructions after `synapse kill` in examples, headless cleanup caveat for `synapse spawn`
+- **Gitignore recommendations**: Added `.claude/worktrees/` to recommended `.gitignore` entries; added `.venv/` to not-copied file examples for consistency
+- **Cross-references**: Added link from team start worktree example to "Worktree の注意事項" section in `guides/usage.md`
+- **Skill copy sync**: Synchronized `.agents/` and `.gemini/` skill copies with canonical `plugins/` source
+
 ## [0.6.6] - 2026-02-20
 
 ### Documentation

--- a/plugins/synapse-a2a/.claude-plugin/plugin.json
+++ b/plugins/synapse-a2a/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synapse-a2a",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "Complete plugin for Synapse A2A multi-agent framework including inter-agent communication, file safety, and history management",
   "author": {
     "name": "s-hiraoku",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synapse-a2a"
-version = "0.6.6"
+version = "0.6.7"
 description = "Agent-to-Agent communication protocol for CLI agents"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- Bump version 0.6.6 → 0.6.7
- Add changelog entry for worktree/tool_args documentation accuracy fixes

## Changelog

### Documentation

- **Worktree/tool_args accuracy**: Corrected docs that incorrectly claimed Synapse filters `--worktree` by agent type
- **Safe worktree examples**: Added Claude-only alternative to prevent errors on non-Claude CLIs
- **Worktree cleanup guidance**: Added branch merge/delete instructions and headless caveat
- **Gitignore recommendations**: Added `.claude/worktrees/` and `.venv/` entries
- **Cross-references**: Added link from team start example to caveats section
- **Skill copy sync**: Synchronized `.agents/` and `.gemini/` copies

## Test plan

- [ ] Version is 0.6.7 in pyproject.toml and plugin.json
- [ ] CHANGELOG.md has [0.6.7] entry
- [ ] Tag v0.6.7 already pushed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * ワークツリーの使用方法と安全性に関するドキュメントを改善しました。
  * ワークツリークリーンアップの手順を明確にしました。
  * 設定例とベストプラクティスを更新しました。

* **チョア**
  * バージョンを 0.6.6 から 0.6.7 にアップデートしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->