### PR TITLE
chore: release v0.6.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.8] - 2026-02-23
+
+### Added
+
+- Add working_dir mismatch warning to `synapse send` and `synapse interrupt` with `--force` bypass (#266)
+- Add WORKING_DIR column to `synapse list` non-TTY text output
+- Add learning mode with independent prompt improvement and translation flags (#268)
+
 ## [0.6.7] - 2026-02-23
 
 ### Added

--- a/plugins/synapse-a2a/.claude-plugin/plugin.json
+++ b/plugins/synapse-a2a/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synapse-a2a",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "Complete plugin for Synapse A2A multi-agent framework including inter-agent communication, file safety, and history management",
   "author": {
     "name": "s-hiraoku",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synapse-a2a"
-version = "0.6.7"
+version = "0.6.8"
 description = "Agent-to-Agent communication protocol for CLI agents"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- Bump version 0.6.7 → 0.6.8
- Update `pyproject.toml`, `plugin.json`, and `CHANGELOG.md`

### Changelog

#### Added
- Add working_dir mismatch warning to `synapse send` and `synapse interrupt` with `--force` bypass (#266)
- Add WORKING_DIR column to `synapse list` non-TTY text output
- Add learning mode with independent prompt improvement and translation flags (#268)

## Test plan

- [x] Version strings updated in pyproject.toml and plugin.json
- [x] CHANGELOG.md entry matches merged PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)