### PR TITLE
fix: use event-driven workflow chain for PyPI Trusted Publishing

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -11,9 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write    # Tag creation + Release creation
-    outputs:
-      tag: ${{ steps.version.outputs.tag }}
-      released: ${{ steps.create_release.outcome == 'success' }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -69,22 +66,5 @@ jobs:
             --title "${TAG}" \
             --notes-file /tmp/release-notes.md
 
-  publish:
-    needs: release
-    if: needs.release.outputs.released == 'true'
-    uses: ./.github/workflows/publish.yml
-    with:
-      tag: ${{ needs.release.outputs.tag }}
-    permissions:
-      contents: read
-      id-token: write
-
-  update-installers:
-    needs: [release, publish]
-    if: needs.release.outputs.released == 'true'
-    uses: ./.github/workflows/update-installers.yml
-    with:
-      tag: ${{ needs.release.outputs.tag }}
-    permissions:
-      contents: write
-      pull-requests: write
+  # publish.yml triggers on 'release: published' event (created above)
+  # update-installers.yml triggers on 'workflow_run: Publish to PyPI completed'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,12 +1,8 @@
 name: Publish to PyPI
 
 on:
-  workflow_call:
-    inputs:
-      tag:
-        description: 'Tag name (e.g. v1.2.3)'
-        required: true
-        type: string
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       tag:
@@ -23,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.tag || github.ref }}
+          ref: ${{ inputs.tag || github.event.release.tag_name || github.ref }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/update-installers.yml
+++ b/.github/workflows/update-installers.yml
@@ -1,16 +1,14 @@
 name: Update Installers
 
 on:
-  workflow_call:
-    inputs:
-      tag:
-        description: 'Tag name (e.g. v1.2.3)'
-        required: true
-        type: string
+  workflow_run:
+    workflows: ["Publish to PyPI"]
+    types: [completed]
 
 jobs:
   update-installers:
     runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
     permissions:
       contents: write
       pull-requests: write
@@ -24,10 +22,16 @@ jobs:
         with:
           python-version: '3.14'
 
-      - name: Extract version from tag
+      - name: Extract version from release tag
         id: version
         run: |
-          TAG="${{ inputs.tag || github.ref_name }}"
+          # workflow_run event carries the head_branch (tag name for release-triggered runs)
+          TAG="${{ github.event.workflow_run.head_branch }}"
+          if [ -z "$TAG" ]; then
+            echo "ERROR: Could not determine tag from workflow_run event"
+            exit 1
+          fi
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
 
       - name: Wait for PyPI availability


### PR DESCRIPTION
## Summary
- Replace reusable workflow calls (`workflow_call`) with event-driven triggers to fix OIDC certificate mismatch with PyPI Trusted Publishing
- `publish.yml`: trigger on `release: published` event instead of being called from `auto-release.yml`
- `update-installers.yml`: trigger on `workflow_run: "Publish to PyPI" completed` event
- `auto-release.yml`: remove `publish` and `update-installers` jobs (now event-driven)

## Root Cause
When `auto-release.yml` called `publish.yml` as a reusable workflow, the OIDC certificate contained `auto-release.yml` as the Build Config URI. PyPI Trusted Publishing expected `publish.yml`, causing a 400 Bad Request:

```
Certificate's Build Config URI (auto-release.yml@refs/heads/main)
does not match expected Trusted Publisher (publish.yml @ s-hiraoku/synapse-a2a)
```

## New Flow
```
pyproject.toml push → auto-release.yml (tag + release creation)
                          ↓ release: published event
                      publish.yml (PyPI publish)
                          ↓ workflow_run: completed event
                      update-installers.yml (Homebrew/Scoop update)
```

## Test plan
- [ ] Merge to main with a version bump and verify auto-release → publish → update-installers chain works
- [ ] Verify manual `workflow_dispatch` on `publish.yml` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * リリースパイプラインの自動化を改善しました。ワークフロー間の結合度を低下させ、より堅牢なリリース、パブリッシュ、インストーラー更新プロセスを実現しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->