### PR TITLE
fix: automate full release chain without manual intervention

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write    # Tag creation + Release creation
+      actions: write     # Trigger publish.yml via workflow_dispatch
     steps:
       - uses: actions/checkout@v6
         with:
@@ -66,5 +67,17 @@ jobs:
             --title "${TAG}" \
             --notes-file /tmp/release-notes.md
 
-  # publish.yml triggers on 'release: published' event (created above)
-  # update-installers.yml triggers on 'workflow_run: Publish to PyPI completed'
+      - name: Trigger Publish to PyPI
+        if: steps.create_release.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          echo "Triggering Publish to PyPI for ${TAG}..."
+          gh workflow run "Publish to PyPI" -f tag="${TAG}"
+          echo "Publish workflow dispatched for ${TAG}"
+
+  # Chain: auto-release → (workflow_dispatch) → publish.yml → (workflow_run) → update-installers.yml
+  # Note: GITHUB_TOKEN supports workflow_dispatch since Sep 2022.
+  # The 'release: published' trigger on publish.yml is kept as a fallback
+  # for manual releases created with a PAT.

--- a/.github/workflows/update-installers.yml
+++ b/.github/workflows/update-installers.yml
@@ -48,16 +48,18 @@ jobs:
       - name: Wait for PyPI availability
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          echo "Waiting for synapse-a2a==${VERSION} on PyPI..."
+          echo "Waiting for synapse-a2a==${VERSION} to be installable from PyPI..."
           for i in $(seq 1 30); do
-            if curl -sf "https://pypi.org/pypi/synapse-a2a/${VERSION}/json" > /dev/null 2>&1; then
-              echo "Found on PyPI after ${i} attempts"
+            # Use pip install --dry-run to verify actual installability
+            # (curl on JSON API succeeds before package files are distributed)
+            if pip install --dry-run "synapse-a2a==${VERSION}" > /dev/null 2>&1; then
+              echo "Package installable from PyPI after ${i} attempts"
               exit 0
             fi
-            echo "Attempt ${i}/30 - not yet available, waiting 30s..."
+            echo "Attempt ${i}/30 - not yet installable, waiting 30s..."
             sleep 30
           done
-          echo "ERROR: synapse-a2a==${VERSION} not found on PyPI after 15 minutes"
+          echo "ERROR: synapse-a2a==${VERSION} not installable from PyPI after 15 minutes"
           exit 1
 
       - name: Generate Homebrew formula with poet

--- a/docs/release.md
+++ b/docs/release.md
@@ -6,9 +6,9 @@ This document describes how to release a new version of synapse-a2a to PyPI.
 
 Releases are fully automated via GitHub Actions. When a `pyproject.toml` version change is merged to `main`, the following chain runs automatically:
 
-1. **`auto-release.yml`** — Detects version bump, creates git tag (`v*`) and GitHub Release with changelog
-2. **`publish.yml`** — Called by `auto-release.yml` via `workflow_call`, builds and publishes to PyPI (Trusted Publisher)
-3. **`update-installers.yml`** — Called by `auto-release.yml` via `workflow_call`, creates PR to update Homebrew formula and Scoop manifest
+1. **`auto-release.yml`** — Detects version bump, creates git tag (`v*`) and GitHub Release with changelog, then triggers `publish.yml` via `workflow_dispatch`
+2. **`publish.yml`** — Triggered by `auto-release.yml` (or `release: published` as fallback), builds and publishes to PyPI (Trusted Publisher)
+3. **`update-installers.yml`** — Triggered by `workflow_run` when `publish.yml` completes, creates PR to update Homebrew formula and Scoop manifest
 
 ## Release Steps
 
@@ -99,6 +99,7 @@ gh release create vX.Y.Z --title "vX.Y.Z" --notes-file /tmp/release-notes.md
 rm /tmp/release-notes.md
 ```
 
-> **Note**: `publish.yml` and `update-installers.yml` do not have `push.tags` triggers.
-> After manually creating the tag and release, trigger `publish.yml` via
-> `workflow_dispatch` in the Actions tab to publish to PyPI.
+> **Note**: The full chain is automated — `auto-release.yml` triggers `publish.yml` via
+> `workflow_dispatch` (using `GITHUB_TOKEN` with `actions: write`), and `update-installers.yml`
+> runs automatically after `publish.yml` completes. If you create a manual release, trigger
+> `publish.yml` via `workflow_dispatch` in the Actions tab.


### PR DESCRIPTION
## Summary
- **auto-release.yml**: Add `workflow_dispatch` trigger to directly invoke `publish.yml` after creating a release (bypasses `GITHUB_TOKEN` limitation where `release: published` events don't fire)
- **update-installers.yml**: Replace `curl` JSON API check with `pip install --dry-run` to verify actual package installability (fixes PyPI propagation delay race condition)
- **docs/release.md**: Update flow description to reflect the new automation chain

## Background

Two issues prevented fully automated releases:

1. **GITHUB_TOKEN limitation**: Releases created with `GITHUB_TOKEN` don't fire `release: published` events, so `publish.yml` never triggered automatically. Previous attempt used `workflow_call` but failed due to PyPI Trusted Publisher OIDC certificate mismatch. Solution: use `workflow_dispatch` (supported by `GITHUB_TOKEN` since Sep 2022), which runs `publish.yml` independently so OIDC matches.

2. **PyPI propagation delay**: The "Wait for PyPI" step used `curl` to check the JSON API, which succeeds immediately. But `pip install` (used by Homebrew poet) would fail because package files weren't distributed yet. Solution: use `pip install --dry-run` which tests actual installability.

## New release chain
```
auto-release.yml → (workflow_dispatch) → publish.yml → (workflow_run) → update-installers.yml
```

## Test plan
- [ ] Verify next release triggers full chain automatically (no manual `gh workflow run` needed)
- [ ] Verify `update-installers.yml` waits for actual pip installability before running poet

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Release workflow の自動化を改善し、ワークフロー連鎖を明確化。パッケージの installability 検証プロセスを更新しました。

* **Documentation**
  * Release automation workflow の説明を更新し、新しいワークフロートリガーメカニズムを反映させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->