### PR TITLE
fix: resolve shared memory bugs (#286-#291)

### DIFF
--- a/synapse/a2a_compat.py
+++ b/synapse/a2a_compat.py
@@ -1152,7 +1152,11 @@ def create_a2a_router(
         if not result:
             raise HTTPException(status_code=503, detail="Shared memory is disabled")
         if request.notify:
-            _memory_broadcast_notify_api(request.key)
+            threading.Thread(
+                target=_memory_broadcast_notify_api,
+                args=(request.key,),
+                daemon=True,
+            ).start()
         return dict(result)
 
     @router.get("/memory/search")

--- a/synapse/cli.py
+++ b/synapse/cli.py
@@ -2397,8 +2397,8 @@ def _memory_broadcast_notify(key: str) -> None:
                         print(f"  Notified: {name}")
                 except Exception as e:
                     print(f"  Failed: {name}: {e}")
-    except Exception:
-        pass
+    except Exception as e:
+        print(f"  Broadcast failed: {e}", file=sys.stderr)
 
 
 def cmd_memory_list(args: argparse.Namespace) -> None:

--- a/tests/test_cli_memory.py
+++ b/tests/test_cli_memory.py
@@ -363,7 +363,8 @@ class TestMemoryBroadcastNotify:
             patch("synapse.cli.A2AClient") as mock_client_cls,
         ):
             mock_client = MagicMock()
-            mock_client.send_to_local.return_value = None
+            mock_task = MagicMock()
+            mock_client.send_to_local.return_value = mock_task
             mock_client_cls.return_value = mock_client
 
             from synapse.cli import _memory_broadcast_notify
@@ -431,4 +432,5 @@ class TestMemoryBroadcastNotify:
             _memory_broadcast_notify("test-key")
 
         out = capsys.readouterr().out
-        assert "failed" in out.lower() or "Notified" not in out
+        assert "Failed:" in out
+        assert "connection refused" in out

--- a/tests/test_memory_api.py
+++ b/tests/test_memory_api.py
@@ -193,7 +193,12 @@ class TestMemoryDeleteEndpoint:
 
 
 class TestMemorySaveNotify:
-    """Tests for POST /memory/save with notify=True (#286)."""
+    """Tests for POST /memory/save with notify=True (#286).
+
+    Notification runs in a background daemon thread. We mock
+    _memory_broadcast_notify_api so the thread executes the mock
+    instantly (no real network calls).
+    """
 
     def test_save_with_notify_calls_broadcast(self, app_client):
         """POST /memory/save with notify=True should trigger broadcast."""
@@ -310,7 +315,7 @@ class TestMemoryListValidation:
     """Tests for limit/tags validation on GET /memory/list (#288)."""
 
     def test_limit_zero_clamped_to_1(self, app_client):
-        """limit=0 should be clamped to 1."""
+        """limit=0 should be clamped to 1, returning exactly 1 result."""
         app_client.post(
             "/memory/save",
             json={"key": "k1", "content": "v1", "author": "claude"},
@@ -321,26 +326,34 @@ class TestMemoryListValidation:
         )
         response = app_client.get("/memory/list?limit=0")
         assert response.status_code == 200
-        assert len(response.json()["memories"]) >= 1
+        assert len(response.json()["memories"]) == 1
 
     def test_negative_limit_clamped_to_1(self, app_client):
-        """limit=-5 should be clamped to 1."""
+        """limit=-5 should be clamped to 1, returning exactly 1 result."""
         app_client.post(
             "/memory/save",
             json={"key": "k1", "content": "v1", "author": "claude"},
+        )
+        app_client.post(
+            "/memory/save",
+            json={"key": "k2", "content": "v2", "author": "claude"},
         )
         response = app_client.get("/memory/list?limit=-5")
         assert response.status_code == 200
-        assert len(response.json()["memories"]) >= 1
+        assert len(response.json()["memories"]) == 1
 
-    def test_huge_limit_clamped_to_100(self, app_client):
+    def test_huge_limit_clamped_to_100(self, app_client, tmp_path):
         """limit=999999 should be clamped to 100."""
-        app_client.post(
-            "/memory/save",
-            json={"key": "k1", "content": "v1", "author": "claude"},
-        )
-        response = app_client.get("/memory/list?limit=999999")
+        from synapse.shared_memory import SharedMemory
+
+        mem = SharedMemory(db_path=str(tmp_path / "memory.db"))
+        for i in range(101):
+            mem.save(key=f"clamp-k{i}", content=f"v{i}", author="claude")
+        # Patch from_env to use the pre-populated instance
+        with patch("synapse.shared_memory.SharedMemory.from_env", return_value=mem):
+            response = app_client.get("/memory/list?limit=999999")
         assert response.status_code == 200
+        assert len(response.json()["memories"]) == 100
 
     def test_tags_with_whitespace_trimmed(self, app_client):
         """tags with whitespace should be trimmed."""


### PR DESCRIPTION
## Summary

- **#286**: Wire `MemorySaveRequest.notify` to broadcast via `_memory_broadcast_notify_api`
- **#287**: Add `_require_shared_memory()` helper for consistent 503 across all `/memory/*` endpoints
- **#288**: Clamp limit to 1..100 and trim/filter whitespace in tags on `/memory/list`
- **#289**: Fix CLI tags split to trim whitespace and filter empty strings
- **#290**: Add `"memory"` to `subcommand_parsers` to prevent crash on bare `synapse memory`
- **#291**: Implement actual `A2AClient.send_to_local()` calls in `_memory_broadcast_notify`
- Cross-review fix: check `send_to_local()` return value for None (silent failure path)

## Multi-Agent Collaboration

パンダ先輩 (Claude) が API 側 (`a2a_compat.py`) を、伏黒恵 (Codex) が CLI 側 (`cli.py`) を分担。クロスレビューで `send_to_local()` の None 返却未チェックを相互発見・修正。

## Follow-up Issues

連携で得た知見を改善 issue として登録:
- #297: エージェントの実作業状態を表示する
- #298: `send_to_local()` の戻り値 None を一貫してチェックする
- #299: 分担時のファイルロック自動検出・警告

## Test plan

- [x] `pytest tests/test_memory_api.py -v` (25 passed)
- [x] `pytest tests/test_cli_memory.py -v` (18 passed)
- [x] Full test suite (2118 passed, 15 pre-existing failures in test_settings.py)
- [x] Pre-commit hooks (ruff, ruff format, mypy) all passed

Closes #286, #287, #288, #289, #290, #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * メモリ保存時のブロードキャスト通知機能を追加

* **バグ修正**
  * メモリタグの解析を改善（空白スペース処理、カンマ区切り対応）
  * 共有メモリ無効時に適切な エラー（503）を返すように修正
  * メモリリスト機能の入力値検証を強化（limit値の上限設定）
  * メモリ関連エンドポイントのレスポンス形式を統一

* **テスト**
  * CLIメモリコマンドの包括的なテストカバレッジを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->