### PR TITLE
feat: add completion callback for --no-response task tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -846,7 +846,7 @@ synapse send claude "Review this" --force
 synapse send claude "Hello" --from $SYNAPSE_AGENT_ID
 ```
 
-**Default behavior:** With `a2a.flow=auto` (default), `synapse send` waits for a response unless `--no-response` is specified.
+**Default behavior:** With `a2a.flow=auto` (default), `synapse send` waits for a response unless `--no-response` is specified. In `--no-response` mode, sender-side history is updated on receiver completion via best-effort callback (`sent` -> `completed`/`failed`/`canceled`).
 
 **Sender auto-detection:** `--from` is optional. Synapse auto-detects the sender using `SYNAPSE_AGENT_ID` (set at startup), then falls back to PID matching (process ancestry). Use explicit `--from` only in sandboxed environments (like Codex) where env vars may not propagate.
 

--- a/guides/references.md
+++ b/guides/references.md
@@ -1734,7 +1734,7 @@ curl -X POST http://localhost:8100/external/discover \
 | `@agent message` | メッセージ送信（デフォルトで応答待ち） |
 | `@agent-port message` | 特定ポートのエージェントに送信 |
 
-> **Note**: レスポンスを待たずに送信したい場合は、`synapse send` コマンドの `--no-response` オプションを使用してください。
+> **Note**: レスポンスを待たずに送信したい場合は、`synapse send --no-response` を使用してください。`--no-response` でも受信側完了時に sender 側 history のステータスは best-effort で更新されます（通知不達時は `sent` のまま）。
 
 ### 3.3 例
 
@@ -1752,7 +1752,7 @@ curl -X POST http://localhost:8100/external/discover \
 @claude '複雑な メッセージ'
 ```
 
-> **Note**: レスポンスを待たない送信には `synapse send --no-response` を使用してください:
+> **Note**: レスポンスを待たない送信には `synapse send --no-response` を使用してください（完了時の history 更新は best-effort）:
 > ```bash
 > synapse send codex "バックグラウンドで処理して" --no-response
 > ```

--- a/guides/usage.md
+++ b/guides/usage.md
@@ -1200,7 +1200,7 @@ Ink ベースの TUI（Claude Code など）では、以下の問題が発生す
 
 ### 7.3 レスポンス待ちのタイムアウト
 
-`@Agent` パターンはデフォルトでレスポンスを待ちます（最大 60 秒）。レスポンスを待たずに送信のみ行いたい場合は、`synapse send` コマンドの `--no-response` オプションを使用してください。長時間の処理を依頼する場合は、別途 `/status` API でポーリングしてください。
+`@Agent` パターンはデフォルトでレスポンスを待ちます（最大 60 秒）。レスポンスを待たずに送信のみ行いたい場合は、`synapse send --no-response` を使用してください。`--no-response` でも受信側の完了時に sender 側 history の該当タスク（`sent`）を `completed` / `failed` / `canceled` へ best-effort で更新します（通知不達時は `sent` のまま）。
 
 ---
 

--- a/synapse/a2a_compat.py
+++ b/synapse/a2a_compat.py
@@ -358,6 +358,14 @@ class SendMessageResponse(BaseModel):
     task: Task
 
 
+class HistoryUpdateRequest(BaseModel):
+    """Request to update sender-side history status."""
+
+    task_id: str
+    status: Literal["completed", "failed", "canceled"]
+    output_summary: str | None = None
+
+
 class CreateTaskRequest(BaseModel):
     """Request to create a task (without sending to PTY)."""
 
@@ -591,6 +599,77 @@ async def _send_response_to_sender(
         return False
     except Exception as e:
         logger.error(f"Unexpected error sending response to {sender_endpoint}: {e}")
+        return False
+
+
+async def _notify_sender_completion(
+    task: Task,
+    sender_endpoint: str,
+    sender_uds_path: str | None = None,
+    sender_task_id: str | None = None,
+    status: str | None = None,
+) -> bool:
+    """Notify sender to update history for no-response tasks.
+
+    Uses UDS first (when available), then falls back to HTTP.
+    Best effort: failures are logged and return False.
+    """
+    callback_task_id = sender_task_id or task.id
+    callback_status = status or task.status
+
+    output_parts = [_format_artifact_text(a) for a in task.artifacts]
+    output_summary = "\n".join(output_parts) if output_parts else None
+
+    payload = {
+        "task_id": callback_task_id,
+        "status": callback_status,
+        "output_summary": output_summary,
+    }
+
+    if sender_uds_path and os.path.exists(sender_uds_path):
+        try:
+            transport = httpx.AsyncHTTPTransport(uds=sender_uds_path)
+            async with httpx.AsyncClient(transport=transport, timeout=10.0) as client:
+                response = await client.post(
+                    "http://localhost/history/update", json=payload
+                )
+                response.raise_for_status()
+                logger.info(
+                    "Completion callback sent via UDS for task %s", callback_task_id[:8]
+                )
+                return True
+        except httpx.HTTPError as e:
+            logger.warning(
+                "UDS completion callback failed for %s: %s", callback_task_id, e
+            )
+
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            url = f"{sender_endpoint}/history/update"
+            response = await client.post(url, json=payload)
+            response.raise_for_status()
+            logger.info(
+                "Completion callback sent to %s for task %s",
+                sender_endpoint,
+                callback_task_id[:8],
+            )
+            return True
+    except httpx.HTTPStatusError as e:
+        logger.warning(
+            "Failed to send completion callback to %s: HTTP %s",
+            sender_endpoint,
+            e.response.status_code,
+        )
+        return False
+    except httpx.RequestError as e:
+        logger.warning(
+            "Failed to send completion callback to %s: %s", sender_endpoint, e
+        )
+        return False
+    except Exception as e:
+        logger.error(
+            "Unexpected completion callback error to %s: %s", sender_endpoint, e
+        )
         return False
 
 
@@ -1004,6 +1083,22 @@ def create_a2a_router(
         task_store.update_status(task.id, "working")
         return CreateTaskResponse(task=task)
 
+    @router.post("/history/update")
+    async def update_history(  # noqa: B008
+        request: HistoryUpdateRequest, _: Any = Depends(require_auth)
+    ) -> dict[str, Any]:
+        """Update an existing history observation by task ID."""
+        updated = history_manager.update_observation_status(
+            task_id=request.task_id,
+            status=request.status,
+            output_text=request.output_summary,
+            metadata_update={"completion_callback": True},
+        )
+        if not updated:
+            raise HTTPException(status_code=404, detail="Task not found in history")
+
+        return {"updated": True, "task_id": request.task_id, "status": request.status}
+
     # --------------------------------------------------------
     # Task Board Endpoints (B1: Shared Task Board)
     # NOTE: These must be defined BEFORE /tasks/{task_id} to avoid route conflicts
@@ -1361,16 +1456,28 @@ def create_a2a_router(
                     response_expected = metadata.get("response_expected", False)
                     sender_info = _extract_sender_info(metadata)
 
-                    if response_expected and sender_info.sender_endpoint:
-                        # Send response asynchronously
-                        asyncio.create_task(
-                            _send_response_to_sender(
-                                updated_task,
-                                sender_info.sender_endpoint,
-                                agent_id or "unknown",
-                                sender_task_id=sender_info.sender_task_id,
+                    if sender_info.sender_endpoint:
+                        if response_expected:
+                            # Send response asynchronously
+                            asyncio.create_task(
+                                _send_response_to_sender(
+                                    updated_task,
+                                    sender_info.sender_endpoint,
+                                    agent_id or "unknown",
+                                    sender_task_id=sender_info.sender_task_id,
+                                )
                             )
-                        )
+                        else:
+                            # Best-effort callback for no-response flow
+                            asyncio.create_task(
+                                _notify_sender_completion(
+                                    task=updated_task,
+                                    sender_endpoint=sender_info.sender_endpoint,
+                                    sender_uds_path=sender_info.sender_uds_path,
+                                    sender_task_id=sender_info.sender_task_id,
+                                    status=updated_task.status,
+                                )
+                            )
 
             updated_task = task_store.get(task_id)
             if updated_task:

--- a/synapse/history.py
+++ b/synapse/history.py
@@ -204,6 +204,99 @@ class HistoryManager:
                 print(f"Warning: Failed to retrieve observation: {e}", file=sys.stderr)
                 return None
 
+    def update_observation_status(
+        self,
+        task_id: str,
+        status: str,
+        output_text: str | None = None,
+        metadata_update: dict[str, Any] | None = None,
+    ) -> bool:
+        """Update status of an existing observation.
+
+        Args:
+            task_id: Task identifier to update
+            status: New task status
+            output_text: Optional replacement output text
+            metadata_update: Optional metadata keys to merge into existing metadata
+
+        Returns:
+            True if an existing observation was updated, otherwise False
+        """
+        if not self.enabled:
+            return False
+
+        with self._lock:
+            try:
+                with _db_connection(self.db_path, row_factory=True) as conn:
+                    cursor = conn.cursor()
+
+                    metadata_json: str | None = None
+                    if metadata_update is not None:
+                        cursor.execute(
+                            "SELECT metadata FROM observations WHERE task_id = ?",
+                            (task_id,),
+                        )
+                        row = cursor.fetchone()
+                        if row is None:
+                            return False
+
+                        current_metadata: dict[str, Any] = {}
+                        raw_metadata = row["metadata"]
+                        if raw_metadata:
+                            with contextlib.suppress(TypeError, ValueError):
+                                parsed = json.loads(raw_metadata)
+                                if isinstance(parsed, dict):
+                                    current_metadata = parsed
+
+                        current_metadata.update(metadata_update)
+                        with contextlib.suppress(TypeError, ValueError):
+                            metadata_json = json.dumps(current_metadata)
+
+                    if output_text is None and metadata_json is None:
+                        cursor.execute(
+                            """
+                            UPDATE observations
+                            SET status = ?, timestamp = CURRENT_TIMESTAMP
+                            WHERE task_id = ?
+                            """,
+                            (status, task_id),
+                        )
+                    elif output_text is None:
+                        cursor.execute(
+                            """
+                            UPDATE observations
+                            SET status = ?, metadata = ?, timestamp = CURRENT_TIMESTAMP
+                            WHERE task_id = ?
+                            """,
+                            (status, metadata_json, task_id),
+                        )
+                    elif metadata_json is None:
+                        cursor.execute(
+                            """
+                            UPDATE observations
+                            SET status = ?, output = ?, timestamp = CURRENT_TIMESTAMP
+                            WHERE task_id = ?
+                            """,
+                            (status, output_text, task_id),
+                        )
+                    else:
+                        cursor.execute(
+                            """
+                            UPDATE observations
+                            SET status = ?, output = ?, metadata = ?, timestamp = CURRENT_TIMESTAMP
+                            WHERE task_id = ?
+                            """,
+                            (status, output_text, metadata_json, task_id),
+                        )
+
+                    return cursor.rowcount > 0
+            except sqlite3.Error as e:
+                print(
+                    f"Warning: Failed to update observation status: {e}",
+                    file=sys.stderr,
+                )
+                return False
+
     def list_observations(
         self,
         limit: int = 50,

--- a/tests/test_completion_callback.py
+++ b/tests/test_completion_callback.py
@@ -1,0 +1,229 @@
+"""Tests for completion callback feature (Issue #285)."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from synapse.a2a_compat import Message, Task, TextPart, create_a2a_router
+from synapse.history import HistoryManager
+
+
+class TestHistoryUpdate:
+    """Tests for HistoryManager.update_observation_status()."""
+
+    @pytest.fixture
+    def history_manager(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "history.db"
+            yield HistoryManager(db_path=str(db_path))
+
+    def test_update_observation_status_updates_status_and_output(self, history_manager):
+        history_manager.save_observation(
+            task_id="task-1",
+            agent_name="claude",
+            session_id="a2a-send",
+            input_text="hello",
+            output_text="Task sent",
+            status="sent",
+            metadata={"direction": "sent", "priority": 1},
+        )
+
+        updated = history_manager.update_observation_status(
+            task_id="task-1",
+            status="completed",
+            output_text="Task completed",
+            metadata_update={"completion_callback": True},
+        )
+
+        assert updated is True
+        observation = history_manager.get_observation("task-1")
+        assert observation is not None
+        assert observation["status"] == "completed"
+        assert observation["output"] == "Task completed"
+        assert observation["metadata"]["direction"] == "sent"
+        assert observation["metadata"]["completion_callback"] is True
+
+    def test_update_observation_status_returns_false_for_missing_task(
+        self, history_manager
+    ):
+        updated = history_manager.update_observation_status(
+            task_id="missing-task",
+            status="completed",
+        )
+
+        assert updated is False
+
+
+class TestHistoryUpdateEndpoint:
+    """Tests for POST /history/update endpoint."""
+
+    @pytest.fixture
+    def app(self):
+        controller = MagicMock()
+        controller.status = "IDLE"
+        controller.get_context.return_value = "done"
+
+        app = FastAPI()
+        router = create_a2a_router(controller, "test-agent", 8121, "\n")
+        app.include_router(router)
+        return app
+
+    @pytest.fixture
+    def client(self, app):
+        return TestClient(app)
+
+    def test_history_update_endpoint_returns_200(self, client):
+        with patch("synapse.a2a_compat.history_manager") as mock_history:
+            mock_history.enabled = True
+            mock_history.update_observation_status.return_value = True
+
+            response = client.post(
+                "/history/update",
+                json={
+                    "task_id": "task-123",
+                    "status": "completed",
+                    "output_summary": "done",
+                },
+            )
+
+        assert response.status_code == 200
+
+    def test_history_update_endpoint_returns_404_for_missing_task(self, client):
+        with patch("synapse.a2a_compat.history_manager") as mock_history:
+            mock_history.enabled = True
+            mock_history.update_observation_status.return_value = False
+
+            response = client.post(
+                "/history/update",
+                json={
+                    "task_id": "missing",
+                    "status": "completed",
+                    "output_summary": "done",
+                },
+            )
+
+        assert response.status_code == 404
+
+
+class TestCompletionNotification:
+    """Tests for --no-response completion callback behavior."""
+
+    @pytest.fixture
+    def app(self):
+        controller = MagicMock()
+        controller.status = "IDLE"
+        controller.get_context.return_value = "task done successfully"
+
+        app = FastAPI()
+        router = create_a2a_router(controller, "test-agent", 8121, "\n")
+        app.include_router(router)
+        return app
+
+    @pytest.fixture
+    def client(self, app):
+        return TestClient(app)
+
+    def test_no_response_task_triggers_completion_notification(self, client):
+        send_response = client.post(
+            "/tasks/send",
+            json={
+                "message": {"role": "user", "parts": [{"type": "text", "text": "run"}]},
+                "metadata": {
+                    "response_expected": False,
+                    "sender": {
+                        "sender_id": "synapse-claude-8100",
+                        "sender_endpoint": "http://localhost:8100",
+                        "sender_uds_path": "/tmp/sender.sock",
+                    },
+                },
+            },
+        )
+        assert send_response.status_code == 200
+        task_id = send_response.json()["task"]["id"]
+
+        with (
+            patch(
+                "synapse.a2a_compat._notify_sender_completion",
+                new_callable=AsyncMock,
+                create=True,
+            ) as mock_notify,
+            patch(
+                "synapse.a2a_compat._send_response_to_sender", new_callable=AsyncMock
+            ) as mock_send,
+        ):
+            get_response = client.get(f"/tasks/{task_id}")
+
+        assert get_response.status_code == 200
+        mock_notify.assert_called_once()
+        mock_send.assert_not_called()
+
+    def test_response_expected_flow_still_sends_response(self, client):
+        send_response = client.post(
+            "/tasks/send",
+            json={
+                "message": {"role": "user", "parts": [{"type": "text", "text": "run"}]},
+                "metadata": {
+                    "response_expected": True,
+                    "sender": {
+                        "sender_id": "synapse-claude-8100",
+                        "sender_endpoint": "http://localhost:8100",
+                        "sender_task_id": "sender-task-1",
+                    },
+                },
+            },
+        )
+        assert send_response.status_code == 200
+        task_id = send_response.json()["task"]["id"]
+
+        with (
+            patch(
+                "synapse.a2a_compat._send_response_to_sender", new_callable=AsyncMock
+            ) as mock_send,
+            patch(
+                "synapse.a2a_compat._notify_sender_completion",
+                new_callable=AsyncMock,
+                create=True,
+            ) as mock_notify,
+        ):
+            get_response = client.get(f"/tasks/{task_id}")
+
+        assert get_response.status_code == 200
+        mock_send.assert_called_once()
+        mock_notify.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_notify_sender_completion_is_best_effort(self):
+        import synapse.a2a_compat as compat
+
+        assert hasattr(compat, "_notify_sender_completion")
+
+        task = Task(
+            id="task-abc",
+            status="completed",
+            message=Message(parts=[TextPart(text="in")]),
+            created_at="",
+            updated_at="",
+        )
+
+        with patch("synapse.a2a_compat.httpx.AsyncClient") as mock_client:
+            mock_post = AsyncMock()
+            import httpx
+
+            mock_post.side_effect = httpx.RequestError("boom")
+            mock_client.return_value.__aenter__.return_value.post = mock_post
+
+            result = await compat._notify_sender_completion(
+                task=task,
+                sender_endpoint="http://localhost:8100",
+                sender_uds_path=None,
+                sender_task_id="task-abc",
+                status="completed",
+            )
+
+        assert result is False


### PR DESCRIPTION
## Summary
- add `HistoryManager.update_observation_status()` to update existing history rows (status/output/metadata merge)
- add `POST /history/update` endpoint for sender-side history status updates
- add `_notify_sender_completion()` and invoke it when receiver completes `response_expected=false` tasks
- keep existing `response_expected=true` reply flow unchanged
- document best-effort callback behavior for `--no-response` in README and guides
- add end-to-end tests in `tests/test_completion_callback.py`

## Related
- Closes #285

## Test
- `pytest tests/test_completion_callback.py -v`
- `pytest tests/test_history.py -q`
- `pytest tests/test_a2a_compat_extended.py -q`

## Notes
- full `pytest -q` currently reports failures in `tests/test_settings.py` due unrelated learning-mode instruction output expectations
