### PR TITLE
docs: replace character names and add skill install guide

### DIFF
--- a/.agents/skills/synapse-a2a/references/commands.md
+++ b/.agents/skills/synapse-a2a/references/commands.md
@@ -67,6 +67,10 @@ synapse claude --skill-set dev-set
 # Delegate/manager mode (no file editing, delegates via synapse send)
 synapse claude --delegate-mode --name manager --role "task manager"
 
+# Worktree isolation in current terminal (Synapse-native, all agent types)
+synapse claude --worktree my-feature              # Start in worktree in current terminal
+synapse gemini --worktree review --name Reviewer --role "code reviewer"
+
 # Skip interactive name/role setup
 synapse claude --no-setup
 

--- a/.synapse/agents/golden-phoenix.agent
+++ b/.synapse/agents/golden-phoenix.agent
@@ -1,5 +1,5 @@
 id=golden-phoenix
-name=張飛
+name=Dave
 profile=gemini
-role=@./roles/golden-phoenix.md
+role=documentation specialist
 skill_set=documentation

--- a/.synapse/agents/swift-tiger.agent
+++ b/.synapse/agents/swift-tiger.agent
@@ -1,5 +1,5 @@
 id=swift-tiger
-name=趙雲
+name=Eve
 profile=codex
-role=実装テスト担当
+role=implementation and testing
 skill_set=developer

--- a/.synapse/agents/wise-strategist.agent
+++ b/.synapse/agents/wise-strategist.agent
@@ -1,5 +1,5 @@
 id=wise-strategist
-name=孔明
+name=Frank
 profile=claude
-role=軍師
+role=task manager
 skill_set=manager

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.5] - 2026-03-02
+
+### Changed
+
+- Replace copyrighted character names with generic English names (Alice, Bob, Charlie, Dave, Eve, Frank) across docs, tests, and agent definitions
+- Replace Japanese role descriptions with English equivalents in `.agent` files and role templates
+
+### Documentation
+
+- Add skill installation guide (`npx skills add s-hiraoku/synapse-a2a`) to Getting Started, Quick Start, and Skills pages
+- Add `synapse-reinst` to Built-in Skills section with admonition
+- Remove `doc-organizer` from core skill install tables (not essential for A2A communication)
+- Add prerequisites box to Quick Start page
+- Add worktree profile shortcut examples to plugin skill commands reference
+
 ## [0.8.4] - 2026-03-02
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -401,9 +401,6 @@ plugins/synapse-a2a/skills/synapse-a2a/   # Skills source of truth (plugin scope
 plugins/synapse-a2a/skills/synapse-manager/  # Multi-agent management skill
 └── SKILL.md                                 # Delegation, monitoring, verification, feedback, review
 
-plugins/synapse-a2a/skills/doc-organizer/    # Documentation organization skill
-└── SKILL.md                                 # Audit, restructure, deduplication, terminology, staleness
-
 .claude/hooks/                             # Claude Code PostToolUse hooks
 ├── check-ci-trigger.sh                    # PostToolUse: triggers CI poll + PR status poll on git push / gh pr create
 ├── poll-ci.sh                             # Background: polls GitHub Actions CI status
@@ -418,15 +415,13 @@ plugins/synapse-a2a/skills/doc-organizer/    # Documentation organization skill
 # Sync targets (auto-synced from plugins/ via sync-plugin-skills):
 .claude/skills/synapse-a2a/      # Claude Code
 .claude/skills/synapse-manager/  # Claude Code
-.claude/skills/doc-organizer/    # Claude Code
 .agents/skills/synapse-a2a/      # Codex / OpenCode / Copilot / Gemini
 .agents/skills/synapse-manager/  # Codex / OpenCode / Copilot / Gemini
-.agents/skills/doc-organizer/    # Codex / OpenCode / Copilot / Gemini
 ```
 
 ### Skill Update Rules
 
-**`plugins/synapse-a2a/skills/` がスキルのソースオブトゥルース（`synapse-a2a`, `synapse-manager`, `doc-organizer` 等）。** スキルを更新する際は必ず `plugins/` 側を編集し、`sync-plugin-skills` で `.claude/`, `.agents/` に同期すること。個別のエージェントディレクトリを直接編集してはならない。
+**`plugins/synapse-a2a/skills/` がスキルのソースオブトゥルース（`synapse-a2a`, `synapse-manager` 等）。** スキルを更新する際は必ず `plugins/` 側を編集し、`sync-plugin-skills` で `.claude/`, `.agents/` に同期すること。個別のエージェントディレクトリを直接編集してはならない。
 
 ### CI Automation: Hooks and Skills
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -353,7 +353,6 @@ npx skills add s-hiraoku/synapse-a2a
 |--------|------|
 | **synapse-a2a** | エージェント間通信の総合ガイド：`synapse send`、優先度、A2A プロトコル、履歴、File Safety、設定 |
 | **synapse-manager** | 5ステップのマルチエージェント管理（委譲、監視、検証、フィードバック、レビュー） |
-| **doc-organizer** | ドキュメントの監査、再構成、重複排除、同期管理 |
 
 ### スキル管理
 

--- a/README.md
+++ b/README.md
@@ -359,7 +359,6 @@ npx skills add s-hiraoku/synapse-a2a
 |-------|-------------|
 | **synapse-a2a** | Comprehensive guide for inter-agent communication: `synapse send`, priority, A2A protocol, history, File Safety, settings |
 | **synapse-manager** | Multi-agent management workflow: task delegation, progress monitoring, quality verification with regression testing, feedback delivery, and cross-review orchestration |
-| **doc-organizer** | Documentation audit, restructure, deduplication, terminology normalization, navigation improvement, and staleness detection |
 | **check-ci** | Check CI status, merge conflict state, and CodeRabbit review status for the current PR (`/check-ci`, `/check-ci --fix`) |
 | **fix-ci** | Auto-diagnose and fix CI failures: lint, format, type-check, test errors |
 | **fix-conflict** | Auto-resolve merge conflicts: fetch base, test merge, analyze both sides, resolve, verify, push |
@@ -419,7 +418,7 @@ Synapse ships with 6 built-in skill sets (defined in `.synapse/skill_sets.json`)
 | **reviewer** | Code review and security — structured reviews, security audits, code simplification | synapse-a2a, code-review, security-audit, code-simplifier |
 | **frontend** | Frontend development — React/Next.js performance, component composition, design systems, accessibility | synapse-a2a, react-performance, frontend-design, react-composition, web-accessibility |
 | **manager** | Multi-agent management — task delegation, progress monitoring, quality verification, cross-review orchestration, re-instruction | synapse-a2a, synapse-manager, task-planner, agent-memory, code-review, synapse-reinst |
-| **documentation** | Documentation expert — audit, restructure, synchronize, and maintain project documentation | synapse-a2a, project-docs, doc-organizer, api-design, agent-memory |
+| **documentation** | Documentation expert — audit, restructure, synchronize, and maintain project documentation | synapse-a2a, project-docs, api-design, agent-memory |
 
 ### Directory Structure
 
@@ -430,8 +429,7 @@ plugins/
     ├── README.md
     └── skills/
         ├── synapse-a2a/SKILL.md
-        ├── synapse-manager/SKILL.md
-        └── doc-organizer/SKILL.md
+        └── synapse-manager/SKILL.md
 ```
 
 See [plugins/synapse-a2a/README.md](plugins/synapse-a2a/README.md) for details.

--- a/guides/references.md
+++ b/guides/references.md
@@ -310,7 +310,7 @@ synapse team start <agent_spec1> <agent_spec2> ... [--layout split|horizontal|ve
 ```bash
 synapse team start claude gemini codex              # claude=ここ、他=新ペイン
 synapse team start silent-snake gemini              # saved_agent_id で起動
-synapse team start 狗巻棘 gemini:伏黒恵              # saved_agent_name で起動
+synapse team start Alice gemini:Bob              # saved_agent_name で起動
 synapse team start claude gemini --layout horizontal
 synapse team start claude gemini --all-new          # 全員新ペイン
 synapse team start claude gemini -- --dangerously-skip-permissions  # ツール引数を渡す
@@ -376,13 +376,13 @@ synapse agents delete <id-or-name>
 | `add` | 定義を作成/更新（`id` は エージェントID形式: `silent-snake`） |
 | `delete` | ID または名前で削除 |
 
-**例（狗巻棘）**:
+**例（Alice）**:
 
 ```bash
-synapse agents add silent-snake --name 狗巻棘 --profile codex --role @./roles/reviewer.md --skill-set architect --scope project
+synapse agents add silent-snake --name Alice --profile codex --role @./roles/reviewer.md --skill-set architect --scope project
 synapse agents list
-synapse agents show 狗巻棘
-synapse spawn 狗巻棘
+synapse agents show Alice
+synapse spawn Alice
 ```
 
 **終了時保存プロンプト**:

--- a/guides/usage.md
+++ b/guides/usage.md
@@ -566,7 +566,7 @@ synapse kill Tester -f
 
 ```bash
 synapse spawn claude                          # 新しいペインで Claude を起動
-synapse spawn 狗巻棘                           # 保存済みエージェント名で起動
+synapse spawn Alice                           # 保存済みエージェント名で起動
 synapse spawn silent-snake                    # 保存済みエージェントIDで起動
 synapse spawn gemini --port 8115              # ポートを指定して起動
 synapse spawn claude --name Tester --role "テスト担当"  # 名前とロールを指定
@@ -962,7 +962,7 @@ Synapse には 6 つの組み込みスキルセットが用意されています
 | **reviewer** | コードレビューとセキュリティ — 構造化レビュー、セキュリティ監査、コード簡素化 | synapse-a2a, code-review, security-audit, code-simplifier |
 | **frontend** | フロントエンド開発 — React/Next.js パフォーマンス、コンポーネント構成、デザインシステム、アクセシビリティ | synapse-a2a, react-performance, frontend-design, react-composition, web-accessibility |
 | **manager** | マルチエージェント管理 — タスク委任、進捗監視、品質検証、クロスレビュー、再インストラクション | synapse-a2a, synapse-manager, task-planner, agent-memory, code-review, synapse-reinst |
-| **documentation** | ドキュメンテーション専門 — 監査、再構成、同期、プロジェクトドキュメントの維持 | synapse-a2a, project-docs, doc-organizer, api-design, agent-memory |
+| **documentation** | ドキュメンテーション専門 — 監査、再構成、同期、プロジェクトドキュメントの維持 | synapse-a2a, project-docs, api-design, agent-memory |
 
 #### デプロイフロー
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ site_url: https://s-hiraoku.github.io/synapse-a2a/
 site_description: Multi-agent collaboration framework using Google A2A Protocol
 site_author: s-hiraoku
 repo_url: https://github.com/s-hiraoku/synapse-a2a
-repo_name: s-hiraoku/synapse-a2a v0.8.4
+repo_name: s-hiraoku/synapse-a2a v0.8.5
 docs_dir: site-docs
 
 theme:

--- a/plugins/synapse-a2a/.claude-plugin/plugin.json
+++ b/plugins/synapse-a2a/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synapse-a2a",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "Complete plugin for Synapse A2A multi-agent framework including inter-agent communication, file safety, and history management",
   "author": {
     "name": "s-hiraoku",

--- a/plugins/synapse-a2a/skills/synapse-a2a/references/commands.md
+++ b/plugins/synapse-a2a/skills/synapse-a2a/references/commands.md
@@ -67,6 +67,10 @@ synapse claude --skill-set dev-set
 # Delegate/manager mode (no file editing, delegates via synapse send)
 synapse claude --delegate-mode --name manager --role "task manager"
 
+# Worktree isolation in current terminal (Synapse-native, all agent types)
+synapse claude --worktree my-feature              # Start in worktree in current terminal
+synapse gemini --worktree review --name Reviewer --role "code reviewer"
+
 # Skip interactive name/role setup
 synapse claude --no-setup
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synapse-a2a"
-version = "0.8.4"
+version = "0.8.5"
 description = "Agent-to-Agent communication protocol for CLI agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/roles/golden-phoenix.md
+++ b/roles/golden-phoenix.md
@@ -1,28 +1,28 @@
-ドキュメント更新エキスパート
+Documentation Specialist
 
-あなたはプロジェクトのドキュメントを常に最新かつ正確に保つ専門家です。
+You are an expert at keeping project documentation accurate and up-to-date.
 
-## 責務
+## Responsibilities
 
-- README.md、guides/、docs/ の内容をコード変更に追従させる
-- CLAUDE.md のコマンド一覧・アーキテクチャ図を最新に保つ
-- CHANGELOG.md へ変更履歴を追記する
-- API ドキュメントとコードの整合性を検証する
-- ドキュメント間の重複や矛盾を検出・解消する
+- Keep README.md, guides/, and docs/ in sync with code changes
+- Maintain CLAUDE.md command lists and architecture diagrams
+- Append change history to CHANGELOG.md
+- Verify consistency between API docs and code
+- Detect and resolve duplication or contradictions across docs
 
-## 作業フロー
+## Workflow
 
-1. コード変更の差分を確認し、影響するドキュメントを特定する
-2. `/ralph-loop` を起動して、変更検出 → ドキュメント更新 → 検証のサイクルを回す
-3. 更新完了後、他のエージェントにレビューを依頼する
+1. Review code diffs and identify affected documentation
+2. Start `/ralph-loop` for iterative detect → update → verify cycles
+3. After updates are complete, request review from other agents
 
-## ralph-loop の活用（必須）
+## Using ralph-loop (Required)
 
-作業の開始時には必ず `/ralph-loop` を使い、反復的に品質を改善すること。
-特に以下の場面で活用する：
+Always start with `/ralph-loop` at the beginning of work for iterative quality improvement.
+Use it especially for:
 
-- ドキュメントの一括更新（複数ファイルにまたがる変更）
-- 整合性チェック（コードとドキュメントの突き合わせ）
-- 大きな変更のセルフレビュー
+- Batch documentation updates (changes spanning multiple files)
+- Consistency checks (cross-referencing code and docs)
+- Self-review of large changes
 
-`/ralph-loop` で開始し、完了条件を満たしたら `/cancel-ralph` で終了する。
+Start with `/ralph-loop` and finish with `/cancel-ralph` when done.

--- a/site-docs/changelog.md
+++ b/site-docs/changelog.md
@@ -4,6 +4,12 @@ For the complete changelog, see [CHANGELOG.md on GitHub](https://github.com/s-hi
 
 ## Recent Highlights
 
+### v0.8.5
+
+- **Changed**: Replace copyrighted character names with generic English names (Alice, Bob, Charlie, Dave, Eve, Frank)
+- **Docs**: Add skill installation guide (`npx skills add`) to Getting Started and Skills pages
+- **Docs**: Add `synapse-reinst` to Built-in Skills; remove `doc-organizer` from core install tables
+
 ### v0.8.4
 
 - **Added**: Synapse-native worktree isolation (`--worktree` / `-w`) for all agent types

--- a/site-docs/concepts/a2a-protocol.md
+++ b/site-docs/concepts/a2a-protocol.md
@@ -17,7 +17,7 @@ Every A2A agent publishes a discovery document at `/.well-known/agent.json`:
   "name": "synapse-claude-8100",
   "description": "Claude Code agent managed by Synapse A2A",
   "url": "http://localhost:8100",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "capabilities": {
     "streaming": false,
     "pushNotifications": false

--- a/site-docs/getting-started/installation.md
+++ b/site-docs/getting-started/installation.md
@@ -58,7 +58,7 @@
 synapse --version
 ```
 
-You should see the version number (e.g., `0.8.4`).
+You should see the version number (e.g., `0.8.5`).
 
 ## Initialize Configuration
 
@@ -72,6 +72,31 @@ synapse init --scope project   # ./.synapse/settings.json
 ```
 
 This creates the configuration directory with default settings and instruction templates.
+
+## Install Skills
+
+Skills teach agents how to use Synapse features — messaging, file safety, task delegation, and more. The `synapse-a2a` skill package is **essential** for multi-agent communication.
+
+```bash
+npx skills add s-hiraoku/synapse-a2a
+```
+
+This installs all core skills into your project:
+
+| Skill | Description |
+|-------|-------------|
+| **synapse-a2a** | Core A2A communication — commands, API, file safety, task board |
+| **synapse-manager** | Multi-agent orchestration (7-step workflow) |
+| **synapse-reinst** | Re-inject instructions after `/clear` or context reset |
+
+!!! tip "Why This Matters"
+    Without `synapse-a2a`, agents won't automatically discover peers or use `synapse send`/`synapse reply`. Install it in every project where you use Synapse.
+
+Verify installation:
+
+```bash
+synapse skills list --scope project
+```
 
 ## Terminal Requirements
 
@@ -93,4 +118,5 @@ For multi-agent features like `synapse team start` and `synapse spawn`, you need
 
 - [Quick Start](quickstart.md) — Launch your first agent and send a message
 - [Interactive Setup](setup.md) — Configure agent names, roles, and skill sets
+- [Skills](../guide/skills.md) — Manage skills, skill sets, and deployment
 - [Architecture](../concepts/architecture.md) — Understand how Synapse A2A works

--- a/site-docs/getting-started/quickstart.md
+++ b/site-docs/getting-started/quickstart.md
@@ -2,6 +2,13 @@
 
 Get two agents communicating in under 5 minutes.
 
+!!! warning "Prerequisites"
+    1. Install Synapse A2A (`pipx install synapse-a2a`)
+    2. Initialize configuration: `synapse init`
+    3. Install skills: `npx skills add s-hiraoku/synapse-a2a`
+
+    See [Installation](installation.md) for details.
+
 ## Step 1: Start Your First Agent
 
 Open a terminal and start Claude Code with Synapse:

--- a/site-docs/guide/agent-management.md
+++ b/site-docs/guide/agent-management.md
@@ -174,7 +174,7 @@ synapse rename my-claude --clear
 Save frequently used name/role/skill-set combinations as reusable definitions:
 
 ```bash
-synapse agents add silent-snake --name 狗巻棘 --profile codex --role @./roles/reviewer.md --scope project
+synapse agents add silent-snake --name Alice --profile codex --role @./roles/reviewer.md --scope project
 synapse agents list
 synapse spawn silent-snake     # Spawn using saved definition
 ```

--- a/site-docs/guide/agent-teams.md
+++ b/site-docs/guide/agent-teams.md
@@ -99,7 +99,7 @@ You can also spawn using a saved agent ID or display name instead of a profile:
 
 ```bash
 synapse spawn silent-snake              # Spawn by saved agent ID
-synapse spawn 狗巻棘                     # Spawn by saved agent display name
+synapse spawn Alice                     # Spawn by saved agent display name
 ```
 
 The saved agent's profile, name, role, and skill set are automatically resolved. CLI flags override saved values when specified.
@@ -251,7 +251,7 @@ Save reusable agent definitions for repeated use with `synapse spawn`. Definitio
 
 ```bash
 synapse agents add silent-snake \
-  --name 狗巻棘 \
+  --name Alice \
   --profile codex \
   --role @./roles/reviewer.md \
   --skill-set architect \
@@ -271,7 +271,7 @@ synapse agents add silent-snake \
 
 ```bash
 synapse agents list          # Table of all saved agents
-synapse agents show 狗巻棘    # Show details for one agent
+synapse agents show Alice    # Show details for one agent
 ```
 
 ### Deleting
@@ -286,7 +286,7 @@ Once defined, spawn by saved agent ID or display name:
 
 ```bash
 synapse spawn silent-snake
-synapse spawn 狗巻棘
+synapse spawn Alice
 ```
 
 CLI flags override saved values:

--- a/site-docs/guide/communication.md
+++ b/site-docs/guide/communication.md
@@ -87,7 +87,7 @@ synapse send codex "Run the full test suite and fix any failures" --silent
 
 ```bash
 synapse send my-claude "Review this code" --wait
-synapse send 釘崎野薔薇 "テストを書いて" --silent
+synapse send Charlie "Write the tests" --silent
 ```
 
 **Sender (`--from`)** — always uses agent ID format (`synapse-<type>-<port>`). This is auto-detected, so you rarely need to specify it.
@@ -117,7 +117,7 @@ If sender information is not fully available, it falls back to:
 - `A2A: <message content>` (Backward-compatible format)
 
 !!! info "Sender Identification"
-    The name is retrieved from the agent registry based on the sender's PID or explicit `--from` ID. If an agent has a custom name (e.g., `釘崎野薔薇`), that name is shown for better context.
+    The name is retrieved from the agent registry based on the sender's PID or explicit `--from` ID. If an agent has a custom name (e.g., `Charlie`), that name is shown for better context.
 
 ## Replying
 

--- a/site-docs/guide/skills.md
+++ b/site-docs/guide/skills.md
@@ -4,6 +4,37 @@
 
 The Skills system lets you discover, deploy, and manage specialized capabilities across agents. Skills are Markdown-based definitions that configure agent behavior for specific tasks.
 
+## Install Core Skills
+
+The `synapse-a2a` skill package is the foundation for all agent communication. Install it before using multi-agent features.
+
+### Quick Install
+
+```bash
+# 1. Initialize Synapse (creates .synapse/ directory)
+synapse init
+
+# 2. Install skills via skills.sh
+npx skills add s-hiraoku/synapse-a2a
+```
+
+!!! info "What is skills.sh?"
+    [skills.sh](https://skills.sh/) is a platform for discovering and installing agent skills. `npx skills add` downloads skill definitions into your project's `.claude/skills/` and `.agents/skills/` directories.
+
+### What Gets Installed
+
+| Skill | Purpose | Included In |
+|-------|---------|-------------|
+| **synapse-a2a** | Core A2A communication — message sending, file safety, task board, settings management | All skill sets |
+| **synapse-manager** | 7-step multi-agent orchestration: Plan, Delegate, Monitor, Approve, Verify, Feedback, Review | `manager` set |
+| **synapse-reinst** | Re-inject initial instructions after `/clear` or context reset — restores agent identity and A2A config | `manager` set |
+
+### Verification
+
+```bash
+synapse skills list --scope project
+```
+
 ## Skills TUI
 
 Launch the interactive skills manager:
@@ -104,16 +135,23 @@ synapse skills delete old-skill --force    # Skip confirmation
 
 ## Built-in Skills
 
-Synapse ships with three plugin-bundled skills that provide core multi-agent capabilities:
+Install via [`npx skills add s-hiraoku/synapse-a2a`](#install-core-skills). Four core skills provide multi-agent capabilities:
 
 | Skill | Description |
 |-------|-------------|
 | **synapse-a2a** | Core A2A communication — commands, API endpoints, file safety, task board usage |
 | **synapse-manager** | Multi-agent management workflow — task delegation, progress monitoring, quality verification with regression testing, feedback delivery, and cross-review orchestration |
+| **synapse-reinst** | Re-inject initial instructions after `/clear` — restores agent identity using preserved `SYNAPSE_*` env vars |
 | **doc-organizer** | Documentation audit, restructure, and consolidation — inventory docs, detect staleness, deduplicate content, normalize terminology, and improve navigation |
 
 !!! tip "synapse-manager"
     The `synapse-manager` skill teaches an agent a structured 5-step workflow: **Delegate** (spawn agents and assign subtasks), **Monitor** (check status and artifacts), **Verify** (run tests with regression triage), **Feedback** (send actionable fix instructions), and **Review** (cross-review and cleanup). Activate it via the `manager` skill set or deploy it directly.
+
+!!! tip "synapse-reinst"
+    When an agent runs `/clear` or loses context, it forgets its Synapse instructions.
+    The `synapse-reinst` skill rebuilds and re-injects the complete instruction set using
+    persistent environment variables (`SYNAPSE_AGENT_ID`, `SYNAPSE_PORT`, etc.).
+    Included in the `manager` skill set.
 
 !!! tip "doc-organizer"
     The `doc-organizer` skill guides an agent through a 4-step workflow: **Audit** (inventory all docs and classify topics), **Plan** (propose restructuring with moves, merges, deletions), **Execute** (apply changes), and **Verify** (cross-check links, terminology, completeness). Activate it via the `documentation` skill set or deploy it directly.

--- a/synapse/cli.py
+++ b/synapse/cli.py
@@ -4974,7 +4974,7 @@ Outputs '{agent_id} {port}' on success for scripting use.""",
         epilog="""Examples:
   synapse spawn claude                          Spawn Claude in a new pane
   synapse spawn silent-snake                    Spawn by saved agent ID
-  synapse spawn 狗巻棘                           Spawn by saved agent name
+  synapse spawn Alice                           Spawn by saved agent name
   synapse spawn gemini --port 8115              Spawn Gemini on specific port
   synapse spawn claude --name Tester --role "test writer"
   synapse spawn claude --terminal tmux          Use specific terminal""",

--- a/synapse/long_message.py
+++ b/synapse/long_message.py
@@ -209,7 +209,7 @@ def format_file_reference(
         file_path: Path to the message file.
         response_mode: Response mode ("wait", "notify", or "silent").
         sender_id: Sender agent ID (e.g., synapse-claude-8100).
-        sender_name: Sender display name (e.g., 虎杖悠仁).
+        sender_name: Sender display name (e.g., Alice).
 
     Returns:
         Formatted reference message string with optional sender and reply marker.

--- a/synapse/utils.py
+++ b/synapse/utils.py
@@ -156,7 +156,7 @@ def format_a2a_message(
         content: Message content
         response_mode: Response mode ("wait", "notify", or "silent")
         sender_id: Sender agent ID (e.g., synapse-claude-8100)
-        sender_name: Sender display name (e.g., 虎杖悠仁)
+        sender_name: Sender display name (e.g., Alice)
 
     Returns:
         Formatted message string with A2A prefix, optional sender, and reply marker

--- a/tests/test_agent_profile_scope.py
+++ b/tests/test_agent_profile_scope.py
@@ -34,8 +34,8 @@ def test_maybe_prompt_save_uses_provided_store(
     responses = iter(["y", "wise-strategist", "project"])
     _maybe_prompt_save_agent_profile(
         profile="claude",
-        name="孔明",
-        role="軍師",
+        name="Frank",
+        role="task manager",
         skill_set="manager",
         headless=False,
         is_tty=True,
@@ -63,8 +63,8 @@ def test_maybe_prompt_save_without_store_uses_cwd(
     responses = iter(["y", "wise-strategist", "project"])
     _maybe_prompt_save_agent_profile(
         profile="claude",
-        name="孔明",
-        role="軍師",
+        name="Frank",
+        role="task manager",
         skill_set=None,
         headless=False,
         is_tty=True,

--- a/tests/test_agent_profiles.py
+++ b/tests/test_agent_profiles.py
@@ -21,14 +21,14 @@ def test_add_and_resolve_by_name(
     store = AgentProfileStore()
     store.add(
         profile_id="silent-snake",
-        name="狗巻棘",
+        name="Alice",
         profile="claude",
         role="@./roles/reviewer.md",
         skill_set="reviewer",
         scope="project",
     )
 
-    resolved = store.resolve("狗巻棘")
+    resolved = store.resolve("Alice")
     assert resolved is not None
     assert resolved.profile_id == "silent-snake"
     assert resolved.profile == "claude"
@@ -49,7 +49,7 @@ def test_add_rejects_non_petname_id(
     with pytest.raises(AgentProfileError, match="petname"):
         store.add(
             profile_id="dog",
-            name="狗巻棘",
+            name="Alice",
             profile="claude",
             role=None,
             skill_set=None,
@@ -69,15 +69,15 @@ def test_delete_by_name(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None
     store = AgentProfileStore()
     store.add(
         profile_id="silent-snake",
-        name="狗巻棘",
+        name="Alice",
         profile="claude",
         role=None,
         skill_set=None,
         scope="project",
     )
-    deleted = store.delete("狗巻棘")
+    deleted = store.delete("Alice")
     assert deleted
-    assert store.resolve("狗巻棘") is None
+    assert store.resolve("Alice") is None
 
 
 def test_list_all_skips_corrupted_agent_file(

--- a/tests/test_agents_save_prompt.py
+++ b/tests/test_agents_save_prompt.py
@@ -14,7 +14,7 @@ def test_save_prompt_skips_when_not_tty() -> None:
     store = MagicMock()
     _maybe_prompt_save_agent_profile(
         profile="claude",
-        name="狗巻棘",
+        name="Alice",
         role="@./roles/reviewer.md",
         skill_set="reviewer",
         headless=False,
@@ -33,7 +33,7 @@ def test_save_prompt_persists_when_confirmed() -> None:
 
     _maybe_prompt_save_agent_profile(
         profile="claude",
-        name="狗巻棘",
+        name="Alice",
         role="@./roles/reviewer.md",
         skill_set="reviewer",
         headless=False,
@@ -45,7 +45,7 @@ def test_save_prompt_persists_when_confirmed() -> None:
 
     store.add.assert_called_once_with(
         profile_id="silent-snake",
-        name="狗巻棘",
+        name="Alice",
         profile="claude",
         role="@./roles/reviewer.md",
         skill_set="reviewer",
@@ -61,7 +61,7 @@ def test_save_prompt_skips_when_env_disabled(monkeypatch: pytest.MonkeyPatch) ->
 
     _maybe_prompt_save_agent_profile(
         profile="claude",
-        name="狗巻棘",
+        name="Alice",
         role="@./roles/reviewer.md",
         skill_set="reviewer",
         headless=False,

--- a/tests/test_auto_spawn.py
+++ b/tests/test_auto_spawn.py
@@ -371,7 +371,7 @@ class TestTeamStartExecution:
         from synapse.cli import cmd_team_start
 
         args = argparse.Namespace(
-            agents=["claude:狗巻棘", "gemini:狗巻棘"],
+            agents=["claude:Alice", "gemini:Alice"],
             layout="split",
             all_new=True,
         )
@@ -392,7 +392,7 @@ class TestTeamStartExecution:
         from synapse.cli import cmd_team_start
 
         args = argparse.Namespace(
-            agents=["claude:狗巻棘", "gemini:伏黒恵"],
+            agents=["claude:Alice", "gemini:Bob"],
             layout="split",
             all_new=True,
         )
@@ -415,7 +415,7 @@ class TestTeamStartExecution:
         from synapse.cli import cmd_team_start
 
         args = argparse.Namespace(
-            agents=["silent-snake", "gemini:狗巻棘"],
+            agents=["silent-snake", "gemini:Alice"],
             layout="split",
             all_new=True,
         )
@@ -430,7 +430,7 @@ class TestTeamStartExecution:
             mock_store = mock_store_cls.return_value
             mock_store.resolve.return_value = argparse.Namespace(
                 profile_id="silent-snake",
-                name="狗巻棘",
+                name="Alice",
                 profile="codex",
                 role="reviewer",
                 skill_set="architect",
@@ -470,7 +470,7 @@ class TestTeamStartExecution:
             mock_store = mock_store_cls.return_value
             mock_store.resolve.return_value = argparse.Namespace(
                 profile_id="silent-snake",
-                name="狗巻棘",
+                name="Alice",
                 profile="codex",
                 role="reviewer",
                 skill_set="architect",
@@ -479,7 +479,7 @@ class TestTeamStartExecution:
 
         assert len(captured_agents) == 1
         first_spec = captured_agents[0][0]
-        assert first_spec.startswith("codex:狗巻棘:reviewer:architect:")
+        assert first_spec.startswith("codex:Alice:reviewer:architect:")
 
 
 # ============================================================

--- a/tests/test_cli_interactive.py
+++ b/tests/test_cli_interactive.py
@@ -110,7 +110,7 @@ class TestCmdRunInteractive:
             patch("synapse.cli.interactive_agent_setup") as mock_setup,
             pytest.raises(SystemExit) as exc_info,
         ):
-            mock_setup.return_value = ("狗巻棘", "review role", "architect")
+            mock_setup.return_value = ("Alice", "review role", "architect")
             cmd_run_interactive("test_profile", 8100)
 
         assert exc_info.value.code == 1

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -155,7 +155,7 @@ class TestCliMain:
                 "add",
                 "silent-snake",
                 "--name",
-                "狗巻棘",
+                "Alice",
                 "--profile",
                 "claude",
                 "--scope",
@@ -169,7 +169,7 @@ class TestCliMain:
         assert args.command == "agents"
         assert args.agents_command == "add"
         assert args.id == "silent-snake"
-        assert args.name == "狗巻棘"
+        assert args.name == "Alice"
 
     @patch("synapse.cli.cmd_history_list")
     @patch("synapse.cli.install_skills")

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -158,15 +158,15 @@ def test_register_overwrites_existing(registry):
 
 def test_register_rejects_duplicate_custom_name(registry):
     """Register should reject duplicate custom names across different agent IDs."""
-    registry.register("agent_a", "claude", 8100, name="狗巻棘")
+    registry.register("agent_a", "claude", 8100, name="Alice")
     with pytest.raises(NameConflictError):
-        registry.register("agent_b", "gemini", 8110, name="狗巻棘")
+        registry.register("agent_b", "gemini", 8110, name="Alice")
 
 
 def test_register_allows_same_agent_id_same_name_overwrite(registry):
     """Re-registering the same agent ID with same name should be allowed."""
-    registry.register("agent_same", "claude", 8100, name="狗巻棘")
-    registry.register("agent_same", "claude", 8100, name="狗巻棘", status="READY")
+    registry.register("agent_same", "claude", 8100, name="Alice")
+    registry.register("agent_same", "claude", 8100, name="Alice", status="READY")
     assert registry.get_agent("agent_same")["status"] == "READY"
 
 
@@ -178,7 +178,7 @@ def test_register_duplicate_name_concurrent_only_one_succeeds(registry):
     def register_one(agent_id: str, port: int) -> None:
         try:
             barrier.wait(timeout=2.0)
-            registry.register(agent_id, "codex", port, name="狗巻棘")
+            registry.register(agent_id, "codex", port, name="Alice")
         except Exception as e:  # noqa: BLE001 - collect for assertion
             errors.append(e)
 
@@ -194,7 +194,7 @@ def test_register_duplicate_name_concurrent_only_one_succeeds(registry):
     assert len(conflicts) == 1
 
     named = [
-        info for info in registry.list_agents().values() if info.get("name") == "狗巻棘"
+        info for info in registry.list_agents().values() if info.get("name") == "Alice"
     ]
     assert len(named) == 1
 

--- a/tests/test_sender_in_pty.py
+++ b/tests/test_sender_in_pty.py
@@ -33,9 +33,9 @@ class TestFormatA2AMessageWithSender:
         result = format_a2a_message(
             "Hello",
             sender_id="synapse-claude-8100",
-            sender_name="虎杖悠仁",
+            sender_name="Alice",
         )
-        assert result == "A2A: [From: 虎杖悠仁 (synapse-claude-8100)] Hello"
+        assert result == "A2A: [From: Alice (synapse-claude-8100)] Hello"
 
     def test_sender_with_reply_expected(self):
         """Sender info should appear before REPLY EXPECTED marker."""
@@ -43,10 +43,10 @@ class TestFormatA2AMessageWithSender:
             "What do you think?",
             response_mode="wait",
             sender_id="synapse-gemini-8110",
-            sender_name="伏黒恵",
+            sender_name="Bob",
         )
         assert result == (
-            "A2A: [From: 伏黒恵 (synapse-gemini-8110)] [REPLY EXPECTED] What do you think?"
+            "A2A: [From: Bob (synapse-gemini-8110)] [REPLY EXPECTED] What do you think?"
         )
 
     def test_sender_id_with_reply_expected_no_name(self):
@@ -83,12 +83,12 @@ class TestSenderInfoInMetadata:
         info = {
             "agent_type": "claude",
             "endpoint": "http://localhost:8100",
-            "name": "虎杖悠仁",
+            "name": "Alice",
         }
         result = _extract_sender_info_from_agent("synapse-claude-8100", info)
 
         assert result["sender_id"] == "synapse-claude-8100"
-        assert result["sender_name"] == "虎杖悠仁"
+        assert result["sender_name"] == "Alice"
 
     def test_sender_name_absent_when_no_name(self):
         """_extract_sender_info_from_agent should omit name when not set."""
@@ -114,14 +114,14 @@ class TestSenderInfoExtraction:
         metadata = {
             "sender": {
                 "sender_id": "synapse-claude-8100",
-                "sender_name": "虎杖悠仁",
+                "sender_name": "Alice",
                 "sender_endpoint": "http://localhost:8100",
             }
         }
         info = _extract_sender_info(metadata)
 
         assert info.sender_id == "synapse-claude-8100"
-        assert info.sender_name == "虎杖悠仁"
+        assert info.sender_name == "Alice"
 
     def test_extract_sender_name_absent(self):
         """_extract_sender_info should default sender_name to None."""
@@ -151,9 +151,9 @@ class TestLongMessageFileReference:
         result = format_file_reference(
             Path("/tmp/test.txt"),
             sender_id="synapse-claude-8100",
-            sender_name="虎杖悠仁",
+            sender_name="Alice",
         )
-        assert "[From: 虎杖悠仁 (synapse-claude-8100)]" in result
+        assert "[From: Alice (synapse-claude-8100)]" in result
         assert "[LONG MESSAGE - FILE ATTACHED]" in result
 
     def test_file_reference_without_sender(self):
@@ -197,22 +197,22 @@ class TestPTYInjectionIncludesSender:
         metadata = {
             "sender": {
                 "sender_id": "synapse-claude-8100",
-                "sender_name": "虎杖悠仁",
+                "sender_name": "Alice",
                 "sender_endpoint": "http://localhost:8100",
             },
             "response_mode": "wait",
         }
         info = _extract_sender_info(metadata)
         assert info.sender_id == "synapse-claude-8100"
-        assert info.sender_name == "虎杖悠仁"
+        assert info.sender_name == "Alice"
 
         # Verify format_a2a_message produces correct output with this info
         result = format_a2a_message(
-            "テストメッセージ",
+            "test message",
             response_mode="wait",
             sender_id=info.sender_id,
             sender_name=info.sender_name,
         )
-        assert "[From: 虎杖悠仁 (synapse-claude-8100)]" in result
+        assert "[From: Alice (synapse-claude-8100)]" in result
         assert "[REPLY EXPECTED]" in result
-        assert "テストメッセージ" in result
+        assert "test message" in result

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -359,7 +359,7 @@ class TestSpawnCLIExecution:
         agent_info = {"agent_id": "synapse-claude-8100", "pid": 123, "port": 8100}
 
         args = argparse.Namespace(
-            profile="狗巻棘",
+            profile="Alice",
             port=None,
             name=None,
             role=None,
@@ -377,7 +377,7 @@ class TestSpawnCLIExecution:
             mock_registry_cls.return_value.is_name_unique.return_value = True
             mock_saved = argparse.Namespace(
                 profile_id="silent-snake",
-                name="狗巻棘",
+                name="Alice",
                 profile="claude",
                 role="@./roles/reviewer.md",
                 skill_set="reviewer",
@@ -387,7 +387,7 @@ class TestSpawnCLIExecution:
 
         kwargs = mock_spawn.call_args.kwargs
         assert kwargs["profile"] == "claude"
-        assert kwargs["name"] == "狗巻棘"
+        assert kwargs["name"] == "Alice"
         assert kwargs["role"] == "@./roles/reviewer.md"
         assert kwargs["skill_set"] == "reviewer"
 
@@ -398,7 +398,7 @@ class TestSpawnCLIExecution:
         args = argparse.Namespace(
             profile="claude",
             port=None,
-            name="狗巻棘",
+            name="Alice",
             role=None,
             skill_set=None,
             terminal=None,

--- a/uv.lock
+++ b/uv.lock
@@ -1118,7 +1118,7 @@ wheels = [
 
 [[package]]
 name = "synapse-a2a"
-version = "0.7.0"
+version = "0.8.4"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

- Replace copyrighted anime/historical character names with generic English names (Alice, Bob, Charlie, Dave, Eve, Frank) across docs, tests, source code, and `.agent` files
- Replace Japanese role descriptions with English equivalents (`軍師` → `task manager`, etc.)
- Add skill installation guide (`npx skills add s-hiraoku/synapse-a2a`) to Getting Started, Quick Start, and Skills pages
- Add `synapse-reinst` to Built-in Skills section
- Remove `doc-organizer` from core skill install tables (not essential for A2A communication)
- Bump version to 0.8.5

## Test plan

- [x] `pytest` — 2319 passed, 3 skipped
- [x] `uv run mkdocs build --strict` — success
- [x] Pre-commit hooks (ruff, ruff format, mypy) — all passed
- [ ] Manual: verify site-docs pages render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)