### PR TITLE
release: bump version to 0.9.1 with workflow changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-03-04
+
+### Added
+
+- **Saved Workflows** (`synapse workflow`): define and replay reusable message sequences to running agents
+  - `synapse workflow create <name>` — generate a template YAML workflow
+  - `synapse workflow list` — list saved workflows (Rich TUI table or plain-text fallback)
+  - `synapse workflow show <name>` — display workflow steps and details
+  - `synapse workflow run <name>` — execute steps sequentially via A2A send
+  - `synapse workflow delete <name>` — remove saved workflows
+  - `--dry-run` and `--continue-on-error` flags for run
+  - Project/user scope storage (`.synapse/workflows/`, `~/.synapse/workflows/`)
+- Enhance help discoverability for root/team/session commands
+
+### Fixed
+
+- `WorkflowStore.exists()` for file-existence checks (corrupted YAML no longer bypasses overwrite protection)
+- Validate `WorkflowStep` target/message are `str` type, not just non-empty
+- `_parse_file` warns and uses filename stem when YAML `name` field mismatches
+
+### Documentation
+
+- Add x-synapse-context Agent Card extension documentation
+- Add workflow guide and CLI reference to GitHub Pages
+- Update README, guides, CLAUDE.md, and plugin skills with workflow commands
+
 ## [0.9.0] - 2026-03-03
 
 ### Added

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ site_url: https://s-hiraoku.github.io/synapse-a2a/
 site_description: Multi-agent collaboration framework using Google A2A Protocol
 site_author: s-hiraoku
 repo_url: https://github.com/s-hiraoku/synapse-a2a
-repo_name: s-hiraoku/synapse-a2a
+repo_name: s-hiraoku/synapse-a2a v0.9.1
 docs_dir: site-docs
 
 theme:

--- a/plugins/synapse-a2a/.claude-plugin/plugin.json
+++ b/plugins/synapse-a2a/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synapse-a2a",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Complete plugin for Synapse A2A multi-agent framework including inter-agent communication, file safety, and history management",
   "author": {
     "name": "s-hiraoku",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synapse-a2a"
-version = "0.9.0"
+version = "0.9.1"
 description = "Agent-to-Agent communication protocol for CLI agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/site-docs/changelog.md
+++ b/site-docs/changelog.md
@@ -4,6 +4,19 @@ For the complete changelog, see [CHANGELOG.md on GitHub](https://github.com/s-hi
 
 ## Recent Highlights
 
+### v0.9.1
+
+- **Added**: Saved Workflows (`synapse workflow`) — define and replay reusable message sequences to running agents
+- **Added**: Enhance help discoverability for root/team/session commands
+- **Fixed**: Corrupted YAML no longer bypasses workflow overwrite protection
+- **Fixed**: Validate WorkflowStep target/message are `str` type
+- **Docs**: Add workflow guide and CLI reference to GitHub Pages
+
+### v0.9.0
+
+- **Added**: Session Save/Restore (`synapse session`) — save and restore team configurations as named snapshots
+- **Docs**: Add Session Save/Restore guide, update CLI reference and plugin skills
+
 ### v0.8.6
 
 - **Changed**: Unify agent example names with model-hinting English names (Claud, Cody, Rex, Gem)

--- a/site-docs/concepts/a2a-protocol.md
+++ b/site-docs/concepts/a2a-protocol.md
@@ -17,7 +17,7 @@ Every A2A agent publishes a discovery document at `/.well-known/agent.json`:
   "name": "synapse-claude-8100",
   "description": "Claude Code agent managed by Synapse A2A",
   "url": "http://localhost:8100",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "capabilities": {
     "streaming": false,
     "pushNotifications": false

--- a/site-docs/getting-started/installation.md
+++ b/site-docs/getting-started/installation.md
@@ -58,7 +58,7 @@
 synapse --version
 ```
 
-You should see the version number (e.g., `0.9.0`).
+You should see the version number (e.g., `0.9.1`).
 
 ## Initialize Configuration
 


### PR DESCRIPTION
## Summary

- Bump version `0.9.0` → `0.9.1` across all version files
- Add changelog entry for workflow feature (`synapse workflow` CRUD + run)
- Update site-docs version references and changelog highlights

## Changed Files

- `pyproject.toml` — version bump
- `plugins/synapse-a2a/.claude-plugin/plugin.json` — version bump
- `CHANGELOG.md` — v0.9.1 entry
- `site-docs/changelog.md` — v0.9.1 + v0.9.0 highlights
- `site-docs/getting-started/installation.md` — version example
- `site-docs/concepts/a2a-protocol.md` — Agent Card version
- `mkdocs.yml` — repo_name header version

## Test plan

- [ ] `pytest` passes (no code changes, version-only)
- [ ] `uv run mkdocs build --strict` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# バージョン 0.9.1 リリースノート

* **新機能**
  * Saved Workflows機能を実装：ワークフローの定義、作成、保存、実行、削除、リプレイが可能に
  * ワークフロー実行フラグを追加
  * ルート、チーム、セッションコマンドのヘルプ発見性を改善

* **バグ修正**
  * ワークフロー検証とパース処理を改善
  * ワークフロータイプの検証を強化
  * YAML設定の不一致問題を修正

* **ドキュメント**
  * ドキュメントを更新

<!-- end of auto-generated comment: release notes by coderabbit.ai -->