### PR TITLE
fix: autofill canvas agent names from registry

### DIFF
--- a/synapse/commands/canvas.py
+++ b/synapse/commands/canvas.py
@@ -16,12 +16,29 @@ from pathlib import Path
 import httpx
 
 from synapse.canvas.store import CanvasStore
+from synapse.registry import AgentRegistry
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_PORT = 3000
 PID_FILE = ".synapse/canvas.pid"
 LOG_FILE = os.path.expanduser("~/.synapse/logs/canvas.log")
+
+
+def _resolve_agent_name(agent_id: str, agent_name: str = "") -> str:
+    """Resolve agent display name from registry unless already provided."""
+    if agent_name or not agent_id:
+        return agent_name
+
+    try:
+        info = AgentRegistry().get_agent(agent_id)
+    except Exception:
+        logger.debug("Failed to resolve agent name for %s", agent_id, exc_info=True)
+        return ""
+
+    if not info:
+        return ""
+    return str(info.get("name") or "")
 
 
 # ============================================================
@@ -217,6 +234,7 @@ def post_shortcut(
     """Post a card via format shortcut. Returns card dict or None."""
     if file_path:
         body = Path(file_path).read_text(encoding="utf-8")
+    agent_name = _resolve_agent_name(agent_id, agent_name)
     content_dict: dict = {"format": format_name, "body": body}
     if lang:
         content_dict["lang"] = lang

--- a/tests/test_canvas_cli.py
+++ b/tests/test_canvas_cli.py
@@ -64,6 +64,59 @@ class TestCanvasPost:
         assert content["format"] == "mermaid"
         assert content["body"] == "graph TD; File-->Canvas"
 
+    def test_post_shortcut_autofills_agent_name_from_registry(
+        self, tmp_path, monkeypatch
+    ):
+        """Should resolve agent_name from registry when only agent_id is given."""
+        from synapse.commands.canvas import post_shortcut
+
+        class _Registry:
+            def get_agent(self, agent_id):
+                assert agent_id == "synapse-codex-8120"
+                return {"name": "Cody"}
+
+        monkeypatch.setattr(
+            "synapse.commands.canvas.AgentRegistry", lambda: _Registry()
+        )
+
+        result = post_shortcut(
+            format_name="markdown",
+            body="hello",
+            title="Auto Name",
+            agent_id="synapse-codex-8120",
+            db_path=str(tmp_path / "canvas.db"),
+        )
+
+        assert result is not None
+        assert result["agent_name"] == "Cody"
+
+    def test_post_shortcut_prefers_explicit_agent_name_over_registry(
+        self, tmp_path, monkeypatch
+    ):
+        """Explicit agent_name should win over registry-derived name."""
+        from synapse.commands.canvas import post_shortcut
+
+        class _Registry:
+            def get_agent(self, agent_id):
+                assert agent_id == "synapse-codex-8120"
+                return {"name": "RegistryName"}
+
+        monkeypatch.setattr(
+            "synapse.commands.canvas.AgentRegistry", lambda: _Registry()
+        )
+
+        result = post_shortcut(
+            format_name="markdown",
+            body="hello",
+            title="Explicit Name",
+            agent_id="synapse-codex-8120",
+            agent_name="Cody",
+            db_path=str(tmp_path / "canvas.db"),
+        )
+
+        assert result is not None
+        assert result["agent_name"] == "Cody"
+
 
 # ============================================================
 # TestCanvasMermaid — synapse canvas mermaid shortcut


### PR DESCRIPTION
## Summary
- auto-fill `agent_name` for `synapse canvas post` from the registry when only `agent_id` is provided
- keep explicit `--agent-name` values higher priority than registry-derived names
- add Canvas CLI tests covering auto-fill and explicit override behavior

## Tests
- `pytest tests/test_canvas_cli.py -q -k "autofills_agent_name_from_registry or prefers_explicit_agent_name_over_registry"`
- `pytest tests/test_canvas_cli.py -q`