### PR TITLE
feat: add completion callback for silent sends

### DIFF
--- a/.agents/skills/synapse-a2a/SKILL.md
+++ b/.agents/skills/synapse-a2a/SKILL.md
@@ -137,7 +137,7 @@ Choose based on whether you need the result:
 |------|------|----------|
 | **Wait** | `--wait` | You need the answer before continuing (questions, reviews) |
 | **Notify** | `--notify` (default) | Async — you'll be notified on completion |
-| **Silent** | `--silent` | Fire-and-forget delegation (no response needed) |
+| **Silent** | `--silent` | Fire-and-forget delegation (no response needed; sender history still updates best-effort on completion) |
 
 ## Worker Agent Guide
 

--- a/.agents/skills/synapse-a2a/references/api.md
+++ b/.agents/skills/synapse-a2a/references/api.md
@@ -44,9 +44,25 @@ The framework automatically handles routing - you don't need to know where the m
 |----------|--------|-------------|
 | `/tasks/send-priority` | POST | Send with priority (1-5, 5=interrupt; subject to Readiness Gate) |
 | `/tasks/create` | POST | Create task without PTY send (for `--wait`) |
+| `/history/update` | POST | Update sender-side history observation (completion callback) |
 | `/reply-stack/list` | GET | List sender IDs available for reply (`synapse reply --list-targets`) |
 | `/reply-stack/get` | GET | Get sender info without removing (supports `?sender_id=`) |
 | `/reply-stack/pop` | GET | Pop sender info from reply map (supports `?sender_id=`) |
+
+## Completion Callback (`--silent` Flow)
+
+When `--silent` is used, the sender does not wait for a reply. However, the receiver still notifies the sender when the task completes (or fails) by calling `POST /history/update` on the sender's server. This updates the sender's history record from `sent` to the final status.
+
+1. **Sender** calls `/tasks/send` on the target agent with `response_mode: "silent"` and sender metadata (endpoint, UDS path, task ID)
+2. **Target agent** processes the message until completion
+3. **Target agent** calls `POST /history/update` on the sender's endpoint (UDS first, HTTP fallback)
+4. **Sender's** history record is updated from `sent` to `completed`/`failed`/`canceled`
+
+**Characteristics:**
+- **Best-effort**: Callback failures are logged but do not affect the receiver's processing
+- **Transport preference**: Uses UDS (Unix Domain Socket) when available, falls back to HTTP
+- **Timeout**: 10 seconds per callback attempt
+- **Metadata marker**: Updated observations include `completion_callback: true` in metadata
 
 ### Agent Teams Endpoints
 

--- a/.agents/skills/synapse-a2a/references/commands.md
+++ b/.agents/skills/synapse-a2a/references/commands.md
@@ -407,7 +407,7 @@ synapse send <target> "<message>" [--from <sender>] [--priority <1-5>] [--wait |
   - 5: Critical/emergency (sends SIGINT first)
 - `--wait`: Synchronous blocking - wait for receiver to reply with `synapse reply`
 - `--notify`: Async notification - get notified when task completes (default)
-- `--silent`: Fire and forget - no reply or notification needed
+- `--silent`: Fire and forget - no reply or PTY notification needed. The receiver sends a best-effort completion callback (`POST /history/update`) to update the sender's history when the task finishes.
 - `--callback`: Shell command to run on sender after task completion (requires `--silent`)
 - `--message-file`: Read message from file (use `-` for stdin)
 - `--stdin`: Read message from stdin
@@ -431,6 +431,8 @@ Analyze the message content and determine if you need immediate results:
 | Task with result expected | `--notify` | "Run tests and report the results" |
 | Delegated task (fire-and-forget) | `--silent` | "Fix this bug and commit" |
 | Notification | `--silent` | "FYI: Build completed" |
+
+**Completion Callback:** With `--silent`, the receiver sends a best-effort callback to the sender when the task completes or fails. This updates the sender's history from `sent` to the final status with an output summary. The callback is fire-and-forget; failures are logged but do not block the receiver.
 
 **Examples:**
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,7 @@ pytest tests/test_file_attachment.py -v   # --attach file attachment tests
 pytest tests/test_cmd_trace.py -v         # synapse trace command tests
 pytest tests/test_interactive_setup.py -v # Interactive setup + core skills tests
 pytest tests/test_learning_mode.py -v    # Learning mode tests
+pytest tests/test_completion_callback.py -v # Completion callback (--silent history update)
 pytest tests/test_proactive_mode.py -v   # Proactive mode tests
 
 # Agent Teams feature tests

--- a/guides/references.md
+++ b/guides/references.md
@@ -496,6 +496,7 @@ synapse send <target> <message|--message-file PATH|--stdin> [--from AGENT_ID] [-
 | `--force` | No | 作業ディレクトリの不一致チェックをバイパスして送信 |
 
 **Note**: `a2a.flow=auto`（デフォルト）の場合、フラグなしは `--notify`（非同期通知）になります。
+**Note**: `--silent` でも受信側完了時に sender 側 history のステータスは best-effort で更新されます（`sent` → `completed` / `failed` / `canceled`、通知不達時は `sent` のまま）。
 **Note**: メッセージの入力元は **positional / `--message-file` / `--stdin` のいずれか1つ** を指定します。
 **Note**: 送信元の CWD とターゲットの `working_dir` が異なる場合、警告を表示して終了コード 1 で終了します。`--force` でバイパスできます。
 
@@ -1692,6 +1693,7 @@ flowchart LR
 | GET | `/tasks` | Task 一覧 |
 | POST | `/tasks/{id}/cancel` | Task キャンセル |
 | POST | `/tasks/send-priority` | Priority 付きメッセージ送信（Synapse 拡張） |
+| POST | `/history/update` | sender 側 history ステータスを best-effort で更新（完了コールバック、Synapse 拡張） |
 | GET | `/reply-stack/list` | 返信可能な sender 一覧取得 |
 | GET | `/reply-stack/get` | 返信先 sender 情報取得（`?sender_id=` で指定可） |
 | GET | `/reply-stack/pop` | 返信先 sender 情報取得＋削除（`?sender_id=` で指定可） |
@@ -1843,6 +1845,56 @@ curl -X POST "http://localhost:8100/tasks/send-priority?priority=5" \
   -H "Content-Type: application/json" \
   -d '{"message": {"role": "user", "parts": [{"type": "text", "text": "処理を止めて"}]}}'
 ```
+
+---
+
+### 2.2.2 POST /history/update
+
+`--silent` 送信時の完了コールバック用エンドポイントです（Synapse 拡張）。受信側エージェントがタスクを完了すると、sender 側の history ステータスを best-effort で更新します。
+
+**リクエスト**:
+
+```http
+POST /history/update HTTP/1.1
+Host: localhost:8100
+Content-Type: application/json
+
+{
+  "task_id": "uuid-task-id",
+  "status": "completed",
+  "output_summary": "タスクの出力サマリー（省略可）"
+}
+```
+
+| フィールド | 型 | 必須 | 説明 |
+|-----------|-----|------|------|
+| `task_id` | string | Yes | 更新対象のタスク ID |
+| `status` | string | Yes | 新しいステータス（`completed` / `failed` / `canceled`） |
+| `output_summary` | string | No | タスク出力のサマリー |
+
+**レスポンス**:
+
+```json
+{
+  "updated": true,
+  "task_id": "uuid-task-id",
+  "status": "completed"
+}
+```
+
+**エラーレスポンス**:
+
+| ステータスコード | 説明 |
+|----------------|------|
+| 200 | 更新成功 |
+| 404 | 指定された task_id が history に存在しない |
+
+**動作の流れ**:
+
+1. sender が `synapse send --silent` でメッセージを送信
+2. receiver がタスクを処理し、完了（`completed` / `failed` / `canceled`）に遷移
+3. receiver が sender の `/history/update` に POST して、sender 側 history のステータスを更新
+4. 通知不達時は sender 側 history は `sent` のまま（best-effort）
 
 ---
 

--- a/guides/usage.md
+++ b/guides/usage.md
@@ -847,7 +847,7 @@ synapse send <agent> "メッセージ" [--from AGENT_ID] [--priority <n>] [--wai
 | `--silent` | - | - | ワンウェイモード - 送りっぱなし、返信・通知不要 |
 | `--force` | - | false | 作業ディレクトリの不一致チェックをバイパスして送信 |
 
-**Note**: `a2a.flow=auto`（デフォルト）の場合、フラグなしは `--notify`（非同期通知）になります。待たない場合は `--silent` を指定してください。
+**Note**: `a2a.flow=auto`（デフォルト）の場合、フラグなしは `--notify`（非同期通知）になります。待たない場合は `--silent` を指定してください。`--silent` でも受信側完了時に sender 側 history のステータスは best-effort で更新されます（`sent` → `completed` / `failed` / `canceled`、通知不達時は `sent` のまま）。
 
 **レスポンスモードの使い分け**:
 

--- a/plugins/synapse-a2a/skills/synapse-a2a/SKILL.md
+++ b/plugins/synapse-a2a/skills/synapse-a2a/SKILL.md
@@ -137,7 +137,7 @@ Choose based on whether you need the result:
 |------|------|----------|
 | **Wait** | `--wait` | You need the answer before continuing (questions, reviews) |
 | **Notify** | `--notify` (default) | Async — you'll be notified on completion |
-| **Silent** | `--silent` | Fire-and-forget delegation (no response needed) |
+| **Silent** | `--silent` | Fire-and-forget delegation (no response needed; sender history still updates best-effort on completion) |
 
 ## Worker Agent Guide
 

--- a/plugins/synapse-a2a/skills/synapse-a2a/references/api.md
+++ b/plugins/synapse-a2a/skills/synapse-a2a/references/api.md
@@ -44,9 +44,25 @@ The framework automatically handles routing - you don't need to know where the m
 |----------|--------|-------------|
 | `/tasks/send-priority` | POST | Send with priority (1-5, 5=interrupt; subject to Readiness Gate) |
 | `/tasks/create` | POST | Create task without PTY send (for `--wait`) |
+| `/history/update` | POST | Update sender-side history observation (completion callback) |
 | `/reply-stack/list` | GET | List sender IDs available for reply (`synapse reply --list-targets`) |
 | `/reply-stack/get` | GET | Get sender info without removing (supports `?sender_id=`) |
 | `/reply-stack/pop` | GET | Pop sender info from reply map (supports `?sender_id=`) |
+
+## Completion Callback (`--silent` Flow)
+
+When `--silent` is used, the sender does not wait for a reply. However, the receiver still notifies the sender when the task completes (or fails) by calling `POST /history/update` on the sender's server. This updates the sender's history record from `sent` to the final status.
+
+1. **Sender** calls `/tasks/send` on the target agent with `response_mode: "silent"` and sender metadata (endpoint, UDS path, task ID)
+2. **Target agent** processes the message until completion
+3. **Target agent** calls `POST /history/update` on the sender's endpoint (UDS first, HTTP fallback)
+4. **Sender's** history record is updated from `sent` to `completed`/`failed`/`canceled`
+
+**Characteristics:**
+- **Best-effort**: Callback failures are logged but do not affect the receiver's processing
+- **Transport preference**: Uses UDS (Unix Domain Socket) when available, falls back to HTTP
+- **Timeout**: 10 seconds per callback attempt
+- **Metadata marker**: Updated observations include `completion_callback: true` in metadata
 
 ### Agent Teams Endpoints
 

--- a/plugins/synapse-a2a/skills/synapse-a2a/references/commands.md
+++ b/plugins/synapse-a2a/skills/synapse-a2a/references/commands.md
@@ -407,7 +407,7 @@ synapse send <target> "<message>" [--from <sender>] [--priority <1-5>] [--wait |
   - 5: Critical/emergency (sends SIGINT first)
 - `--wait`: Synchronous blocking - wait for receiver to reply with `synapse reply`
 - `--notify`: Async notification - get notified when task completes (default)
-- `--silent`: Fire and forget - no reply or notification needed
+- `--silent`: Fire and forget - no reply or PTY notification needed. The receiver sends a best-effort completion callback (`POST /history/update`) to update the sender's history when the task finishes.
 - `--callback`: Shell command to run on sender after task completion (requires `--silent`)
 - `--message-file`: Read message from file (use `-` for stdin)
 - `--stdin`: Read message from stdin
@@ -431,6 +431,8 @@ Analyze the message content and determine if you need immediate results:
 | Task with result expected | `--notify` | "Run tests and report the results" |
 | Delegated task (fire-and-forget) | `--silent` | "Fix this bug and commit" |
 | Notification | `--silent` | "FYI: Build completed" |
+
+**Completion Callback:** With `--silent`, the receiver sends a best-effort callback to the sender when the task completes or fails. This updates the sender's history from `sent` to the final status with an output summary. The callback is fire-and-forget; failures are logged but do not block the receiver.
 
 **Examples:**
 ```bash

--- a/site-docs/changelog.md
+++ b/site-docs/changelog.md
@@ -6,6 +6,9 @@ For the complete changelog, see [CHANGELOG.md on GitHub](https://github.com/s-hi
 
 ### v0.11.1
 
+- **Added**: Completion callback for `--silent` sends — sender-side history is updated (`sent` -> `completed`/`failed`/`canceled`) via best-effort callback when the receiver finishes processing
+- **Added**: `POST /history/update` API endpoint for receiver-to-sender history status notification
+- **Added**: `HistoryManager.update_observation_status()` for atomic history record updates with metadata merge
 - **Added**: Proactive Mode — `SYNAPSE_PROACTIVE_MODE_ENABLED=true` injects mandatory checklist for using all Synapse features (task board, shared memory, canvas, file safety, delegation, broadcast)
 - **Added**: New proactive mode user guide and specification document
 

--- a/site-docs/guide/communication.md
+++ b/site-docs/guide/communication.md
@@ -27,6 +27,9 @@ synapse send <target> "<message>" \
 synapse send codex "Refactor the auth module" --silent
 ```
 
+!!! info "Completion Callback"
+    Even in `--silent` mode, sender-side history is updated when the receiver completes the task. The receiver sends a best-effort callback (`POST /history/update`) to transition the sender's history record from `sent` to `completed`, `failed`, or `canceled`. If the callback cannot be delivered, the history record remains `sent`.
+
 ### With Priority
 
 ```bash

--- a/site-docs/guide/history.md
+++ b/site-docs/guide/history.md
@@ -141,6 +141,26 @@ SYNAPSE_HISTORY_ENABLED=false synapse claude
 SYNAPSE_HISTORY_ENABLED=true
 ```
 
+## Completion Callback (`--silent`)
+
+When you send a message with `--silent`, the sender's history initially records the task as `sent`. Once the receiver finishes processing, a best-effort callback updates the sender-side history:
+
+```
+sent  →  completed / failed / canceled
+```
+
+**How it works:**
+
+1. Sender dispatches a fire-and-forget message; history records status as `sent`
+2. Receiver processes the task and reaches a terminal state (`completed`, `failed`, or `canceled`)
+3. Receiver sends `POST /history/update` to the sender (UDS first, HTTP fallback)
+4. Sender's history record is updated to the final status
+
+**Best-effort delivery:** If the sender is offline or unreachable when the callback fires, the history record stays as `sent`. No retries are attempted.
+
+!!! tip
+    Use `synapse history list` to check whether delegated tasks have been updated. Records still showing `sent` may indicate the callback was not delivered.
+
 ## Monitoring Delegated Tasks
 
 When orchestrating multiple agents, use history to track progress:

--- a/site-docs/reference/api.md
+++ b/site-docs/reference/api.md
@@ -227,6 +227,46 @@ curl -X POST http://localhost:8100/tasks/create \
 }
 ```
 
+## History Update (Completion Callback)
+
+| Method | Endpoint | Description |
+|:------:|----------|-------------|
+| POST | `/history/update` | Update sender-side history status (completion callback) |
+
+Used by the receiver to notify the sender that a `--silent` task has reached a terminal state. The sender's history record is updated from `sent` to the new status.
+
+### Request
+
+```bash
+curl -X POST http://localhost:8100/history/update \
+  -H "Content-Type: application/json" \
+  -d '{
+    "task_id": "abc123-...",
+    "status": "completed",
+    "output_summary": "Refactoring complete. 3 files changed."
+  }'
+```
+
+| Field | Type | Required | Description |
+|-------|------|:--------:|-------------|
+| `task_id` | string | Yes | Task ID to update in sender's history |
+| `status` | string | Yes | New status: `completed`, `failed`, or `canceled` |
+| `output_summary` | string | No | Optional output summary text |
+
+### Response
+
+**200 OK:**
+
+```json
+{
+  "updated": true,
+  "task_id": "abc123-...",
+  "status": "completed"
+}
+```
+
+**404 Not Found** — returned if `task_id` does not exist in the sender's history.
+
 ### GET /status
 
 Returns the current agent status and a tail of recent PTY output (last 2000 characters).

--- a/site-docs/reference/cli.md
+++ b/site-docs/reference/cli.md
@@ -172,7 +172,7 @@ synapse send <target> "<message>" [OPTIONS]
 | `--priority N` / `-p N` | Priority 1-5 (default: 3) |
 | `--wait` | Wait for reply (synchronous blocking) |
 | `--notify` | Return immediately, receive PTY notification on completion (**default**) |
-| `--silent` | Fire-and-forget (no completion notification) |
+| `--silent` | Fire-and-forget (no PTY notification; sender history updated via completion callback) |
 | `--message-file PATH` | Read message from file (`-` for stdin) |
 | `--stdin` | Read message from stdin |
 | `--attach FILE` | Attach file (repeatable) |
@@ -181,7 +181,7 @@ synapse send <target> "<message>" [OPTIONS]
 !!! tip "Choosing response mode"
     - `--notify` (default): Returns immediately; you get a PTY notification when the receiver completes. Best for most use cases.
     - `--wait`: Blocks until the receiver replies. Use for questions or when you need the result before proceeding.
-    - `--silent`: Fire-and-forget with no completion notification. Use for pure notifications or delegated tasks.
+    - `--silent`: Fire-and-forget with no PTY notification. Use for pure notifications or delegated tasks; sender history is still updated best-effort on completion.
 
 ### Reply
 

--- a/synapse/a2a_compat.py
+++ b/synapse/a2a_compat.py
@@ -659,28 +659,33 @@ async def _notify_sender_completion(
         "output_summary": output_summary,
     }
 
+    # Try UDS first, fall through to HTTP on failure
     if sender_uds_path and os.path.exists(sender_uds_path):
         try:
             transport = httpx.AsyncHTTPTransport(uds=sender_uds_path)
             async with httpx.AsyncClient(transport=transport, timeout=10.0) as client:
-                response = await client.post(
+                resp = await client.post(
                     "http://localhost/history/update", json=payload
                 )
-                response.raise_for_status()
+                resp.raise_for_status()
                 logger.info(
-                    "Completion callback sent via UDS for task %s", callback_task_id[:8]
+                    "Completion callback sent via UDS for task %s",
+                    callback_task_id[:8],
                 )
                 return True
         except httpx.HTTPError as e:
             logger.warning(
-                "UDS completion callback failed for %s: %s", callback_task_id, e
+                "UDS completion callback failed for %s, falling back to HTTP: %s",
+                callback_task_id[:8],
+                e,
             )
 
+    # HTTP fallback
     try:
         async with httpx.AsyncClient(timeout=10.0) as client:
             url = f"{sender_endpoint}/history/update"
-            response = await client.post(url, json=payload)
-            response.raise_for_status()
+            resp = await client.post(url, json=payload)
+            resp.raise_for_status()
             logger.info(
                 "Completion callback sent to %s for task %s",
                 sender_endpoint,
@@ -693,17 +698,15 @@ async def _notify_sender_completion(
             sender_endpoint,
             e.response.status_code,
         )
-        return False
     except httpx.RequestError as e:
         logger.warning(
             "Failed to send completion callback to %s: %s", sender_endpoint, e
         )
-        return False
     except Exception as e:
         logger.error(
             "Unexpected completion callback error to %s: %s", sender_endpoint, e
         )
-        return False
+    return False
 
 
 # ============================================================

--- a/synapse/history.py
+++ b/synapse/history.py
@@ -252,42 +252,23 @@ class HistoryManager:
                         with contextlib.suppress(TypeError, ValueError):
                             metadata_json = json.dumps(current_metadata)
 
-                    if output_text is None and metadata_json is None:
-                        cursor.execute(
-                            """
-                            UPDATE observations
-                            SET status = ?, timestamp = CURRENT_TIMESTAMP
-                            WHERE task_id = ?
-                            """,
-                            (status, task_id),
-                        )
-                    elif output_text is None:
-                        cursor.execute(
-                            """
-                            UPDATE observations
-                            SET status = ?, metadata = ?, timestamp = CURRENT_TIMESTAMP
-                            WHERE task_id = ?
-                            """,
-                            (status, metadata_json, task_id),
-                        )
-                    elif metadata_json is None:
-                        cursor.execute(
-                            """
-                            UPDATE observations
-                            SET status = ?, output = ?, timestamp = CURRENT_TIMESTAMP
-                            WHERE task_id = ?
-                            """,
-                            (status, output_text, task_id),
-                        )
-                    else:
-                        cursor.execute(
-                            """
-                            UPDATE observations
-                            SET status = ?, output = ?, metadata = ?, timestamp = CURRENT_TIMESTAMP
-                            WHERE task_id = ?
-                            """,
-                            (status, output_text, metadata_json, task_id),
-                        )
+                    set_clauses = ["status = ?"]
+                    params: list[Any] = [status]
+
+                    if output_text is not None:
+                        set_clauses.append("output = ?")
+                        params.append(output_text)
+                    if metadata_json is not None:
+                        set_clauses.append("metadata = ?")
+                        params.append(metadata_json)
+
+                    set_clauses.append("timestamp = CURRENT_TIMESTAMP")
+                    params.append(task_id)
+                    cursor.execute(
+                        f"UPDATE observations SET {', '.join(set_clauses)}"
+                        f" WHERE task_id = ?",
+                        params,
+                    )
 
                     return cursor.rowcount > 0
             except sqlite3.Error as e:


### PR DESCRIPTION
## Summary
- add best-effort completion callback delivery with UDS-first then HTTP fallback
- simplify history observation status updates and document the new /history/update flow
- sync synapse-a2a skill references with the current --wait/--notify/--silent terminology

## Testing
- pytest tests/test_completion_callback.py -v