### PR TITLE
fix: tighten test assertions per review feedback

### DIFF
--- a/tests/test_claude_shared_memory_docs.py
+++ b/tests/test_claude_shared_memory_docs.py
@@ -43,3 +43,5 @@ class TestClaudeSharedMemoryDocs:
         text = _read_docs()
 
         assert "memory.db" in text
+        # Verify it appears in the .synapse/ storage context
+        assert ".synapse/" in text

--- a/tests/test_mcp_bootstrap.py
+++ b/tests/test_mcp_bootstrap.py
@@ -282,9 +282,46 @@ def test_mcp_module_ignores_initialized_notification_over_stdio() -> None:
 
 
 def test_stdio_helpers_use_json_line_protocol() -> None:
-    source = Path("synapse/mcp/server.py").read_text(encoding="utf-8")
+    """Verify MCP server uses JSON-line protocol, not HTTP-style Content-Length framing."""
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "synapse.mcp",
+            "--agent-id",
+            "synapse-codex-8120",
+            "--agent-type",
+            "codex",
+            "--port",
+            "8120",
+        ],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
 
-    assert "Content-Length:" not in source
+    try:
+        assert proc.stdin is not None
+        proc.stdin.write(
+            json.dumps(
+                {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}}
+            )
+            + "\n"
+        )
+        proc.stdin.flush()
+
+        assert proc.stdout is not None
+        first_line = proc.stdout.readline()
+
+        # Must NOT use HTTP-style Content-Length framing
+        assert not first_line.startswith("Content-Length:")
+        # Must be valid JSON (JSON-line protocol)
+        payload = json.loads(first_line)
+        assert payload.get("jsonrpc") == "2.0"
+    finally:
+        proc.terminate()
+        proc.wait(timeout=5)
 
 
 def test_module_entrypoint_uses_env_defaults_for_agent_context() -> None:


### PR DESCRIPTION
## Summary
- **test_storage_section_includes_shared_memory_db**: Add `.synapse/` context assertion alongside `memory.db` basename check to prevent false positives
- **test_stdio_helpers_use_json_line_protocol**: Replace fragile source-text grep with runtime subprocess assertion that verifies JSON-line output format

## Test plan
- [x] `pytest tests/test_claude_shared_memory_docs.py -v` passes
- [x] `pytest tests/test_mcp_bootstrap.py -v` passes
- [x] Full test suite passes (2990 passed, 21 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## テスト
* 共有メモリデータベース参照がストレージコンテキストのドキュメント内に正しく含まれることを確認するテストを追加
* MCPモジュールをサブプロセスとして起動し、JSON-RPC通信を通じて動作を検証する統合テストを実装

<!-- end of auto-generated comment: release notes by coderabbit.ai -->