### PR TITLE
fix: keep canvas sidebar collapse control inside panel

### DIFF
--- a/synapse/canvas/static/canvas.css
+++ b/synapse/canvas/static/canvas.css
@@ -194,8 +194,7 @@ body.sidebar-collapsed .sidebar-header h1 {
 }
 
 body.sidebar-collapsed .sidebar-header h1 .brand-icon {
-  width: 24px;
-  height: 24px;
+  display: none;
 }
 
 body.sidebar-collapsed #sidebar-collapse {

--- a/tests/test_canvas_frontend.py
+++ b/tests/test_canvas_frontend.py
@@ -530,6 +530,10 @@ def test_collapsed_sidebar_header_hides_title_and_keeps_button_inside() -> None:
     assert "overflow: hidden;" in collapsed_heading_block
     assert "justify-content: center;" in collapsed_heading_block
     assert "body.sidebar-collapsed #sidebar-collapse {" in css
+    collapsed_icon_block = css.split(
+        "body.sidebar-collapsed .sidebar-header h1 .brand-icon {", 1
+    )[1].split("}", 1)[0]
+    assert "display: none;" in collapsed_icon_block
 
 
 def test_collapsed_main_content_margin_matches_sidebar_width() -> None:


### PR DESCRIPTION
## Summary
- keep the collapsed Canvas sidebar wide enough to show the full title
- keep the collapse button inside the sidebar header instead of letting it overflow
- add frontend regression tests for the collapsed sidebar layout

## Testing
- pytest tests/test_canvas_frontend.py -v