### PR TITLE
fix: improve saved agent id prompt

### DIFF
--- a/synapse/agent_profiles.py
+++ b/synapse/agent_profiles.py
@@ -188,3 +188,56 @@ class AgentProfileStore:
     def _validate_required(value: str, field_name: str) -> None:
         if not value.strip():
             raise AgentProfileError(f"{field_name} is required")
+
+
+def suggest_petname_ids(*values: str | None, limit: int = 3) -> list[str]:
+    """Suggest a few valid petname-style IDs from user-facing labels."""
+    tokens: list[str] = []
+    seen: set[str] = set()
+
+    for value in values:
+        if not value:
+            continue
+        for token in re.findall(r"[a-z]+", value.lower()):
+            if token in seen:
+                continue
+            seen.add(token)
+            tokens.append(token)
+
+    candidates: list[str] = []
+    used: set[str] = set()
+
+    for i, left in enumerate(tokens):
+        for right in tokens[i + 1 :]:
+            if left == right:
+                continue
+            candidate = f"{left}-{right}"
+            if candidate in used:
+                continue
+            used.add(candidate)
+            candidates.append(candidate)
+            if len(candidates) >= limit:
+                return candidates
+
+    fallbacks = ["agent", "helper", "worker", "guide"]
+    for left in tokens:
+        for right in fallbacks:
+            if left == right:
+                continue
+            candidate = f"{left}-{right}"
+            if candidate in used:
+                continue
+            used.add(candidate)
+            candidates.append(candidate)
+            if len(candidates) >= limit:
+                return candidates
+
+    generic = ["silent-snake", "calm-lead", "steady-builder"]
+    for candidate in generic:
+        if candidate in used:
+            continue
+        candidates.append(candidate)
+        if len(candidates) >= limit:
+            break
+
+    return candidates

--- a/synapse/cli.py
+++ b/synapse/cli.py
@@ -22,7 +22,11 @@ if TYPE_CHECKING:
     from synapse.history import HistoryManager
 
 from synapse.a2a_client import A2AClient, get_client
-from synapse.agent_profiles import AgentProfileError, AgentProfileStore
+from synapse.agent_profiles import (
+    AgentProfileError,
+    AgentProfileStore,
+    suggest_petname_ids,
+)
 from synapse.auth import generate_api_key
 from synapse.commands.list import ListCommand
 from synapse.commands.session import (
@@ -685,10 +689,20 @@ def _maybe_prompt_save_agent_profile(
     if save not in {"y", "yes"}:
         return
 
-    profile_id = input_func("Saved agent ID (petname, e.g. silent-snake): ").strip()
-    if not profile_id:
-        print_func("Skipped: no saved agent ID provided.")
-        return
+    while True:
+        profile_id = input_func("Saved agent ID (petname, e.g. silent-snake): ").strip()
+        if not profile_id:
+            print_func("Skipped: no saved agent ID provided.")
+            return
+        try:
+            AgentProfileStore._validate_profile_id(profile_id)
+        except AgentProfileError as e:
+            print_func(f"Invalid saved agent ID: {e}")
+            suggestions = suggest_petname_ids(name, role, skill_set, profile)
+            if suggestions:
+                print_func("Try one of: " + ", ".join(suggestions))
+            continue
+        break
 
     raw_scope = input_func("Scope [project/user] (default: project): ").strip().lower()
     if not raw_scope:

--- a/tests/test_agents_save_prompt.py
+++ b/tests/test_agents_save_prompt.py
@@ -192,3 +192,34 @@ def test_save_prompt_asks_when_no_saved_profiles() -> None:
     )
 
     store.add.assert_not_called()  # user declined, but prompt was shown
+
+
+def test_save_prompt_suggests_petname_and_retries_on_invalid_id() -> None:
+    """Invalid IDs should show suggestions and allow retrying with a petname."""
+    store = MagicMock(spec=AgentProfileStore)
+    store.list_all.return_value = []
+    answers = iter(["y", "Alice", "alice-reviewer", "project"])
+    printed: list[str] = []
+
+    _maybe_prompt_save_agent_profile(
+        profile="claude",
+        name="Alice",
+        role="reviewer",
+        skill_set="review-set",
+        headless=False,
+        is_tty=True,
+        input_func=lambda _p: next(answers),
+        print_func=printed.append,
+        store=store,
+    )
+
+    store.add.assert_called_once_with(
+        profile_id="alice-reviewer",
+        name="Alice",
+        profile="claude",
+        role="reviewer",
+        skill_set="review-set",
+        scope="project",
+    )
+    assert any("petname format" in msg for msg in printed)
+    assert any("alice-reviewer" in msg for msg in printed)


### PR DESCRIPTION
## Summary
- validate saved-agent IDs before persisting from the exit prompt
- suggest petname-style IDs and let users retry invalid input
- add regression coverage for invalid ID retry flow

## Testing
- pytest tests/test_agents_save_prompt.py tests/test_agent_profiles.py tests/test_cli_main.py tests/test_cli_interactive.py tests/test_agent_profile_scope.py -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能
- エージェント ID の入力検証が強化され、無効な ID が入力された場合、ペットネーム形式の候補 ID が自動的に複数提案されるようになりました。
- 提案された複数の候補から最適なものを選択して再入力することで、より簡単で迅速にエージェントプロファイルを保存できます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->