### PR TITLE
release: bump version to 0.11.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.13] - 2026-03-11
+
+### Fixed
+
+- expand canvas image cards to available height
+- remove canvas card height caps
+
+### Tests
+
+- tighten canvas chart height assertion
+
 ## [0.11.12] - 2026-03-11
 
 ### Fixed
@@ -2149,6 +2160,7 @@ See v0.3.14 for reply PTY injection, CURRENT column, and history default changes
 - External agent connectivity vision document
 - PyPI publishing instructions
 
+[0.11.13]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.11.12...v0.11.13
 [0.11.12]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.11.11...v0.11.12
 [0.11.11]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.11.10...v0.11.11
 [0.11.10]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.11.9...v0.11.10

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ site_url: https://s-hiraoku.github.io/synapse-a2a/
 site_description: Multi-agent collaboration framework using Google A2A Protocol
 site_author: s-hiraoku
 repo_url: https://github.com/s-hiraoku/synapse-a2a
-repo_name: s-hiraoku/synapse-a2a v0.11.12
+repo_name: s-hiraoku/synapse-a2a v0.11.13
 docs_dir: site-docs
 
 theme:

--- a/plugins/synapse-a2a/.claude-plugin/plugin.json
+++ b/plugins/synapse-a2a/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synapse-a2a",
-  "version": "0.11.12",
+  "version": "0.11.13",
   "description": "Complete plugin for Synapse A2A multi-agent framework including inter-agent communication, file safety, and history management",
   "author": {
     "name": "s-hiraoku",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synapse-a2a"
-version = "0.11.12"
+version = "0.11.13"
 description = "Agent-to-Agent communication protocol for CLI agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/site-docs/changelog.md
+++ b/site-docs/changelog.md
@@ -4,6 +4,12 @@ For the complete changelog, see [CHANGELOG.md on GitHub](https://github.com/s-hi
 
 ## Recent Highlights
 
+### v0.11.13
+
+- **Fixed**: Expand canvas image cards to available height
+- **Fixed**: Remove canvas card height caps for image, HTML, and chart spotlight rendering
+- **Tests**: Tighten canvas chart height assertion
+
 ### v0.11.12
 
 - **Fixed**: Use returned task IDs instead of numeric indices in skill docs and guides

--- a/site-docs/concepts/a2a-protocol.md
+++ b/site-docs/concepts/a2a-protocol.md
@@ -17,7 +17,7 @@ Every A2A agent publishes a discovery document at `/.well-known/agent.json`:
   "name": "synapse-claude-8100",
   "description": "Claude Code agent managed by Synapse A2A",
   "url": "http://localhost:8100",
-  "version": "0.11.12",
+  "version": "0.11.13",
   "capabilities": {
     "streaming": false,
     "pushNotifications": false

--- a/site-docs/getting-started/installation.md
+++ b/site-docs/getting-started/installation.md
@@ -58,7 +58,7 @@
 synapse --version
 ```
 
-You should see the version number (e.g., `0.11.12`).
+You should see the version number (e.g., `0.11.13`).
 
 ## Initialize Configuration
 


### PR DESCRIPTION
## Summary
- bump package and plugin version from 0.11.12 to 0.11.13
- add the 0.11.13 changelog entry and comparison link
- sync site docs version references and recent highlights

## Testing
- pytest tests/test_extract_changelog.py tests/test_site_docs.py -v