### PR TITLE
release: v0.11.17 — tmux pane titles and synapse list fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.17] - 2026-03-13
+
+### Added
+
+- Set tmux pane titles to show agent name (`synapse(claude)` or `synapse(claude:Reviewer)`)
+- Auto-enable `pane-border-status` so pane titles are visible without manual tmux.conf changes
+
+### Fixed
+
+- Align `synapse list` help keybinding display
+
 ## [0.11.16] - 2026-03-13
 
 ### Fixed
@@ -2238,6 +2249,7 @@ See v0.3.14 for reply PTY injection, CURRENT column, and history default changes
 - External agent connectivity vision document
 - PyPI publishing instructions
 
+[0.11.17]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.11.16...v0.11.17
 [0.11.16]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.11.15...v0.11.16
 [0.11.15]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.11.14...v0.11.15
 [0.11.14]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.11.13...v0.11.14

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ site_url: https://s-hiraoku.github.io/synapse-a2a/
 site_description: Multi-agent collaboration framework using Google A2A Protocol
 site_author: s-hiraoku
 repo_url: https://github.com/s-hiraoku/synapse-a2a
-repo_name: s-hiraoku/synapse-a2a v0.11.16
+repo_name: s-hiraoku/synapse-a2a v0.11.17
 docs_dir: site-docs
 
 theme:

--- a/plugins/synapse-a2a/.claude-plugin/plugin.json
+++ b/plugins/synapse-a2a/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synapse-a2a",
-  "version": "0.11.16",
+  "version": "0.11.17",
   "description": "Complete plugin for Synapse A2A multi-agent framework including inter-agent communication, file safety, and history management",
   "author": {
     "name": "s-hiraoku",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synapse-a2a"
-version = "0.11.16"
+version = "0.11.17"
 description = "Agent-to-Agent communication protocol for CLI agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/site-docs/changelog.md
+++ b/site-docs/changelog.md
@@ -4,6 +4,12 @@ For the complete changelog, see [CHANGELOG.md on GitHub](https://github.com/s-hi
 
 ## Recent Highlights
 
+### v0.11.17
+
+- **Added**: Set tmux pane titles to show agent name (`synapse(claude)` or `synapse(claude:Reviewer)`)
+- **Added**: Auto-enable `pane-border-status` so pane titles are visible without manual tmux.conf changes
+- **Fixed**: Align `synapse list` help keybinding display
+
 ### v0.11.16
 
 - **Fixed**: Send submit_seq twice for Copilot CLI paste buffer flush — resolves enter key not executing when sending messages via `synapse send`

--- a/site-docs/concepts/a2a-protocol.md
+++ b/site-docs/concepts/a2a-protocol.md
@@ -17,7 +17,7 @@ Every A2A agent publishes a discovery document at `/.well-known/agent.json`:
   "name": "synapse-claude-8100",
   "description": "Claude Code agent managed by Synapse A2A",
   "url": "http://localhost:8100",
-  "version": "0.11.16",
+  "version": "0.11.17",
   "capabilities": {
     "streaming": false,
     "pushNotifications": false

--- a/site-docs/getting-started/installation.md
+++ b/site-docs/getting-started/installation.md
@@ -58,7 +58,7 @@
 synapse --version
 ```
 
-You should see the version number (e.g., `0.11.16`).
+You should see the version number (e.g., `0.11.17`).
 
 ## Initialize Configuration
 


### PR DESCRIPTION
## Summary
- Bump version `0.11.16` → `0.11.17`
- Update CHANGELOG, site-docs, plugin.json, mkdocs.yml

## Test plan
- [ ] Version strings are consistent across all files
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * tmuxペインのタイトルにエージェント名を表示するように設定
  * ペインタイトルを表示するため、pane-border-statusを自動有効化

* **バグ修正**
  * synapse list ヘルプキーバインド表示を調整

<!-- end of auto-generated comment: release notes by coderabbit.ai -->