### PR TITLE
fix: port availability check and tmux pane title persistence

### DIFF
--- a/synapse/port_manager.py
+++ b/synapse/port_manager.py
@@ -56,8 +56,7 @@ def is_port_available(port: int) -> bool:
     """
     try:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            s.bind(("localhost", port))
+            s.bind(("0.0.0.0", port))
             return True
     except OSError:
         return False

--- a/synapse/terminal_jump.py
+++ b/synapse/terminal_jump.py
@@ -752,6 +752,8 @@ def create_tmux_panes(
     # Use window-level option to avoid affecting other tmux sessions.
     commands.append("tmux set-option -q pane-border-status top")
     commands.append('tmux set-option -q pane-border-format "#{pane_title}"')
+    # Prevent spawned processes from overwriting pane titles via OSC escapes.
+    commands.append("tmux set-option -q allow-rename off")
 
     # For "auto" layout, use spawn zone tiling:
     # - First spawn (no SYNAPSE_SPAWN_PANES): split current pane with -h


### PR DESCRIPTION
## Summary
- Fix Errno 48 "address already in use": `is_port_available()` was checking `localhost` but server binds to `0.0.0.0`
- Fix tmux pane titles showing `python:3.13` instead of `synapse(agent)`: add `allow-rename off` to prevent OSC escape overwrite
- Remove `SO_REUSEADDR` from port check which caused false positives

## Test plan
- [x] 66 related tests pass (`pytest -k "tmux or port_manager"`)
- [ ] Manual: start agent, verify no Errno 48 on port reuse
- [ ] Manual: verify tmux pane shows `synapse(claude)` not `python:3.13`

🤖 Generated with [Claude Code](https://claude.com/claude-code)