### PR TITLE
fix: unset CLAUDECODE env var in controller launch path

### DIFF
--- a/synapse/controller.py
+++ b/synapse/controller.py
@@ -1178,6 +1178,10 @@ class TerminalController:
         # pty.spawn() inherits current environment, so update os.environ
         # to pass SYNAPSE_* vars to child process for sender identification
         os.environ.update(self.env)
+        # Remove CLAUDECODE from os.environ to prevent nested-session detection.
+        # self.env already has it popped, but os.environ may still carry it
+        # from the parent process.
+        os.environ.pop("CLAUDECODE", None)
 
         if use_input_callback:
             pty.spawn(cmd_list, read_callback, input_callback)


### PR DESCRIPTION
## Summary
- Unset `CLAUDECODE` environment variable in `TerminalController.__init__()` to prevent Claude Code's nested-session detection error
- `terminal_jump.py` (spawn path) already handled this via `env -u CLAUDECODE` (PR #238), but the controller's direct launch path (`subprocess.Popen` / `pty.spawn`) was missing the same fix

## Context
When running `synapse claude` from within a Claude Code session, the `CLAUDECODE` env var leaks into the child process, causing:
```
Error: Claude Code cannot be launched inside another Claude Code session.
```

## Test plan
- [x] Existing `TestClaudeCodeEnvUnset` tests pass (9/9)
- [x] All controller tests pass (74/74)
- [x] ruff, ruff format, mypy all pass via pre-commit
- [ ] Manual: run `synapse claude` from within Claude Code session

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 起動時や対話モードで特定の環境変数が子プロセスに引き継がれないようにし、ネストされたセッションの発生を防止してセッション管理の安定性を改善しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->