### PR TITLE
chore: bump version to 0.15.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.5] - 2026-03-19
+
+### Added
+
+- `clean_copilot_response()` in `output_parser.py` — strips Ink TUI artifacts (spinners, box-drawing borders, status bars, input echo, re-render duplicates) from Copilot task responses
+- Sent message metadata (`_sent_message`) stored in task for input echo removal during response cleaning
+- Copilot Ctrl+S submit fallback — sends `\x13` (Ctrl+S "run command") as additional fallback when `\r` fails to trigger Ink TUI submission
+
+### Fixed
+
+- Copilot reply artifacts no longer contain TUI garbage (ANSI escapes, braille spinners, box-drawing borders, status bar text, model name fragments)
+- Copilot input confirmation: added Ctrl+S as submit fallback for Copilot CLI 1.0.7 which uses Ink's `ctrl+s run command` binding
+- Server-mode logging no longer leaks to stderr/PTY — logs redirect to `~/.synapse/logs/` to prevent corrupting agent TUI display
+- Status bar regex tightened to avoid greedily consuming response text on the same line
+
 ## [0.15.4] - 2026-03-19
 
 ### Added
@@ -54,22 +69,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Name prompt placeholder: `Name [Enter = claude-agent]:` — auto-generates a suggested petname via `suggest_petname_ids()`, accepted with Enter
 - Save ID prompt placeholder: `Saved agent ID [Enter = alice-reviewer]:` — suggests a petname based on name, role, skill set, and profile
-- `clean_copilot_response()` in `output_parser.py` — strips Ink TUI artifacts (spinners, box-drawing borders, status bars, input echo, re-render duplicates) from Copilot task responses
-- Sent message metadata (`_sent_message`) stored in task for input echo removal during response cleaning
-- Copilot Ctrl+S submit fallback — sends `\x13` (Ctrl+S "run command") as additional fallback when `\r` fails to trigger Ink TUI submission
-
 ### Changed
 
 - Canvas menu: "Admin" renamed to "Agent Control" for clarity
 - Canvas sidebar: "Agent Control" moved before "System" in menu order
 - Extracted `_input_with_default()` helper to deduplicate prompt-with-default logic
-
-### Fixed
-
-- Copilot reply artifacts no longer contain TUI garbage (ANSI escapes, braille spinners, box-drawing borders, status bar text, model name fragments)
-- Copilot input confirmation: added Ctrl+S as submit fallback for Copilot CLI 1.0.7 which uses Ink's `ctrl+s run command` binding
-- Server-mode logging no longer leaks to stderr/PTY — logs redirect to `~/.synapse/logs/` to prevent corrupting agent TUI display
-- Status bar regex tightened to avoid greedily consuming response text on the same line
 
 ## [0.15.1] - 2026-03-17
 
@@ -2507,6 +2511,7 @@ See v0.3.14 for reply PTY injection, CURRENT column, and history default changes
 - External agent connectivity vision document
 - PyPI publishing instructions
 
+[0.15.5]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.15.4...v0.15.5
 [0.15.4]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.15.3...v0.15.4
 [0.15.3]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.15.2...v0.15.3
 [0.15.2]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.15.1...v0.15.2

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ site_url: https://s-hiraoku.github.io/synapse-a2a/
 site_description: Multi-agent collaboration framework using Google A2A Protocol
 site_author: s-hiraoku
 repo_url: https://github.com/s-hiraoku/synapse-a2a
-repo_name: s-hiraoku/synapse-a2a v0.15.4
+repo_name: s-hiraoku/synapse-a2a v0.15.5
 docs_dir: site-docs
 
 theme:

--- a/plugins/synapse-a2a/.claude-plugin/plugin.json
+++ b/plugins/synapse-a2a/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synapse-a2a",
-  "version": "0.15.4",
+  "version": "0.15.5",
   "description": "Complete plugin for Synapse A2A multi-agent framework including inter-agent communication, file safety, and history management",
   "author": {
     "name": "s-hiraoku",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synapse-a2a"
-version = "0.15.4"
+version = "0.15.5"
 description = "Agent-to-Agent communication protocol for CLI agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/site-docs/changelog.md
+++ b/site-docs/changelog.md
@@ -4,6 +4,13 @@ For the complete changelog, see [CHANGELOG.md on GitHub](https://github.com/s-hi
 
 ## Recent Highlights
 
+### v0.15.5
+
+- **Added**: `clean_copilot_response()` — strips Ink TUI artifacts (spinners, borders, status bars, input echo) from Copilot reply artifacts
+- **Added**: Copilot Ctrl+S submit fallback for Copilot CLI 1.0.7 Ink TUI
+- **Fixed**: Copilot reply artifacts no longer contain TUI garbage
+- **Fixed**: Server-mode logging no longer leaks to PTY — redirected to `~/.synapse/logs/`
+
 ### v0.15.4
 
 - **Added**: Auto-spawn support for workflow run — agents spawned on demand when not running
@@ -20,11 +27,7 @@ For the complete changelog, see [CHANGELOG.md on GitHub](https://github.com/s-hi
 
 - **Added**: Name prompt placeholder — auto-suggests a petname (e.g., `Name [Enter = claude-agent]:`)
 - **Added**: Save ID prompt placeholder — suggests petname based on agent context
-- **Added**: `clean_copilot_response()` — strips Ink TUI artifacts (spinners, borders, status bars, input echo) from Copilot reply artifacts
-- **Added**: Copilot Ctrl+S submit fallback for Copilot CLI 1.0.7 Ink TUI
 - **Changed**: Canvas menu "Admin" renamed to "Agent Control", reordered before System
-- **Fixed**: Copilot reply artifacts no longer contain TUI garbage (ANSI escapes, braille spinners, box-drawing borders)
-- **Fixed**: Server-mode logging no longer leaks to PTY — redirected to `~/.synapse/logs/`
 
 ### v0.15.1
 

--- a/site-docs/concepts/a2a-protocol.md
+++ b/site-docs/concepts/a2a-protocol.md
@@ -17,7 +17,7 @@ Every A2A agent publishes a discovery document at `/.well-known/agent.json`:
   "name": "synapse-claude-8100",
   "description": "Claude Code agent managed by Synapse A2A",
   "url": "http://localhost:8100",
-  "version": "0.15.4",
+  "version": "0.15.5",
   "capabilities": {
     "streaming": false,
     "pushNotifications": false

--- a/site-docs/getting-started/installation.md
+++ b/site-docs/getting-started/installation.md
@@ -58,7 +58,7 @@
 synapse --version
 ```
 
-You should see the version number (e.g., `0.15.4`).
+You should see the version number (e.g., `0.15.5`).
 
 ## Initialize Configuration
 


### PR DESCRIPTION
## Summary

- Bump version 0.15.4 → 0.15.5
- Add v0.15.5 CHANGELOG entry with Copilot fixes from PR #420
- Update site-docs version references

## Changes included in v0.15.5

- **Added**: `clean_copilot_response()` — Copilot TUI artifact cleaning
- **Added**: Copilot Ctrl+S submit fallback
- **Fixed**: Copilot reply TUI garbage removal
- **Fixed**: Server-mode logging PTY leak suppression

## Test plan

- [x] `pytest` passes (3323 tests)
- [x] Version strings consistent across all files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## v0.15.5 リリースノート

* **新機能**
  * Copilot レスポンスから TUI アーティファクトを削除する機能を追加
  * Copilot の送信フォールバック機能を追加

* **バグ修正**
  * Copilot レスポンスのアーティファクト クリーンアップを改善
  * サーバーモードのログリダイレクションを修正
  * ステータスバーの正規表現をより厳密に調整

<!-- end of auto-generated comment: release notes by coderabbit.ai -->