### PR TITLE
fix: support non-interactive agent listing and release 0.15.8

### DIFF
--- a/.agents/skills/synapse-a2a/SKILL.md
+++ b/.agents/skills/synapse-a2a/SKILL.md
@@ -8,7 +8,9 @@ description: >-
   managing the task board with synapse tasks, sharing knowledge with
   synapse memory, locking files with synapse file-safety, checking
   agent status with synapse list/status, or orchestrating any
-  multi-agent workflow.
+  multi-agent workflow. For AI/programmatic use, prefer `synapse list --json`,
+  `synapse status <target> --json`, or the MCP `list_agents` tool instead of
+  interactive `synapse list`.
 ---
 
 # Synapse A2A Communication
@@ -19,7 +21,7 @@ Inter-agent communication framework via Google A2A Protocol.
 
 | Task | Command |
 |------|---------|
-| List agents | `synapse list` (auto-refresh, interactive: arrows/1-9 select, Enter jump, k kill, / filter; `--json` for machine-readable output). MCP alternative: `list_agents` tool (via `tools/call`) |
+| List agents | `synapse list` for humans (auto-refresh, interactive: arrows/1-9 select, Enter jump, k kill, / filter). For AI/scripts use `synapse list --json`, `synapse list --plain`, or MCP `list_agents` |
 | Agent detail | `synapse status <target> [--json]` |
 | Send message | `synapse send <target> "<msg>"` (default: `--notify`; `--from` auto-detected) |
 | Send with task | `synapse send <target> "<msg>" --task` / `-T` (auto-creates board task, auto-claim on receive, auto-complete on finalize) |
@@ -71,7 +73,7 @@ Evaluate collaboration opportunities before starting work:
 | Discovered a pattern | Share: `synapse memory save <key> "<pattern>" --tags ... --notify` |
 
 **Mandatory Collaboration Gate** (3+ phases OR 10+ file changes):
-1. `synapse list` — check available agents
+1. `synapse list --json` or MCP `list_agents` — check available agents
 2. `synapse memory search "<topic>"` — check shared knowledge
 3. `synapse tasks create` — register work on the task board
 4. Build Agent Assignment Plan (Phase / Agent / Rationale)
@@ -182,7 +184,7 @@ Common defaults:
 | Single focused subtask | Spawn 1 agent |
 | N independent subtasks | Spawn N agents |
 
-**Spawn lifecycle**: spawn → confirm in `synapse list` → wait for READY → send task → evaluate result → kill → confirm cleanup in `synapse list`
+**Spawn lifecycle**: spawn → confirm in `synapse list --json` or `synapse status <target> --json` → wait for READY → send task → evaluate result → kill → confirm cleanup in `synapse list --json`
 
 Killing spawned agents after completion frees ports, memory, and PTY sessions,
 and prevents orphaned agents from accidentally accepting future tasks.
@@ -190,15 +192,15 @@ and prevents orphaned agents from accidentally accepting future tasks.
 ```bash
 # Spawn, delegate, verify, cleanup
 synapse spawn gemini --name Tester --role "test writer" -- --approval-mode=yolo
-synapse list                              # Verify agent appears
+synapse list --json                       # Verify agent appears (AI-safe)
 # Wait for readiness (or rely on server-side Readiness Gate)
 synapse send Tester "Write tests for src/auth.py" --wait
 # Evaluate result, then cleanup
 synapse kill Tester -f
-synapse list                              # Verify cleanup
+synapse list --json                       # Verify cleanup (AI-safe)
 ```
 
-If `synapse kill` fails or the agent still appears in `synapse list`, retry with `-f`,
+If `synapse kill` fails or the agent still appears in `synapse list --json`, retry with `-f`,
 check the agent status/logs, and report the cleanup failure instead of leaving an
 orphaned agent behind.
 

--- a/.agents/skills/synapse-a2a/references/commands.md
+++ b/.agents/skills/synapse-a2a/references/commands.md
@@ -8,9 +8,14 @@
 # Show all running agents (Rich TUI with auto-refresh on changes)
 synapse list
 
+# Force one-shot plain text even on a TTY
+synapse list --plain
+
 # Output agent list as JSON array (machine-readable, no TUI)
 synapse list --json
 ```
+
+**AI / automation rule:** Do not use bare `synapse list` for agent discovery from an AI-controlled TTY. Use `synapse list --json`, `synapse list --plain`, `synapse status <target> --json`, or the MCP `list_agents` tool.
 
 **Rich TUI Features:**
 - Auto-refresh when agent status changes (via file watcher)
@@ -52,8 +57,10 @@ synapse list --json
   - `UDS→` / `TCP→`: Sending via UDS/TCP
   - `→UDS` / `→TCP`: Receiving via UDS/TCP
   - `-`: No active communication
-- **WORKING_DIR**: Working directory (truncated in TUI, full path in detail panel). Also included in non-TTY text output for scripting (e.g., `synapse list | grep my-project`).
+- **WORKING_DIR**: Working directory (truncated in TUI, full path in detail panel). Also included in plain-text output for scripting (e.g., `synapse list --plain | grep my-project`).
 - **EDITING FILE** (when File Safety enabled): Currently locked file name
+
+**Plain Output:** `synapse list --plain` forces single-shot text output without entering the Rich TUI, even when stdout is a TTY. `SYNAPSE_NONINTERACTIVE=1` provides the same behavior for automation wrappers.
 
 **JSON Output:** `synapse list --json` outputs a JSON array of agent objects (fields: `agent_id`, `agent_type`, `name`, `role`, `skill_set`, `port`, `status`, `pid`, `working_dir`, `endpoint`, `transport`, `current_task_preview`, `task_received_at`, optionally `editing_file`).
 

--- a/.agents/skills/synapse-a2a/references/examples.md
+++ b/.agents/skills/synapse-a2a/references/examples.md
@@ -287,14 +287,14 @@ Spawn creates child agents for sub-task delegation — preserving context, paral
 
 #### Waiting for Readiness
 
-`synapse list` is a point-in-time snapshot. After spawning, poll until the agent shows `STATUS=READY`.
+For automation, prefer `synapse status <target> --json` after spawning and poll until the agent shows `STATUS=READY`.
 
-**Note:** Even without polling, the server-side **Readiness Gate** blocks `/tasks/send` requests until the agent finishes initialization. If the agent is not ready within 30 seconds (`AGENT_READY_TIMEOUT`), the API returns HTTP 503 with `Retry-After: 5`. Priority 5 messages and replies bypass this gate. Polling with `synapse list` remains useful for confirming readiness before sending non-urgent messages.
+**Note:** Even without polling, the server-side **Readiness Gate** blocks `/tasks/send` requests until the agent finishes initialization. If the agent is not ready within 30 seconds (`AGENT_READY_TIMEOUT`), the API returns HTTP 503 with `Retry-After: 5`. Priority 5 messages and replies bypass this gate. Human operators can still use `synapse list` interactively.
 
 ```bash
 # Poll until agent is ready (timeout after 30s)
 elapsed=0
-while ! synapse list | grep -q "Tester.*READY"; do
+while ! synapse status Tester --json 2>/dev/null | grep -Eq '"status"[[:space:]]*:[[:space:]]*"READY"'; do
   sleep 1
   elapsed=$((elapsed + 1))
   if [ "$elapsed" -ge 30 ]; then
@@ -310,8 +310,11 @@ For Pattern 3 (multiple agents), wait for all of them:
 # Poll until BOTH agents are ready (single snapshot per iteration)
 elapsed=0
 while true; do
-  snapshot=$(synapse list)
-  echo "$snapshot" | grep -q "Tester.*READY" && echo "$snapshot" | grep -q "Fixer.*READY" && break
+  tester=$(synapse status Tester --json 2>/dev/null || true)
+  fixer=$(synapse status Fixer --json 2>/dev/null || true)
+  echo "$tester" | grep -Eq '"status"[[:space:]]*:[[:space:]]*"READY"' \
+    && echo "$fixer" | grep -Eq '"status"[[:space:]]*:[[:space:]]*"READY"' \
+    && break
   sleep 1
   elapsed=$((elapsed + 1))
   if [ "$elapsed" -ge 30 ]; then

--- a/.agents/skills/synapse-a2a/references/messaging.md
+++ b/.agents/skills/synapse-a2a/references/messaging.md
@@ -221,10 +221,10 @@ Status transitions rely on multiple signals beyond PTY output patterns, reducing
 
 ### Checking Status Before Sending
 
-Run `synapse list` and confirm the target shows `READY`. Also check WORKING_DIR to avoid the working directory mismatch warning:
+For human operators, run `synapse list` and confirm the target shows `READY`. For AI/scripts, use `synapse list --json` or `synapse status <target> --json`. Also check WORKING_DIR to avoid the working directory mismatch warning:
 
 ```bash
-synapse list
+synapse list --json
 # NAME        TYPE    STATUS      PORT   CURRENT              WORKING_DIR
 # my-claude   claude  READY       8100   -                    my-project
 # gemini      gemini  PROCESSING  8110   Review code (1m 5s)  my-project
@@ -253,7 +253,7 @@ Messages sent to an agent that has not yet reached READY for the first time are 
 
 ## Interactive Controls
 
-`synapse list` provides keyboard-driven agent management:
+For humans, `synapse list` provides keyboard-driven agent management:
 
 | Key | Action |
 |-----|--------|

--- a/.agents/skills/synapse-a2a/references/spawning.md
+++ b/.agents/skills/synapse-a2a/references/spawning.md
@@ -56,9 +56,9 @@ Parent receives task
 # 1. Spawn a helper
 synapse spawn gemini --name Tester --role "test writer"
 
-# 2. Poll for readiness (synapse list is a point-in-time snapshot, so poll until READY)
+# 2. Poll for readiness (AI-safe: use status JSON until READY)
 elapsed=0
-while ! synapse list | grep -q "Tester.*READY"; do
+while ! synapse status Tester --json 2>/dev/null | grep -Eq '"status"[[:space:]]*:[[:space:]]*"READY"'; do
   sleep 1; elapsed=$((elapsed + 1))
   [ "$elapsed" -ge 30 ] && echo "ERROR: Tester not READY after ${elapsed}s" >&2 && exit 1
 done
@@ -91,7 +91,7 @@ Killing spawned agents after completion frees ports, memory, and PTY sessions, a
 
 ```bash
 synapse kill <spawned-agent-name> -f
-synapse list  # Verify the agent is gone
+synapse list --json  # Verify the agent is gone
 ```
 
 ## Automation Args (per CLI)

--- a/.agents/skills/synapse-manager/SKILL.md
+++ b/.agents/skills/synapse-manager/SKILL.md
@@ -49,7 +49,7 @@ blocking, and completion state are visible to the whole team.
 **Check existing agents before spawning** — reuse is faster (avoids startup overhead,
 instruction injection, and readiness wait):
 ```bash
-synapse list
+synapse list --json
 ```
 
 Review WORKING_DIR, ROLE, STATUS, TYPE. Only READY agents can accept work immediately.
@@ -140,7 +140,7 @@ synapse send Impl "Implement auth module" --task --attach synapse/server.py --fo
 ```
 
 ```bash
-synapse list                              # Live status (auto-updates)
+synapse list --json                       # AI-safe snapshot
 synapse tasks list                        # Task board progress and dependencies
 synapse history list --agent Impl         # Completed work
 ```
@@ -252,7 +252,7 @@ synapse tasks list                        # Confirm the UUID prefixes before com
 synapse tasks complete "$TESTS_ID"
 synapse tasks complete "$IMPL_ID"
 synapse kill Impl -f && synapse kill Tester -f
-synapse list                              # Verify cleanup
+synapse list --json                       # Verify cleanup
 synapse tasks purge --status completed    # Clean up finished tasks
 synapse tasks purge --older-than 7d      # Clean up old tasks
 synapse tasks purge --dry-run            # Preview what would be deleted

--- a/.agents/skills/synapse-manager/scripts/check_team_status.sh
+++ b/.agents/skills/synapse-manager/scripts/check_team_status.sh
@@ -9,7 +9,7 @@ if ! command -v synapse >/dev/null 2>&1; then
 fi
 
 echo "=== Agent Status ==="
-if list_output=$(synapse list 2>&1); then
+if list_output=$(synapse list --plain 2>&1); then
   if printf '%s\n' "$list_output" | grep -q "No agents running."; then
     echo "No agents are currently running."
   else
@@ -17,7 +17,7 @@ if list_output=$(synapse list 2>&1); then
   fi
 else
   list_status=$?
-  echo "synapse list failed: $list_output" >&2
+  echo "synapse list --plain failed: $list_output" >&2
   exit "$list_status"
 fi
 

--- a/.claude/skills/synapse-a2a/SKILL.md
+++ b/.claude/skills/synapse-a2a/SKILL.md
@@ -8,7 +8,9 @@ description: >-
   managing the task board with synapse tasks, sharing knowledge with
   synapse memory, locking files with synapse file-safety, checking
   agent status with synapse list/status, or orchestrating any
-  multi-agent workflow.
+  multi-agent workflow. For AI/programmatic use, prefer `synapse list --json`,
+  `synapse status <target> --json`, or the MCP `list_agents` tool instead of
+  interactive `synapse list`.
 ---
 
 # Synapse A2A Communication
@@ -19,7 +21,7 @@ Inter-agent communication framework via Google A2A Protocol.
 
 | Task | Command |
 |------|---------|
-| List agents | `synapse list` (auto-refresh, interactive: arrows/1-9 select, Enter jump, k kill, / filter; `--json` for machine-readable output). MCP alternative: `list_agents` tool (via `tools/call`) |
+| List agents | `synapse list` for humans (auto-refresh, interactive: arrows/1-9 select, Enter jump, k kill, / filter). For AI/scripts use `synapse list --json`, `synapse list --plain`, or MCP `list_agents` |
 | Agent detail | `synapse status <target> [--json]` |
 | Send message | `synapse send <target> "<msg>"` (default: `--notify`; `--from` auto-detected) |
 | Send with task | `synapse send <target> "<msg>" --task` / `-T` (auto-creates board task, auto-claim on receive, auto-complete on finalize) |
@@ -71,7 +73,7 @@ Evaluate collaboration opportunities before starting work:
 | Discovered a pattern | Share: `synapse memory save <key> "<pattern>" --tags ... --notify` |
 
 **Mandatory Collaboration Gate** (3+ phases OR 10+ file changes):
-1. `synapse list` — check available agents
+1. `synapse list --json` or MCP `list_agents` — check available agents
 2. `synapse memory search "<topic>"` — check shared knowledge
 3. `synapse tasks create` — register work on the task board
 4. Build Agent Assignment Plan (Phase / Agent / Rationale)
@@ -182,7 +184,7 @@ Common defaults:
 | Single focused subtask | Spawn 1 agent |
 | N independent subtasks | Spawn N agents |
 
-**Spawn lifecycle**: spawn → confirm in `synapse list` → wait for READY → send task → evaluate result → kill → confirm cleanup in `synapse list`
+**Spawn lifecycle**: spawn → confirm in `synapse list --json` or `synapse status <target> --json` → wait for READY → send task → evaluate result → kill → confirm cleanup in `synapse list --json`
 
 Killing spawned agents after completion frees ports, memory, and PTY sessions,
 and prevents orphaned agents from accidentally accepting future tasks.
@@ -190,15 +192,15 @@ and prevents orphaned agents from accidentally accepting future tasks.
 ```bash
 # Spawn, delegate, verify, cleanup
 synapse spawn gemini --name Tester --role "test writer" -- --approval-mode=yolo
-synapse list                              # Verify agent appears
+synapse list --json                       # Verify agent appears (AI-safe)
 # Wait for readiness (or rely on server-side Readiness Gate)
 synapse send Tester "Write tests for src/auth.py" --wait
 # Evaluate result, then cleanup
 synapse kill Tester -f
-synapse list                              # Verify cleanup
+synapse list --json                       # Verify cleanup (AI-safe)
 ```
 
-If `synapse kill` fails or the agent still appears in `synapse list`, retry with `-f`,
+If `synapse kill` fails or the agent still appears in `synapse list --json`, retry with `-f`,
 check the agent status/logs, and report the cleanup failure instead of leaving an
 orphaned agent behind.
 

--- a/.claude/skills/synapse-a2a/references/commands.md
+++ b/.claude/skills/synapse-a2a/references/commands.md
@@ -8,9 +8,14 @@
 # Show all running agents (Rich TUI with auto-refresh on changes)
 synapse list
 
+# Force one-shot plain text even on a TTY
+synapse list --plain
+
 # Output agent list as JSON array (machine-readable, no TUI)
 synapse list --json
 ```
+
+**AI / automation rule:** Do not use bare `synapse list` for agent discovery from an AI-controlled TTY. Use `synapse list --json`, `synapse list --plain`, `synapse status <target> --json`, or the MCP `list_agents` tool.
 
 **Rich TUI Features:**
 - Auto-refresh when agent status changes (via file watcher)
@@ -52,8 +57,10 @@ synapse list --json
   - `UDS→` / `TCP→`: Sending via UDS/TCP
   - `→UDS` / `→TCP`: Receiving via UDS/TCP
   - `-`: No active communication
-- **WORKING_DIR**: Working directory (truncated in TUI, full path in detail panel). Also included in non-TTY text output for scripting (e.g., `synapse list | grep my-project`).
+- **WORKING_DIR**: Working directory (truncated in TUI, full path in detail panel). Also included in plain-text output for scripting (e.g., `synapse list --plain | grep my-project`).
 - **EDITING FILE** (when File Safety enabled): Currently locked file name
+
+**Plain Output:** `synapse list --plain` forces single-shot text output without entering the Rich TUI, even when stdout is a TTY. `SYNAPSE_NONINTERACTIVE=1` provides the same behavior for automation wrappers.
 
 **JSON Output:** `synapse list --json` outputs a JSON array of agent objects (fields: `agent_id`, `agent_type`, `name`, `role`, `skill_set`, `port`, `status`, `pid`, `working_dir`, `endpoint`, `transport`, `current_task_preview`, `task_received_at`, optionally `editing_file`).
 

--- a/.claude/skills/synapse-a2a/references/examples.md
+++ b/.claude/skills/synapse-a2a/references/examples.md
@@ -287,14 +287,14 @@ Spawn creates child agents for sub-task delegation — preserving context, paral
 
 #### Waiting for Readiness
 
-`synapse list` is a point-in-time snapshot. After spawning, poll until the agent shows `STATUS=READY`.
+For automation, prefer `synapse status <target> --json` after spawning and poll until the agent shows `STATUS=READY`.
 
-**Note:** Even without polling, the server-side **Readiness Gate** blocks `/tasks/send` requests until the agent finishes initialization. If the agent is not ready within 30 seconds (`AGENT_READY_TIMEOUT`), the API returns HTTP 503 with `Retry-After: 5`. Priority 5 messages and replies bypass this gate. Polling with `synapse list` remains useful for confirming readiness before sending non-urgent messages.
+**Note:** Even without polling, the server-side **Readiness Gate** blocks `/tasks/send` requests until the agent finishes initialization. If the agent is not ready within 30 seconds (`AGENT_READY_TIMEOUT`), the API returns HTTP 503 with `Retry-After: 5`. Priority 5 messages and replies bypass this gate. Human operators can still use `synapse list` interactively.
 
 ```bash
 # Poll until agent is ready (timeout after 30s)
 elapsed=0
-while ! synapse list | grep -q "Tester.*READY"; do
+while ! synapse status Tester --json 2>/dev/null | grep -Eq '"status"[[:space:]]*:[[:space:]]*"READY"'; do
   sleep 1
   elapsed=$((elapsed + 1))
   if [ "$elapsed" -ge 30 ]; then
@@ -310,8 +310,11 @@ For Pattern 3 (multiple agents), wait for all of them:
 # Poll until BOTH agents are ready (single snapshot per iteration)
 elapsed=0
 while true; do
-  snapshot=$(synapse list)
-  echo "$snapshot" | grep -q "Tester.*READY" && echo "$snapshot" | grep -q "Fixer.*READY" && break
+  tester=$(synapse status Tester --json 2>/dev/null || true)
+  fixer=$(synapse status Fixer --json 2>/dev/null || true)
+  echo "$tester" | grep -Eq '"status"[[:space:]]*:[[:space:]]*"READY"' \
+    && echo "$fixer" | grep -Eq '"status"[[:space:]]*:[[:space:]]*"READY"' \
+    && break
   sleep 1
   elapsed=$((elapsed + 1))
   if [ "$elapsed" -ge 30 ]; then

--- a/.claude/skills/synapse-a2a/references/messaging.md
+++ b/.claude/skills/synapse-a2a/references/messaging.md
@@ -221,10 +221,10 @@ Status transitions rely on multiple signals beyond PTY output patterns, reducing
 
 ### Checking Status Before Sending
 
-Run `synapse list` and confirm the target shows `READY`. Also check WORKING_DIR to avoid the working directory mismatch warning:
+For human operators, run `synapse list` and confirm the target shows `READY`. For AI/scripts, use `synapse list --json` or `synapse status <target> --json`. Also check WORKING_DIR to avoid the working directory mismatch warning:
 
 ```bash
-synapse list
+synapse list --json
 # NAME        TYPE    STATUS      PORT   CURRENT              WORKING_DIR
 # my-claude   claude  READY       8100   -                    my-project
 # gemini      gemini  PROCESSING  8110   Review code (1m 5s)  my-project
@@ -253,7 +253,7 @@ Messages sent to an agent that has not yet reached READY for the first time are 
 
 ## Interactive Controls
 
-`synapse list` provides keyboard-driven agent management:
+For humans, `synapse list` provides keyboard-driven agent management:
 
 | Key | Action |
 |-----|--------|

--- a/.claude/skills/synapse-a2a/references/spawning.md
+++ b/.claude/skills/synapse-a2a/references/spawning.md
@@ -56,9 +56,9 @@ Parent receives task
 # 1. Spawn a helper
 synapse spawn gemini --name Tester --role "test writer"
 
-# 2. Poll for readiness (synapse list is a point-in-time snapshot, so poll until READY)
+# 2. Poll for readiness (AI-safe: use status JSON until READY)
 elapsed=0
-while ! synapse list | grep -q "Tester.*READY"; do
+while ! synapse status Tester --json 2>/dev/null | grep -Eq '"status"[[:space:]]*:[[:space:]]*"READY"'; do
   sleep 1; elapsed=$((elapsed + 1))
   [ "$elapsed" -ge 30 ] && echo "ERROR: Tester not READY after ${elapsed}s" >&2 && exit 1
 done
@@ -91,7 +91,7 @@ Killing spawned agents after completion frees ports, memory, and PTY sessions, a
 
 ```bash
 synapse kill <spawned-agent-name> -f
-synapse list  # Verify the agent is gone
+synapse list --json  # Verify the agent is gone
 ```
 
 ## Automation Args (per CLI)

--- a/.claude/skills/synapse-manager/SKILL.md
+++ b/.claude/skills/synapse-manager/SKILL.md
@@ -49,7 +49,7 @@ blocking, and completion state are visible to the whole team.
 **Check existing agents before spawning** — reuse is faster (avoids startup overhead,
 instruction injection, and readiness wait):
 ```bash
-synapse list
+synapse list --json
 ```
 
 Review WORKING_DIR, ROLE, STATUS, TYPE. Only READY agents can accept work immediately.
@@ -140,7 +140,7 @@ synapse send Impl "Implement auth module" --task --attach synapse/server.py --fo
 ```
 
 ```bash
-synapse list                              # Live status (auto-updates)
+synapse list --json                       # AI-safe snapshot
 synapse tasks list                        # Task board progress and dependencies
 synapse history list --agent Impl         # Completed work
 ```
@@ -252,7 +252,7 @@ synapse tasks list                        # Confirm the UUID prefixes before com
 synapse tasks complete "$TESTS_ID"
 synapse tasks complete "$IMPL_ID"
 synapse kill Impl -f && synapse kill Tester -f
-synapse list                              # Verify cleanup
+synapse list --json                       # Verify cleanup
 synapse tasks purge --status completed    # Clean up finished tasks
 synapse tasks purge --older-than 7d      # Clean up old tasks
 synapse tasks purge --dry-run            # Preview what would be deleted

--- a/.claude/skills/synapse-manager/scripts/check_team_status.sh
+++ b/.claude/skills/synapse-manager/scripts/check_team_status.sh
@@ -9,7 +9,7 @@ if ! command -v synapse >/dev/null 2>&1; then
 fi
 
 echo "=== Agent Status ==="
-if list_output=$(synapse list 2>&1); then
+if list_output=$(synapse list --plain 2>&1); then
   if printf '%s\n' "$list_output" | grep -q "No agents running."; then
     echo "No agents are currently running."
   else
@@ -17,7 +17,7 @@ if list_output=$(synapse list 2>&1); then
   fi
 else
   list_status=$?
-  echo "synapse list failed: $list_output" >&2
+  echo "synapse list --plain failed: $list_output" >&2
   exit "$list_status"
 fi
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ uv sync                                    # Install dependencies
 pytest                                     # Run all tests
 pytest tests/test_<area>.py -v             # Run specific tests
 synapse <profile>                          # Start agent (claude, gemini, codex, opencode, copilot)
-synapse list                               # List running agents
+synapse list --json                        # List running agents for AI/programmatic use
 synapse send <target> "message" --wait     # Send message (synchronous)
 synapse send <target> "message" --silent   # Send message (fire-and-forget)
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.15.7] - 2026-03-20
 
+## [0.15.8] - 2026-03-20
+
+### Added
+
+- `synapse list --plain` for one-shot plain-text agent listings without entering the Rich TUI
+
+### Fixed
+
+- `synapse list` can now be forced into non-interactive mode with `SYNAPSE_NONINTERACTIVE=1`, so AI-controlled TTY sessions no longer hang in the interactive list UI
+
+### Documentation
+
+- Updated AI-facing guidance, plugin skills, and site docs to use `synapse list --json`, `synapse list --plain`, `synapse status <target> --json`, or MCP `list_agents` instead of bare `synapse list`
+
 ### Changed
 
 - Copilot now types short single-line messages instead of pasting them, prefers `Ctrl+S` when the footer advertises `ctrl+s run command`, and continues through submit retries as needed
@@ -2540,7 +2554,8 @@ See v0.3.14 for reply PTY injection, CURRENT column, and history default changes
 - External agent connectivity vision document
 - PyPI publishing instructions
 
-[Unreleased]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.15.7...HEAD
+[Unreleased]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.15.8...HEAD
+[0.15.8]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.15.7...v0.15.8
 [0.15.7]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.15.6...v0.15.7
 [0.15.6]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.15.5...v0.15.6
 [0.15.5]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.15.4...v0.15.5

--- a/README.md
+++ b/README.md
@@ -685,6 +685,7 @@ Save this agent definition for reuse? [y/N]:
 | `synapse rename <target>` | Assign name/role to agent |
 | `synapse --version` | Show version |
 | `synapse list` | List running agents (Rich TUI with auto-refresh and terminal jump) |
+| `synapse list --plain` | Force one-shot plain-text output without entering the TUI |
 | `synapse list --json` | Output agent list as JSON array (for AI/programmatic consumption) |
 | `synapse status <target>` | Show detailed agent status (info, current task, history, file locks, task board). Supports `--json` |
 | `synapse logs <profile>` | Show logs |
@@ -1511,6 +1512,8 @@ The display automatically updates when agent status changes (via file watcher) w
 ### JSON Output
 
 `synapse list --json` outputs a JSON array of agent objects for AI and scripting use. Each object includes: `agent_id`, `agent_type`, `name`, `role`, `skill_set`, `port`, `status`, `pid`, `working_dir`, `endpoint`, `transport`, `current_task_preview`, `task_received_at`, and optionally `editing_file`.
+
+If automation is attached to a TTY, use `synapse list --json`, `synapse list --plain`, or set `SYNAPSE_NONINTERACTIVE=1`. Bare `synapse list` is intended for human-operated interactive terminals.
 
 ### Display Columns
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ site_url: https://s-hiraoku.github.io/synapse-a2a/
 site_description: Multi-agent collaboration framework using Google A2A Protocol
 site_author: s-hiraoku
 repo_url: https://github.com/s-hiraoku/synapse-a2a
-repo_name: s-hiraoku/synapse-a2a v0.15.7
+repo_name: s-hiraoku/synapse-a2a v0.15.8
 docs_dir: site-docs
 
 theme:

--- a/plugins/synapse-a2a/.claude-plugin/plugin.json
+++ b/plugins/synapse-a2a/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synapse-a2a",
-  "version": "0.15.7",
+  "version": "0.15.8",
   "description": "Complete plugin for Synapse A2A multi-agent framework including inter-agent communication, file safety, and history management",
   "author": {
     "name": "s-hiraoku",

--- a/plugins/synapse-a2a/skills/synapse-a2a/SKILL.md
+++ b/plugins/synapse-a2a/skills/synapse-a2a/SKILL.md
@@ -8,7 +8,9 @@ description: >-
   managing the task board with synapse tasks, sharing knowledge with
   synapse memory, locking files with synapse file-safety, checking
   agent status with synapse list/status, or orchestrating any
-  multi-agent workflow.
+  multi-agent workflow. For AI/programmatic use, prefer `synapse list --json`,
+  `synapse status <target> --json`, or the MCP `list_agents` tool instead of
+  interactive `synapse list`.
 ---
 
 # Synapse A2A Communication
@@ -19,7 +21,7 @@ Inter-agent communication framework via Google A2A Protocol.
 
 | Task | Command |
 |------|---------|
-| List agents | `synapse list` (auto-refresh, interactive: arrows/1-9 select, Enter jump, k kill, / filter; `--json` for machine-readable output). MCP alternative: `list_agents` tool (via `tools/call`) |
+| List agents | `synapse list` for humans (auto-refresh, interactive: arrows/1-9 select, Enter jump, k kill, / filter). For AI/scripts use `synapse list --json`, `synapse list --plain`, or MCP `list_agents` |
 | Agent detail | `synapse status <target> [--json]` |
 | Send message | `synapse send <target> "<msg>"` (default: `--notify`; `--from` auto-detected) |
 | Send with task | `synapse send <target> "<msg>" --task` / `-T` (auto-creates board task, auto-claim on receive, auto-complete on finalize) |
@@ -71,7 +73,7 @@ Evaluate collaboration opportunities before starting work:
 | Discovered a pattern | Share: `synapse memory save <key> "<pattern>" --tags ... --notify` |
 
 **Mandatory Collaboration Gate** (3+ phases OR 10+ file changes):
-1. `synapse list` — check available agents
+1. `synapse list --json` or MCP `list_agents` — check available agents
 2. `synapse memory search "<topic>"` — check shared knowledge
 3. `synapse tasks create` — register work on the task board
 4. Build Agent Assignment Plan (Phase / Agent / Rationale)
@@ -182,7 +184,7 @@ Common defaults:
 | Single focused subtask | Spawn 1 agent |
 | N independent subtasks | Spawn N agents |
 
-**Spawn lifecycle**: spawn → confirm in `synapse list` → wait for READY → send task → evaluate result → kill → confirm cleanup in `synapse list`
+**Spawn lifecycle**: spawn → confirm in `synapse list --json` or `synapse status <target> --json` → wait for READY → send task → evaluate result → kill → confirm cleanup in `synapse list --json`
 
 Killing spawned agents after completion frees ports, memory, and PTY sessions,
 and prevents orphaned agents from accidentally accepting future tasks.
@@ -190,15 +192,15 @@ and prevents orphaned agents from accidentally accepting future tasks.
 ```bash
 # Spawn, delegate, verify, cleanup
 synapse spawn gemini --name Tester --role "test writer" -- --approval-mode=yolo
-synapse list                              # Verify agent appears
+synapse list --json                       # Verify agent appears (AI-safe)
 # Wait for readiness (or rely on server-side Readiness Gate)
 synapse send Tester "Write tests for src/auth.py" --wait
 # Evaluate result, then cleanup
 synapse kill Tester -f
-synapse list                              # Verify cleanup
+synapse list --json                       # Verify cleanup (AI-safe)
 ```
 
-If `synapse kill` fails or the agent still appears in `synapse list`, retry with `-f`,
+If `synapse kill` fails or the agent still appears in `synapse list --json`, retry with `-f`,
 check the agent status/logs, and report the cleanup failure instead of leaving an
 orphaned agent behind.
 

--- a/plugins/synapse-a2a/skills/synapse-a2a/references/commands.md
+++ b/plugins/synapse-a2a/skills/synapse-a2a/references/commands.md
@@ -8,9 +8,14 @@
 # Show all running agents (Rich TUI with auto-refresh on changes)
 synapse list
 
+# Force one-shot plain text even on a TTY
+synapse list --plain
+
 # Output agent list as JSON array (machine-readable, no TUI)
 synapse list --json
 ```
+
+**AI / automation rule:** Do not use bare `synapse list` for agent discovery from an AI-controlled TTY. Use `synapse list --json`, `synapse list --plain`, `synapse status <target> --json`, or the MCP `list_agents` tool.
 
 **Rich TUI Features:**
 - Auto-refresh when agent status changes (via file watcher)
@@ -52,8 +57,10 @@ synapse list --json
   - `UDS→` / `TCP→`: Sending via UDS/TCP
   - `→UDS` / `→TCP`: Receiving via UDS/TCP
   - `-`: No active communication
-- **WORKING_DIR**: Working directory (truncated in TUI, full path in detail panel). Also included in non-TTY text output for scripting (e.g., `synapse list | grep my-project`).
+- **WORKING_DIR**: Working directory (truncated in TUI, full path in detail panel). Also included in plain-text output for scripting (e.g., `synapse list --plain | grep my-project`).
 - **EDITING FILE** (when File Safety enabled): Currently locked file name
+
+**Plain Output:** `synapse list --plain` forces single-shot text output without entering the Rich TUI, even when stdout is a TTY. `SYNAPSE_NONINTERACTIVE=1` provides the same behavior for automation wrappers.
 
 **JSON Output:** `synapse list --json` outputs a JSON array of agent objects (fields: `agent_id`, `agent_type`, `name`, `role`, `skill_set`, `port`, `status`, `pid`, `working_dir`, `endpoint`, `transport`, `current_task_preview`, `task_received_at`, optionally `editing_file`).
 

--- a/plugins/synapse-a2a/skills/synapse-a2a/references/examples.md
+++ b/plugins/synapse-a2a/skills/synapse-a2a/references/examples.md
@@ -287,14 +287,14 @@ Spawn creates child agents for sub-task delegation — preserving context, paral
 
 #### Waiting for Readiness
 
-`synapse list` is a point-in-time snapshot. After spawning, poll until the agent shows `STATUS=READY`.
+For automation, prefer `synapse status <target> --json` after spawning and poll until the agent shows `STATUS=READY`.
 
-**Note:** Even without polling, the server-side **Readiness Gate** blocks `/tasks/send` requests until the agent finishes initialization. If the agent is not ready within 30 seconds (`AGENT_READY_TIMEOUT`), the API returns HTTP 503 with `Retry-After: 5`. Priority 5 messages and replies bypass this gate. Polling with `synapse list` remains useful for confirming readiness before sending non-urgent messages.
+**Note:** Even without polling, the server-side **Readiness Gate** blocks `/tasks/send` requests until the agent finishes initialization. If the agent is not ready within 30 seconds (`AGENT_READY_TIMEOUT`), the API returns HTTP 503 with `Retry-After: 5`. Priority 5 messages and replies bypass this gate. Human operators can still use `synapse list` interactively.
 
 ```bash
 # Poll until agent is ready (timeout after 30s)
 elapsed=0
-while ! synapse list | grep -q "Tester.*READY"; do
+while ! synapse status Tester --json 2>/dev/null | grep -Eq '"status"[[:space:]]*:[[:space:]]*"READY"'; do
   sleep 1
   elapsed=$((elapsed + 1))
   if [ "$elapsed" -ge 30 ]; then
@@ -310,8 +310,11 @@ For Pattern 3 (multiple agents), wait for all of them:
 # Poll until BOTH agents are ready (single snapshot per iteration)
 elapsed=0
 while true; do
-  snapshot=$(synapse list)
-  echo "$snapshot" | grep -q "Tester.*READY" && echo "$snapshot" | grep -q "Fixer.*READY" && break
+  tester=$(synapse status Tester --json 2>/dev/null || true)
+  fixer=$(synapse status Fixer --json 2>/dev/null || true)
+  echo "$tester" | grep -Eq '"status"[[:space:]]*:[[:space:]]*"READY"' \
+    && echo "$fixer" | grep -Eq '"status"[[:space:]]*:[[:space:]]*"READY"' \
+    && break
   sleep 1
   elapsed=$((elapsed + 1))
   if [ "$elapsed" -ge 30 ]; then

--- a/plugins/synapse-a2a/skills/synapse-a2a/references/messaging.md
+++ b/plugins/synapse-a2a/skills/synapse-a2a/references/messaging.md
@@ -221,10 +221,10 @@ Status transitions rely on multiple signals beyond PTY output patterns, reducing
 
 ### Checking Status Before Sending
 
-Run `synapse list` and confirm the target shows `READY`. Also check WORKING_DIR to avoid the working directory mismatch warning:
+For human operators, run `synapse list` and confirm the target shows `READY`. For AI/scripts, use `synapse list --json` or `synapse status <target> --json`. Also check WORKING_DIR to avoid the working directory mismatch warning:
 
 ```bash
-synapse list
+synapse list --json
 # NAME        TYPE    STATUS      PORT   CURRENT              WORKING_DIR
 # my-claude   claude  READY       8100   -                    my-project
 # gemini      gemini  PROCESSING  8110   Review code (1m 5s)  my-project
@@ -253,7 +253,7 @@ Messages sent to an agent that has not yet reached READY for the first time are 
 
 ## Interactive Controls
 
-`synapse list` provides keyboard-driven agent management:
+For humans, `synapse list` provides keyboard-driven agent management:
 
 | Key | Action |
 |-----|--------|

--- a/plugins/synapse-a2a/skills/synapse-a2a/references/spawning.md
+++ b/plugins/synapse-a2a/skills/synapse-a2a/references/spawning.md
@@ -56,9 +56,9 @@ Parent receives task
 # 1. Spawn a helper
 synapse spawn gemini --name Tester --role "test writer"
 
-# 2. Poll for readiness (synapse list is a point-in-time snapshot, so poll until READY)
+# 2. Poll for readiness (AI-safe: use status JSON until READY)
 elapsed=0
-while ! synapse list | grep -q "Tester.*READY"; do
+while ! synapse status Tester --json 2>/dev/null | grep -Eq '"status"[[:space:]]*:[[:space:]]*"READY"'; do
   sleep 1; elapsed=$((elapsed + 1))
   [ "$elapsed" -ge 30 ] && echo "ERROR: Tester not READY after ${elapsed}s" >&2 && exit 1
 done
@@ -91,7 +91,7 @@ Killing spawned agents after completion frees ports, memory, and PTY sessions, a
 
 ```bash
 synapse kill <spawned-agent-name> -f
-synapse list  # Verify the agent is gone
+synapse list --json  # Verify the agent is gone
 ```
 
 ## Automation Args (per CLI)

--- a/plugins/synapse-a2a/skills/synapse-manager/SKILL.md
+++ b/plugins/synapse-a2a/skills/synapse-manager/SKILL.md
@@ -49,7 +49,7 @@ blocking, and completion state are visible to the whole team.
 **Check existing agents before spawning** — reuse is faster (avoids startup overhead,
 instruction injection, and readiness wait):
 ```bash
-synapse list
+synapse list --json
 ```
 
 Review WORKING_DIR, ROLE, STATUS, TYPE. Only READY agents can accept work immediately.
@@ -140,7 +140,7 @@ synapse send Impl "Implement auth module" --task --attach synapse/server.py --fo
 ```
 
 ```bash
-synapse list                              # Live status (auto-updates)
+synapse list --json                       # AI-safe snapshot
 synapse tasks list                        # Task board progress and dependencies
 synapse history list --agent Impl         # Completed work
 ```
@@ -252,7 +252,7 @@ synapse tasks list                        # Confirm the UUID prefixes before com
 synapse tasks complete "$TESTS_ID"
 synapse tasks complete "$IMPL_ID"
 synapse kill Impl -f && synapse kill Tester -f
-synapse list                              # Verify cleanup
+synapse list --json                       # Verify cleanup
 synapse tasks purge --status completed    # Clean up finished tasks
 synapse tasks purge --older-than 7d      # Clean up old tasks
 synapse tasks purge --dry-run            # Preview what would be deleted

--- a/plugins/synapse-a2a/skills/synapse-manager/scripts/check_team_status.sh
+++ b/plugins/synapse-a2a/skills/synapse-manager/scripts/check_team_status.sh
@@ -9,7 +9,7 @@ if ! command -v synapse >/dev/null 2>&1; then
 fi
 
 echo "=== Agent Status ==="
-if list_output=$(synapse list 2>&1); then
+if list_output=$(synapse list --plain 2>&1); then
   if printf '%s\n' "$list_output" | grep -q "No agents running."; then
     echo "No agents are currently running."
   else
@@ -17,7 +17,7 @@ if list_output=$(synapse list 2>&1); then
   fi
 else
   list_status=$?
-  echo "synapse list failed: $list_output" >&2
+  echo "synapse list --plain failed: $list_output" >&2
   exit "$list_status"
 fi
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synapse-a2a"
-version = "0.15.7"
+version = "0.15.8"
 description = "Agent-to-Agent communication protocol for CLI agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/site-docs/changelog.md
+++ b/site-docs/changelog.md
@@ -4,6 +4,12 @@ For the complete changelog, see [CHANGELOG.md on GitHub](https://github.com/s-hi
 
 ## Recent Highlights
 
+### v0.15.8
+
+- **Added**: `synapse list --plain` for one-shot plain-text agent listings without entering the Rich TUI
+- **Fixed**: `synapse list` can now be forced into non-interactive mode with `SYNAPSE_NONINTERACTIVE=1`, preventing hangs in AI-controlled TTY sessions
+- **Documentation**: Updated AI-facing guidance, plugin skills, and site docs to use `synapse list --json`, `synapse list --plain`, `synapse status <target> --json`, or MCP `list_agents`
+
 ### v0.15.7
 
 - **Fixed**: Interactive startup logging now switches to per-agent file logs before PTY handoff, so startup warnings no longer leak into interactive terminals

--- a/site-docs/concepts/a2a-protocol.md
+++ b/site-docs/concepts/a2a-protocol.md
@@ -17,7 +17,7 @@ Every A2A agent publishes a discovery document at `/.well-known/agent.json`:
   "name": "synapse-claude-8100",
   "description": "Claude Code agent managed by Synapse A2A",
   "url": "http://localhost:8100",
-  "version": "0.15.7",
+  "version": "0.15.8",
   "capabilities": {
     "streaming": false,
     "pushNotifications": false

--- a/site-docs/getting-started/installation.md
+++ b/site-docs/getting-started/installation.md
@@ -58,7 +58,7 @@
 synapse --version
 ```
 
-You should see the version number (e.g., `0.15.7`).
+You should see the version number (e.g., `0.15.8`).
 
 ## Initialize Configuration
 

--- a/site-docs/guide/communication.md
+++ b/site-docs/guide/communication.md
@@ -349,7 +349,7 @@ Beyond explicit messaging, the synapse-a2a skill teaches agents structured colla
 
 ### When You Need Help
 
-1. Run `synapse list` to check available agents (prefer same `WORKING_DIR`). MCP-capable agents can also use the `list_agents` MCP tool instead of the CLI command — see [MCP Setup](mcp-setup.md#list_agents).
+1. For humans, run `synapse list` to check available agents (prefer same `WORKING_DIR`). For AI/scripts, use `synapse list --json` or the `list_agents` MCP tool instead of the interactive CLI output — see [MCP Setup](mcp-setup.md#list_agents).
 2. Run `synapse memory search "<topic>"` to check shared knowledge first
 3. If no suitable agent exists, spawn one: `synapse spawn <profile> --name <name> --role "<role>"`
 4. Send the request: `synapse send <target> "<specific request>" --wait`

--- a/site-docs/reference/cli.md
+++ b/site-docs/reference/cli.md
@@ -70,6 +70,7 @@ synapse stop <target> -a     # Stop all instances of that profile
 
 ```bash
 synapse list                 # Interactive TUI with real-time updates
+synapse list --plain         # One-shot plain text (no TUI)
 synapse list --json          # Output agent list as JSON array
 ```
 
@@ -78,6 +79,9 @@ Interactive TUI with real-time updates. See [Agent Management](../guide/agent-ma
 | Flag | Description |
 |------|-------------|
 | `--json` | Output agent list as a JSON array for AI/programmatic consumption (no TUI) |
+| `--plain` | Force one-shot plain-text output without entering the Rich TUI |
+
+For AI-controlled terminals, do not use bare `synapse list`. Use `synapse list --json`, `synapse list --plain`, `synapse status <target> --json`, or the MCP `list_agents` tool.
 
 ### Status
 

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -4,7 +4,7 @@
     "synapse-a2a": {
       "source": "s-hiraoku/synapse-a2a",
       "sourceType": "github",
-      "computedHash": "6541fa7bcdf1db8287e31579a49818718d507ea907c363d521687968ecdbc6ad"
+      "computedHash": "88bca24bb70d2d88b23c27fe3a602a1be552bc4d477502de829586cb85d02676"
     },
     "synapse-docs": {
       "source": "s-hiraoku/synapse-a2a",
@@ -14,7 +14,7 @@
     "synapse-manager": {
       "source": "s-hiraoku/synapse-a2a",
       "sourceType": "github",
-      "computedHash": "15ec07d618e145a5f4c8355f335bc8cfda2e413adef9cde9a73fb0bb08c9164d"
+      "computedHash": "8027ef01c842a9c10e61cb6e4368348a3469d1f234028e4780616870eb80feb9"
     },
     "synapse-reinst": {
       "source": "s-hiraoku/synapse-a2a",

--- a/synapse/cli.py
+++ b/synapse/cli.py
@@ -4247,6 +4247,8 @@ def cmd_run_interactive(
     submit_confirm_timeout = config.get("submit_confirm_timeout")
     submit_confirm_poll_interval = config.get("submit_confirm_poll_interval")
     submit_confirm_retries = config.get("submit_confirm_retries")
+    long_submit_confirm_timeout = config.get("long_submit_confirm_timeout")
+    long_submit_confirm_retries = config.get("long_submit_confirm_retries")
     submit_fallback_sequences = config.get("submit_fallback_sequences")
 
     # Create controller - initial instructions sent on IDLE (unless resume mode)
@@ -4279,6 +4281,8 @@ def cmd_run_interactive(
         submit_confirm_timeout=submit_confirm_timeout,
         submit_confirm_poll_interval=submit_confirm_poll_interval,
         submit_confirm_retries=submit_confirm_retries,
+        long_submit_confirm_timeout=long_submit_confirm_timeout,
+        long_submit_confirm_retries=long_submit_confirm_retries,
         submit_fallback_sequences=submit_fallback_sequences,
     )
 
@@ -4837,6 +4841,12 @@ Status meanings:
         action="store_true",
         dest="json_output",
         help="Output agent list as JSON (for programmatic use)",
+    )
+    p_list.add_argument(
+        "--plain",
+        action="store_true",
+        dest="plain_output",
+        help="Force one-shot plain-text output without the Rich TUI",
     )
     p_list.set_defaults(func=cmd_list)
 

--- a/synapse/commands/list.py
+++ b/synapse/commands/list.py
@@ -47,6 +47,12 @@ class ListCommand:
         self._time = time_module
         self._print = print_func
 
+    def _force_noninteractive(self, args: argparse.Namespace) -> bool:
+        """Return True when list output should avoid the Rich TUI."""
+        if getattr(args, "plain_output", False) is True:
+            return True
+        return os.environ.get("SYNAPSE_NONINTERACTIVE") == "1"
+
     def _is_agent_alive(
         self, registry: AgentRegistry, agent_id: str, info: dict[str, Any]
     ) -> bool:
@@ -646,8 +652,8 @@ class ListCommand:
         """List running agents with Rich TUI."""
         registry = self._registry_factory()
 
-        # Check if stdout is a TTY
-        if not sys.stdout.isatty():
+        # AI/programmatic callers may still be attached to a TTY.
+        if self._force_noninteractive(args) or not sys.stdout.isatty():
             # Non-interactive mode: single output
             agents, _, show_file_safety = self._get_agent_data(registry)
             if not agents:

--- a/synapse/controller.py
+++ b/synapse/controller.py
@@ -92,6 +92,8 @@ class TerminalController:
         submit_confirm_timeout: float | None = None,
         submit_confirm_poll_interval: float | None = None,
         submit_confirm_retries: int | None = None,
+        long_submit_confirm_timeout: float | None = None,
+        long_submit_confirm_retries: int | None = None,
         submit_fallback_sequences: str | list[str] | None = None,
     ):
         self.command = command
@@ -313,6 +315,38 @@ class TerminalController:
                     f"got {submit_confirm_retries}"
                 )
             self._submit_confirm_retries = submit_confirm_retries
+
+        self._long_submit_confirm_timeout: float | None = None
+        if long_submit_confirm_timeout is not None:
+            try:
+                long_submit_confirm_timeout = float(long_submit_confirm_timeout)
+            except (TypeError, ValueError):
+                raise ValueError(
+                    "long_submit_confirm_timeout must be numeric, "
+                    f"got {long_submit_confirm_timeout!r}"
+                ) from None
+            if long_submit_confirm_timeout <= 0:
+                raise ValueError(
+                    "long_submit_confirm_timeout must be positive, "
+                    f"got {long_submit_confirm_timeout}"
+                )
+            self._long_submit_confirm_timeout = long_submit_confirm_timeout
+
+        self._long_submit_confirm_retries: int | None = None
+        if long_submit_confirm_retries is not None:
+            try:
+                long_submit_confirm_retries = int(long_submit_confirm_retries)
+            except (TypeError, ValueError):
+                raise ValueError(
+                    "long_submit_confirm_retries must be an integer, "
+                    f"got {long_submit_confirm_retries!r}"
+                ) from None
+            if long_submit_confirm_retries < 0:
+                raise ValueError(
+                    "long_submit_confirm_retries must be non-negative, "
+                    f"got {long_submit_confirm_retries}"
+                )
+            self._long_submit_confirm_retries = long_submit_confirm_retries
 
         # Fallback submit sequences for confirmation retries (Copilot).
         # Each retry cycles through the list (wrapping from end to start).
@@ -984,6 +1018,35 @@ class TerminalController:
             if self._typing_char_delay > 0 and idx + 1 < len(data):
                 time.sleep(self._typing_char_delay)
 
+    def _is_long_submit_message(self, data: str) -> bool:
+        """Whether Copilot confirmation should use long-message heuristics."""
+        if self.agent_type != "copilot":
+            return False
+        return "\n" in data or "\r" in data
+
+    def _pending_submit_markers(self, data: str) -> list[str]:
+        """Extract visible markers that indicate Copilot input still remains."""
+        data_stripped = data.strip()
+        if not data_stripped:
+            return []
+
+        markers: list[str] = [data_stripped]
+        if "[LONG MESSAGE - FILE ATTACHED]" in data_stripped:
+            markers.extend(
+                [
+                    "[LONG MESSAGE - FILE ATTACHED]",
+                    "The full message content is stored at:",
+                    "Please read this file",
+                ]
+            )
+        elif self._is_long_submit_message(data):
+            lines = [line.strip() for line in data.splitlines() if line.strip()]
+            for line in lines:
+                if len(line) >= 8 and line not in markers:
+                    markers.append(line)
+
+        return markers
+
     def write(
         self,
         data: str,
@@ -1058,13 +1121,16 @@ class TerminalController:
 
     def _should_confirm_submit(self, data: str, submit_bytes: bytes) -> bool:
         """Whether submit confirmation should run for this write."""
+        retries = self._submit_confirm_retries
+        if self._is_long_submit_message(data) and self._long_submit_confirm_retries:
+            retries = self._long_submit_confirm_retries
         return bool(
             data
             and submit_bytes
             and self.agent_type == "copilot"
             and self._submit_confirm_timeout is not None
             and self._submit_confirm_poll_interval is not None
-            and self._submit_confirm_retries > 0
+            and retries > 0
         )
 
     def _get_preferred_submit_bytes(self, original: bytes) -> bytes:
@@ -1096,19 +1162,23 @@ class TerminalController:
 
     def _submit_confirmed(self, data: str, initial_status: str) -> bool:
         """Best-effort submit confirmation for Copilot PTY injections."""
+        long_submit = self._is_long_submit_message(data)
+        plain = strip_ansi(self.get_context())
+        markers = self._pending_submit_markers(data)
+        pending = any(marker in plain[-4000:] for marker in markers)
+
         current_status = self.status
         if initial_status == "READY" and current_status != "READY":
-            return True
+            return not long_submit or not pending
         if current_status in {"PROCESSING", "DONE"}:
-            return True
+            return not long_submit or not pending
         if current_status == "WAITING" and initial_status != "WAITING":
+            return not long_submit or not pending
+
+        if not markers:
             return True
 
-        plain = strip_ansi(self.get_context())
-        data_stripped = data.strip()
-        if not data_stripped:
-            return True
-        return data_stripped not in plain[-2000:]
+        return not pending
 
     def _confirm_submit_if_needed(
         self,
@@ -1125,14 +1195,19 @@ class TerminalController:
         assert self._submit_confirm_poll_interval is not None
         original = original_submit_bytes or submit_bytes
         retry_candidates = self._get_retry_submit_candidates(submit_bytes, original)
+        confirm_timeout = self._submit_confirm_timeout
+        confirm_retries = self._submit_confirm_retries
+        if self._is_long_submit_message(data):
+            if self._long_submit_confirm_timeout is not None:
+                confirm_timeout = self._long_submit_confirm_timeout
+            if self._long_submit_confirm_retries is not None:
+                confirm_retries = self._long_submit_confirm_retries
 
         poll_limit = max(
             1,
-            math.ceil(
-                self._submit_confirm_timeout / self._submit_confirm_poll_interval
-            ),
+            math.ceil(confirm_timeout / self._submit_confirm_poll_interval),
         )
-        for attempt in range(self._submit_confirm_retries + 1):
+        for attempt in range(confirm_retries + 1):
             for _ in range(poll_limit):
                 if self._submit_confirmed(data, initial_status):
                     if attempt > 0:
@@ -1145,17 +1220,17 @@ class TerminalController:
                     return
                 time.sleep(self._submit_confirm_poll_interval)
 
-            if attempt < self._submit_confirm_retries:
+            if attempt < confirm_retries:
                 self._write_all(retry_candidates[attempt % len(retry_candidates)])
 
         message = (
             f"[{self.agent_id}] submit confirmation failed after "
-            f"{self._submit_confirm_retries} retries"
+            f"{confirm_retries} retries"
         )
         logger.warning(message)
         self._log_inject(
             "WARN",
-            f"submit confirmation failed retries={self._submit_confirm_retries}",
+            f"submit confirmation failed retries={confirm_retries}",
         )
 
     def interrupt(self) -> None:

--- a/synapse/history.py
+++ b/synapse/history.py
@@ -6,6 +6,7 @@ enabling users to review past interactions and search historical data.
 
 import contextlib
 import json
+import logging
 import os
 import sqlite3
 import sys
@@ -13,6 +14,8 @@ import threading
 from collections.abc import Generator
 from pathlib import Path
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 
 @contextlib.contextmanager
@@ -175,6 +178,13 @@ class HistoryManager:
                             metadata_json,
                         ),
                     )
+            except sqlite3.IntegrityError:
+                # Duplicate task_id saves are benign. The first observation wins,
+                # and later status changes should use update_observation_status().
+                logger.debug(
+                    "Observation already exists for task_id=%s; skipping duplicate save",
+                    task_id,
+                )
             except sqlite3.Error as e:
                 print(f"Warning: Failed to save observation: {e}", file=sys.stderr)
 

--- a/synapse/profiles/copilot.yaml
+++ b/synapse/profiles/copilot.yaml
@@ -15,6 +15,10 @@ submit_retry_delay: 0.15
 submit_confirm_timeout: 1.5
 submit_confirm_poll_interval: 0.05
 submit_confirm_retries: 3
+# Long multiline / file-reference sends can take longer to clear the Copilot
+# prompt after bracketed paste, so use a slightly larger confirmation budget.
+long_submit_confirm_timeout: 3.0
+long_submit_confirm_retries: 5
 # Fallback submit sequences tried in order on each confirmation retry.
 # Copilot CLI 1.0.8 can leave pasted input in the prompt and advertise
 # "ctrl+s run command" instead of executing Enter immediately, so try LF

--- a/synapse/server.py
+++ b/synapse/server.py
@@ -140,6 +140,8 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     submit_confirm_timeout = profile.get("submit_confirm_timeout")
     submit_confirm_poll_interval = profile.get("submit_confirm_poll_interval")
     submit_confirm_retries = profile.get("submit_confirm_retries")
+    long_submit_confirm_timeout = profile.get("long_submit_confirm_timeout")
+    long_submit_confirm_retries = profile.get("long_submit_confirm_retries")
     submit_fallback_sequences = profile.get("submit_fallback_sequences")
 
     controller = TerminalController(
@@ -164,6 +166,8 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         submit_confirm_timeout=submit_confirm_timeout,
         submit_confirm_poll_interval=submit_confirm_poll_interval,
         submit_confirm_retries=submit_confirm_retries,
+        long_submit_confirm_timeout=long_submit_confirm_timeout,
+        long_submit_confirm_retries=long_submit_confirm_retries,
         submit_fallback_sequences=submit_fallback_sequences,
     )
     controller.start()

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -137,6 +137,19 @@ class TestCliMain:
         args = mock_cmd_list.call_args[0][0]
         assert args.command == "list"
 
+    @patch("synapse.cli.cmd_list")
+    @patch("synapse.cli.install_skills")
+    def test_main_command_list_plain(self, mock_install, mock_cmd_list):
+        """synapse list --plain should parse the non-interactive flag."""
+        with patch.object(sys, "argv", ["synapse", "list", "--plain"]):
+            main()
+
+        mock_cmd_list.assert_called_once()
+        args = mock_cmd_list.call_args[0][0]
+        assert args.command == "list"
+        assert args.plain_output is True
+        assert args.json_output is False
+
     @patch("synapse.cli.cmd_mcp_serve")
     @patch("synapse.cli.install_skills")
     def test_main_command_mcp_serve(self, mock_install, mock_cmd_mcp_serve):

--- a/tests/test_cmd_list_watch.py
+++ b/tests/test_cmd_list_watch.py
@@ -254,6 +254,55 @@ class TestCmdListTUI:
 
         assert len(run_rich_called) == 1
 
+    def test_plain_flag_bypasses_tui_even_when_tty(self, temp_registry, capsys):
+        """--plain should force one-shot text output even on a TTY."""
+        agent_id = "synapse-claude-8100"
+        temp_registry.register(agent_id, "claude", 8100, status="READY")
+
+        args = MagicMock()
+        args.plain_output = True
+        args.json_output = False
+        args.working_dir = None
+
+        with (
+            patch("synapse.cli.AgentRegistry", return_value=temp_registry),
+            patch("synapse.cli.is_process_alive", return_value=True),
+            patch("synapse.cli.is_port_open", return_value=True),
+            patch("sys.stdout.isatty", return_value=True),
+            patch("synapse.commands.list.ListCommand._run_rich_tui") as mock_run_rich,
+        ):
+            cmd_list(args)
+
+        captured = capsys.readouterr()
+        assert "claude" in captured.out
+        assert "8100" in captured.out
+        mock_run_rich.assert_not_called()
+
+    def test_noninteractive_env_bypasses_tui_even_when_tty(self, temp_registry, capsys):
+        """SYNAPSE_NONINTERACTIVE=1 should force one-shot text output on a TTY."""
+        agent_id = "synapse-claude-8100"
+        temp_registry.register(agent_id, "claude", 8100, status="READY")
+
+        args = MagicMock()
+        args.plain_output = False
+        args.json_output = False
+        args.working_dir = None
+
+        with (
+            patch("synapse.cli.AgentRegistry", return_value=temp_registry),
+            patch("synapse.cli.is_process_alive", return_value=True),
+            patch("synapse.cli.is_port_open", return_value=True),
+            patch("sys.stdout.isatty", return_value=True),
+            patch.dict("os.environ", {"SYNAPSE_NONINTERACTIVE": "1"}, clear=False),
+            patch("synapse.commands.list.ListCommand._run_rich_tui") as mock_run_rich,
+        ):
+            cmd_list(args)
+
+        captured = capsys.readouterr()
+        assert "claude" in captured.out
+        assert "8100" in captured.out
+        mock_run_rich.assert_not_called()
+
 
 # ============================================================================
 # Tests for Bug #2: Silent Exception Swallowing

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -960,7 +960,7 @@ class TestInterAgentMessageWrite:
         assert result is True
         assert writes == [b"hello", b"\r", b"\r"]
         assert sleeps[:2] == [0.5, 0.15]
-        assert sleeps[2:] == [0.05]
+        assert sleeps[2:] in ([], [0.05])
 
     def test_submit_confirmation_retries_when_waiting_state_does_not_advance(self):
         """Copilot should not treat WAITING->WAITING as confirmation by itself."""
@@ -1386,6 +1386,145 @@ class TestInterAgentMessageWrite:
             ctrl.write("hello\nworld", submit_seq="\r")
 
         assert writes == [b"\x1b[200~hello\nworld\x1b[201~", b"\r", b"\r"]
+
+    def test_copilot_long_message_reference_stays_pending_while_reference_remains(self):
+        """Long-message reference text should keep Copilot confirmation pending."""
+        ctrl = TerminalController(
+            command="echo test",
+            idle_regex=r"\$",
+            agent_type="copilot",
+            write_delay=0.5,
+            submit_retry_delay=0.15,
+            bracketed_paste=True,
+            submit_confirm_timeout=0.1,
+            submit_confirm_poll_interval=0.05,
+            submit_confirm_retries=1,
+        )
+        ctrl.running = True
+        ctrl.master_fd = 1
+        ctrl.status = "READY"
+        ctrl.get_context = (  # type: ignore[method-assign]
+            lambda: (
+                "A2A: [LONG MESSAGE - FILE ATTACHED]\n"
+                "The full message content is stored at: /tmp/msg.txt\n"
+                "Please read this file to get the complete message.\n"
+                "Processing..."
+            )
+        )
+
+        writes: list[bytes] = []
+        with (
+            patch(
+                "synapse.controller.os.write",
+                side_effect=lambda fd, data: (writes.append(data), len(data))[1],
+            ),
+            patch("synapse.controller.time.sleep"),
+        ):
+            ctrl.write(
+                "A2A: [LONG MESSAGE - FILE ATTACHED]\n"
+                "The full message content is stored at: /tmp/msg.txt\n"
+                "Please read this file to get the complete message.",
+                submit_seq="\r",
+            )
+
+        assert writes == [
+            b"\x1b[200~A2A: [LONG MESSAGE - FILE ATTACHED]\n"
+            b"The full message content is stored at: /tmp/msg.txt\n"
+            b"Please read this file to get the complete message.\x1b[201~",
+            b"\r",
+            b"\r",
+            b"\r",
+        ]
+
+    def test_copilot_long_message_status_advance_needs_reference_to_clear(self):
+        """Long Copilot sends should not confirm on PROCESSING while prompt text remains."""
+        ctrl = TerminalController(
+            command="echo test",
+            idle_regex=r"\$",
+            agent_type="copilot",
+            write_delay=0.5,
+            submit_retry_delay=0.15,
+            bracketed_paste=True,
+            submit_confirm_timeout=0.1,
+            submit_confirm_poll_interval=0.05,
+            submit_confirm_retries=1,
+        )
+        ctrl.running = True
+        ctrl.master_fd = 1
+        ctrl.status = "READY"
+        ctrl.get_context = (  # type: ignore[method-assign]
+            lambda: (setattr(ctrl, "status", "PROCESSING") or "")
+            + "[LONG MESSAGE - FILE ATTACHED]\n"
+            + "Please read this file to get the complete message.\n"
+            + "Processing..."
+        )
+
+        writes: list[bytes] = []
+        with (
+            patch(
+                "synapse.controller.os.write",
+                side_effect=lambda fd, data: (writes.append(data), len(data))[1],
+            ),
+            patch("synapse.controller.time.sleep"),
+        ):
+            ctrl.write(
+                "[LONG MESSAGE - FILE ATTACHED]\n"
+                "Please read this file to get the complete message.",
+                submit_seq="\r",
+            )
+
+        assert writes == [
+            b"\x1b[200~[LONG MESSAGE - FILE ATTACHED]\n"
+            b"Please read this file to get the complete message.\x1b[201~",
+            b"\r",
+            b"\r",
+            b"\r",
+        ]
+
+    def test_copilot_multiline_message_uses_long_submit_confirm_budget(self):
+        """Multi-line Copilot sends should use the long-message confirm budget."""
+        ctrl = TerminalController(
+            command="echo test",
+            idle_regex=r"\$",
+            agent_type="copilot",
+            write_delay=0.5,
+            submit_retry_delay=0.15,
+            bracketed_paste=True,
+            submit_confirm_timeout=0.1,
+            submit_confirm_poll_interval=0.05,
+            submit_confirm_retries=1,
+            long_submit_confirm_timeout=0.2,
+            long_submit_confirm_retries=2,
+        )
+        ctrl.running = True
+        ctrl.master_fd = 1
+        ctrl.status = "READY"
+        ctrl.get_context = lambda: "hello\nworld"  # type: ignore[method-assign]
+
+        writes: list[bytes] = []
+        sleeps: list[float] = []
+        with (
+            patch(
+                "synapse.controller.os.write",
+                side_effect=lambda fd, data: (writes.append(data), len(data))[1],
+            ),
+            patch(
+                "synapse.controller.time.sleep",
+                side_effect=lambda t: sleeps.append(t),
+            ),
+        ):
+            ctrl.write("hello\nworld", submit_seq="\r")
+
+        assert writes == [
+            b"\x1b[200~hello\nworld\x1b[201~",
+            b"\r",
+            b"\r",
+            b"\r",
+            b"\r",
+        ]
+        assert sleeps[:2] == [0.5, 0.15]
+        confirm_sleeps = [s for s in sleeps[2:] if s != 0.1]
+        assert confirm_sleeps == [0.05] * 12
 
     # --- Bracketed paste mode tests ---
 

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -95,6 +95,36 @@ class TestHistoryManager:
         assert observations[0]["metadata"]["sender_id"] == "synapse-gemini-8110"
         assert observations[0]["metadata"]["sender_type"] == "gemini"
 
+    def test_save_observation_duplicate_task_id_is_ignored(
+        self, history_manager, capsys
+    ):
+        """Duplicate task_id saves should be ignored without stderr noise."""
+        history_manager.save_observation(
+            task_id="task-dup",
+            agent_name="claude",
+            session_id="session-1",
+            input_text="Input 1",
+            output_text="Output 1",
+            status="completed",
+        )
+        history_manager.save_observation(
+            task_id="task-dup",
+            agent_name="claude",
+            session_id="session-1",
+            input_text="Input 2",
+            output_text="Output 2",
+            status="failed",
+        )
+
+        captured = capsys.readouterr()
+        assert captured.err == ""
+
+        observations = history_manager.list_observations(limit=10)
+        assert len(observations) == 1
+        assert observations[0]["task_id"] == "task-dup"
+        assert observations[0]["input"] == "Input 1"
+        assert observations[0]["status"] == "completed"
+
     def test_list_observations_default_limit(self, history_manager):
         """Should list observations with default limit."""
         # Create 3 observations

--- a/tests/test_skill_docs.py
+++ b/tests/test_skill_docs.py
@@ -44,9 +44,9 @@ def test_check_team_status_reports_failures_and_empty_states_distinctly() -> Non
         "plugins/synapse-a2a/skills/synapse-manager/scripts/check_team_status.sh"
     )
     assert "command -v synapse" in text
-    assert "list_output=$(synapse list 2>&1)" in text
+    assert "list_output=$(synapse list --plain 2>&1)" in text
     assert "list_status=$?" in text
-    assert "synapse list failed:" in text
+    assert "synapse list --plain failed:" in text
     assert "No agents running." in text
     assert "task_output=$(synapse tasks list 2>&1)" in text
     assert "task_status=$?" in text
@@ -87,9 +87,9 @@ def test_synapse_manager_skill_emphasizes_tests_before_implementation() -> None:
 
 def test_synapse_a2a_skill_shows_cleanup_verification() -> None:
     text = _read("plugins/synapse-a2a/skills/synapse-a2a/SKILL.md")
-    assert "synapse list                              # Verify agent appears" in text
+    assert "synapse list --json                       # Verify agent appears" in text
     assert "synapse kill Tester -f" in text
-    assert "synapse list                              # Verify cleanup" in text
+    assert "synapse list --json                       # Verify cleanup" in text
     assert "retry" in text.lower()
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1427,7 +1427,7 @@ wheels = [
 
 [[package]]
 name = "synapse-a2a"
-version = "0.15.7"
+version = "0.15.8"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary
- add `synapse list --plain` and `SYNAPSE_NONINTERACTIVE=1` to avoid hanging AI-controlled TTY sessions in the interactive list UI
- update Synapse AI/automation guidance, plugin skills, mirrored skills, and site docs to use `synapse list --json`, `synapse list --plain`, `synapse status <target> --json`, or MCP `list_agents`
- include the Copilot long-submit/history fixes already in this worktree and bump the release to `0.15.8`

## Testing
- pytest tests/test_cmd_list_json.py tests/test_cmd_list_watch.py tests/test_cli_main.py tests/test_skill_structure.py -q
- pytest tests/test_controller.py tests/test_history.py tests/test_error_detector.py tests/test_tools_a2a.py -q
- uv run mkdocs build --strict


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * `synapse list --plain` を追加：対話的TUIを避けた一回限りのプレーン出力
  * `SYNAPSE_NONINTERACTIVE=1` による非対話モード指定でAI制御TTYのハング回避
  * Copilotの長文/複数行送信に対する確認タイムアウトとリトライ挙動を強化

* **ドキュメント**
  * 人間向け（対話）とAI/スクリプト向け（JSON/プレーン/個別ステータス）の使用指針を明確化
  * README/CHANGELOG/サイト文書をv0.15.8に更新
<!-- end of auto-generated comment: release notes by coderabbit.ai -->