### PR TITLE
docs: sync site-docs with v0.15.11 changes

### DIFF
--- a/site-docs/concepts/architecture.md
+++ b/site-docs/concepts/architecture.md
@@ -51,9 +51,11 @@ The heart of Synapse — manages the PTY connection to the CLI agent.
 - Spawn and manage the CLI process via `pty.spawn()`
 - Detect agent states: READY, PROCESSING, WAITING, DONE, SHUTTING_DOWN
 - Write messages to the PTY (with split-write strategy for Ink TUI apps)
+- Strip ANSI escape sequences with three-stage removal (full sequences → orphaned SGR fragments → bare SGR fragments)
 - Detect idle states using configurable strategies (pattern, timeout, hybrid)
 - Send initial instructions on first idle
 - Manage the Readiness Gate
+- Adaptive paste echo wait for Copilot (polls PTY for TUI re-render before Enter)
 
 **Key attributes:**
 
@@ -101,7 +103,8 @@ HTTP server providing A2A-compatible endpoints.
 Translates between Synapse internals and the Google A2A protocol format.
 
 - Converts incoming A2A messages to PTY writes
-- Formats PTY output as A2A responses
+- Formats PTY output as structured A2A reply artifacts with content scoring to prefer richer responses over trivial PTY noise
+- Cleans TUI artifacts (spinners, box-drawing, status bars, input echo) from all agent types before building reply artifacts
 - Manages task lifecycle (submitted → working → completed/failed)
 - Handles long message storage (>200 chars → file reference)
 

--- a/site-docs/guide/communication.md
+++ b/site-docs/guide/communication.md
@@ -74,6 +74,9 @@ Three response modes are available:
 | `--wait` | Block until receiver replies | Questions, results needed before proceeding |
 | `--silent` | Fire-and-forget, no notification | Pure notifications, delegated tasks |
 
+!!! info "Structured Reply Artifacts"
+    `--wait` and `--notify` produce structured A2A reply artifacts derived from the PTY output delta. TUI response cleaning runs for all agent types, stripping spinners, box-drawing borders, status bars, and input echo before finalization. A content scoring system selects the richest response context and drops trivial PTY noise (e.g., lone cursor movement characters).
+
 ```bash
 # Default (--notify) — returns immediately, notifies on completion
 synapse send gemini "Analyze this codebase"


### PR DESCRIPTION
## Summary

- Update `site-docs/concepts/architecture.md` to document three-stage ANSI stripping, adaptive paste echo wait for Copilot, and structured reply artifacts with all-agent TUI cleaning
- Update `site-docs/guide/communication.md` with Structured Reply Artifacts admonition explaining content scoring and universal TUI response cleaning

## Test plan

- [x] `uv run mkdocs build --strict` passes with no errors or warnings
- [ ] Verify rendered pages display correctly on GitHub Pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)