### PR TITLE
fix: remove --task flag from skill and CLI documentation

### DIFF
--- a/.agents/skills/synapse-a2a/references/commands.md
+++ b/.agents/skills/synapse-a2a/references/commands.md
@@ -403,7 +403,7 @@ Action:   Just do the task. No reply needed unless you have questions.
 **Use this command for inter-agent communication.** Works from any environment including sandboxed agents.
 
 ```bash
-synapse send <target> "<message>" [--from <sender>] [--priority <1-5>] [--wait | --notify | --silent] [--callback "<command>"] [--force] [--task | -T]
+synapse send <target> "<message>" [--from <sender>] [--priority <1-5>] [--wait | --notify | --silent] [--callback "<command>"] [--force]
 ```
 
 **Target Formats (in priority order):**

--- a/.claude/skills/synapse-a2a/references/commands.md
+++ b/.claude/skills/synapse-a2a/references/commands.md
@@ -403,7 +403,7 @@ Action:   Just do the task. No reply needed unless you have questions.
 **Use this command for inter-agent communication.** Works from any environment including sandboxed agents.
 
 ```bash
-synapse send <target> "<message>" [--from <sender>] [--priority <1-5>] [--wait | --notify | --silent] [--callback "<command>"] [--force] [--task | -T]
+synapse send <target> "<message>" [--from <sender>] [--priority <1-5>] [--wait | --notify | --silent] [--callback "<command>"] [--force]
 ```
 
 **Target Formats (in priority order):**

--- a/plugins/synapse-a2a/skills/synapse-a2a/references/commands.md
+++ b/plugins/synapse-a2a/skills/synapse-a2a/references/commands.md
@@ -403,7 +403,7 @@ Action:   Just do the task. No reply needed unless you have questions.
 **Use this command for inter-agent communication.** Works from any environment including sandboxed agents.
 
 ```bash
-synapse send <target> "<message>" [--from <sender>] [--priority <1-5>] [--wait | --notify | --silent] [--callback "<command>"] [--force] [--task | -T]
+synapse send <target> "<message>" [--from <sender>] [--priority <1-5>] [--wait | --notify | --silent] [--callback "<command>"] [--force]
 ```
 
 **Target Formats (in priority order):**

--- a/site-docs/reference/cli.md
+++ b/site-docs/reference/cli.md
@@ -192,7 +192,6 @@ synapse send <target> "<message>" [OPTIONS]
 | `--message-file PATH` | Read message from file (`-` for stdin) |
 | `--stdin` | Read message from stdin |
 | `--attach FILE` | Attach file (repeatable) |
-| `--task` / `-T` | Auto-create a board task linked to the A2A message (auto-claim on receive, auto-complete on finalize) |
 | `--force` | Bypass working_dir mismatch check |
 
 !!! tip "Choosing response mode"


### PR DESCRIPTION
## Summary

- Remove `--task` / `-T` flag reference from `synapse send` command signature in skill documentation and site-docs CLI reference
- This flag was removed in PR #456 (Task Board removal) but one reference remained, causing agents to attempt using the non-existent flag

## Context

Agent `claude-hush` reported an `unrecognized arguments: --task` error when following the skill documentation. The root cause was a stale `[--task | -T]` in `plugins/synapse-a2a/skills/synapse-a2a/references/commands.md` and `site-docs/reference/cli.md`.

## Test plan

- [x] `grep -rl "\-\-task" plugins/ .agents/ .claude/ site-docs/` returns 0 matches
- [x] Skills synced across plugins/, .agents/, .claude/

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * `synapse send` CLIコマンドのリファレンスドキュメントを更新しました。
  * コマンド構文から `--task` / `-T` オプションの記載を削除しました。
  * その他のオプション（`--from`、`--priority`、`--wait/--notify/--silent`、`--callback`、`--force`）は変更されていません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->