### PR TITLE
fix: address CodeRabbit review — ICRNL actual clear, KKP in interactive mode

### DIFF
--- a/synapse/controller.py
+++ b/synapse/controller.py
@@ -1400,6 +1400,29 @@ class TerminalController:
         except OSError:
             pass
 
+    def _ensure_icrnl_disabled(self, submit_bytes: bytes) -> None:
+        """Clear ICRNL on the PTY if sending \\r and not already cleared.
+
+        Ink-based TUIs (Copilot) may re-enable ICRNL which translates
+        \\r→\\n.  Ink maps \\r to key.return (submit) but \\n to
+        key.enter (different event), so ICRNL must be off.
+        """
+        if (
+            submit_bytes == b"\r"
+            and not self._icrnl_cleared
+            and self.master_fd is not None
+        ):
+            try:
+                attrs = termios.tcgetattr(self.master_fd)
+                iflag = attrs[0]
+                if iflag & termios.ICRNL:
+                    attrs[0] = iflag & ~termios.ICRNL
+                    termios.tcsetattr(self.master_fd, termios.TCSANOW, attrs)
+                    logger.debug(f"[{self.agent_id}] ICRNL disabled for submit")
+                self._icrnl_cleared = True
+            except (termios.error, OSError):
+                pass
+
     def _wait_for_copilot_paste_echo(self, pre_paste_context: str) -> None:
         """Wait for Copilot's Ink TUI to reflect the pasted text before Enter.
 
@@ -1519,30 +1542,7 @@ class TerminalController:
                         self._wait_for_copilot_paste_echo(pre_paste_context)
                     elif self._write_delay > 0:
                         time.sleep(self._write_delay)
-                    # Ensure ICRNL is disabled before sending submit bytes.
-                    # Ink-based TUIs (Copilot) call process.stdin.setRawMode(true)
-                    # on startup which may re-enable ICRNL, converting \r→\n.
-                    # Ink maps \r to key.return (submit) but \n to key.enter
-                    # (different event), so ICRNL must be off.
-                    if (
-                        submit_bytes == b"\r"
-                        and not self._icrnl_cleared
-                        and self.master_fd is not None
-                    ):
-                        try:
-                            attrs = termios.tcgetattr(self.master_fd)
-                            iflag = attrs[0]
-                            if iflag & termios.ICRNL:
-                                attrs[0] = iflag & ~termios.ICRNL
-                                termios.tcsetattr(
-                                    self.master_fd, termios.TCSANOW, attrs
-                                )
-                                logger.debug(
-                                    f"[{self.agent_id}] ICRNL disabled for submit"
-                                )
-                            self._icrnl_cleared = True
-                        except (termios.error, OSError):
-                            pass
+                    self._ensure_icrnl_disabled(submit_bytes)
                     # Proactively disable Kitty Keyboard Protocol before
                     # submit if it hasn't been caught by the output monitor.
                     if not self._kkp_disabled and self.agent_type == "copilot":
@@ -1669,8 +1669,11 @@ class TerminalController:
         # re-encoded as CSI 13 u.
         if self.agent_type == "copilot":
             self._disable_kkp("force re-disabled on confirmation failure", force=True)
-            # Also re-clear ICRNL in case Ink toggled it back
+            # Also re-clear ICRNL in case Ink toggled it back.
+            # Reset the cache flag AND perform the actual termios clear
+            # so the final CR is not translated to \n.
             self._icrnl_cleared = False
+            self._ensure_icrnl_disabled(submit_bytes)
             self._write_all(submit_bytes)
             # Brief wait + final check
             time.sleep(nudge_delay or _COPILOT_SUBMIT_NUDGE_DELAY)
@@ -1900,6 +1903,17 @@ class TerminalController:
 
                 self._append_output(data)
                 self._check_idle_state(data)
+
+                # Detect KKP re-activation in interactive mode too.
+                # _monitor_output handles this for background mode; here
+                # we mirror the same check for pty.spawn's read path.
+                if self.agent_type == "copilot" and _KKP_ENABLE_RE.search(data):
+                    self._disable_kkp(
+                        "re-disabled via pop (interactive)"
+                        if self._kkp_disabled
+                        else "disabled via pop (interactive)",
+                        force=True,
+                    )
 
                 # Pass output through directly - AI uses a2a.py tool for routing
                 return data

--- a/synapse/controller.py
+++ b/synapse/controller.py
@@ -725,6 +725,10 @@ class TerminalController:
                                 else "disabled via pop",
                                 force=True,
                             )
+                            # Ink may also re-enable ICRNL when it re-pushes
+                            # KKP, so reset the cache so the next submit
+                            # re-checks termios.
+                            self._icrnl_cleared = False
 
                         # Debug logging for PTY output analysis
                         # Enable with SYNAPSE_DEBUG_PTY=1 to see raw PTY output
@@ -1914,6 +1918,7 @@ class TerminalController:
                         else "disabled via pop (interactive)",
                         force=True,
                     )
+                    self._icrnl_cleared = False
 
                 # Pass output through directly - AI uses a2a.py tool for routing
                 return data


### PR DESCRIPTION
## Summary

Follow-up to PR #522 addressing CodeRabbit review comments:

- **Extract `_ensure_icrnl_disabled()` method**: The last-resort block was only resetting the `_icrnl_cleared` cache flag without performing the actual `termios.tcgetattr/tcsetattr` ICRNL clear. Now uses the extracted method for both the normal write path and the last-resort recovery.
- **KKP detection in interactive mode**: `read_callback()` (used by `pty.spawn` in interactive mode) was missing KKP re-enable detection. Previously only `_monitor_output()` (background mode) checked for KKP. Now both paths detect and disable KKP re-activation.

## Test plan

- [x] 101 controller tests pass
- [x] ruff + mypy pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 改行入力時の処理をさらに改善し、特定の環境での誤変換を防止しました。
  * インタラクティブモードでの入力送信の信頼性を向上させ、再有効化された端末設定への対処を強化しました。

* **パフォーマンス改善**
  * 送信フローを整理して不要な処理を減らし、入力応答の安定性を向上させました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->