### PR TITLE
docs(shared-memory): mark deprecation and add LLM Wiki migration guide

### DIFF
--- a/docs/shared-memory-spec.md
+++ b/docs/shared-memory-spec.md
@@ -1,5 +1,13 @@
 # Shared Memory — エージェント間知識共有 仕様書
 
+> **⚠️ Status (2026-04-10): Deprecation planned.**
+>
+> この機能は [**LLM Wiki**](design/llm-wiki.md) に置き換えられることが設計ドキュメント [design/llm-wiki.md §「Shared Memory の廃止」](design/llm-wiki.md#shared-memory-の廃止) で決定されている。コードと CLI コマンド (`synapse memory save/list/show/search/delete/stats`) は移行期間のために現時点ではまだ動作するが、**新規の知識記録には必ず `synapse wiki` を使うこと**。
+>
+> - **代替機能**: [LLM Wiki — Knowledge Accumulation Layer](design/llm-wiki.md)
+> - **使い分けガイド**: [synapse-reference.md § Shared Memory vs LLM Wiki](synapse-reference.md#shared-memory-vs-llm-wiki)
+> - **本書 (shared-memory-spec.md) の立ち位置**: 既存実装の現行仕様を記録する参照ドキュメント。新規設計の指針としては使用しないこと。
+
 ## 概要
 
 Synapse A2A の複数エージェントが協調作業する際に、セッション間・エージェント間で学んだ知識を共有する仕組みを提供する。

--- a/docs/synapse-reference.md
+++ b/docs/synapse-reference.md
@@ -141,6 +141,53 @@ synapse evolve --output-dir .synapse/evolved/skills  # Custom output directory
 synapse auth setup
 ```
 
+## Shared Memory vs LLM Wiki
+
+Synapse には知識共有のための機能が 2 つ存在するが、**これは移行期間の結果**であり、**LLM Wiki (`synapse wiki`) が Shared Memory (`synapse memory`) を置き換える**ことが [design/llm-wiki.md](design/llm-wiki.md#shared-memory-の廃止) で決定されている。新規の知識記録は必ず LLM Wiki を使うこと。
+
+### 現状 (2026-04-10)
+
+| | **`synapse memory`** (Shared Memory) | **`synapse wiki`** (LLM Wiki / Living Wiki) |
+|---|---|---|
+| **Status** | **Deprecation planned** (`docs/design/llm-wiki.md` で廃止決定済み、コードはまだ残存) | **Actively developed** (v0.21.0 導入, v0.23.0 で Living Wiki 拡張) |
+| **新規使用** | **非推奨** | **推奨** |
+| **データモデル** | Flat key-value + tags | Markdown pages + frontmatter + `[[wikilinks]]` |
+| **知識の構造化** | フラット | 階層的、ページ間リンク、Mermaid graph |
+| **メンテナンス機能** | なし | source_files 追跡、stale 検出、`wiki refresh`、`wiki lint` |
+| **UI** | CLI のみ | CLI + Canvas Knowledge view (`#/knowledge`) + MCP instruction |
+| **page type** | なし | `learning` type で bug fix / discovered pattern を記録 |
+| **検索** | SQLite 全文検索 | `synapse wiki query` (意味的クエリ) |
+| **コマンド** | `save/list/show/search/delete/stats` | `ingest/query/lint/status/refresh/init` |
+
+### 使い分けの指針
+
+**✅ LLM Wiki を使う** — 原則としてすべての知識蓄積ユースケース
+
+- Bug fix の原因と対策の記録（`learning` page type の典型用途）
+- アーキテクチャ決定とその理由
+- 相互リンクで体系化したい知識（`[[wikilink]]`）
+- source コード変更時の自動陳腐化検出（`source_files` frontmatter）
+- Canvas UI での閲覧・共有
+- エージェント間で長期的に蓄積されるプロジェクト知識
+
+**⚠️ Shared Memory が許容される限定的ケース**
+
+- 既に `synapse memory` を使っている既存プロジェクトの一時的な継続運用
+- ごく短命で構造化不要な key-value（例: 進行中 job の ID 共有）
+- ただし、これらも長期的には Wiki に移行することが望ましい
+
+**❌ Shared Memory を新たに導入しない** — 設計ドキュメント上は廃止予定の機能である
+
+### 移行
+
+- **新規の知識**: 必ず `synapse wiki ingest` を使う
+- **既存の `synapse memory` エントリ**: 必要なら `synapse wiki ingest` で Wiki ページに変換（公式の一括移行ツールは未提供、手動作業）
+- **MCP instruction**: `synapse://instructions/default` には現在も "SHARED MEMORY" セクションが残っているが、これは古い情報。LLM Wiki の正式な instruction は `synapse://instructions/wiki`
+
+詳細:
+- LLM Wiki 設計書: [design/llm-wiki.md](design/llm-wiki.md)（§「Shared Memory の廃止」に廃止の根拠）
+- Shared Memory 現行仕様: [shared-memory-spec.md](shared-memory-spec.md)（冒頭に Maintenance mode 注記）
+
 ## Target Resolution
 
 Targets resolve in priority order:


### PR DESCRIPTION
## Summary

The deprecation of `synapse memory save/search` in favor of LLM Wiki has been a documented design decision in `docs/design/llm-wiki.md` § "Shared Memory の廃止" since v0.21.0, but neither the standalone shared-memory spec nor the user-facing reference documented this. New users (and AI agents) reading the docs were left to guess which feature to use.

This PR closes that documentation gap. It is **documentation only** — the CLI commands and `shared_memory.py` are not touched.

## Changes

### `docs/shared-memory-spec.md` (+8 lines)

Add a "Deprecation planned" warning at the top, with cross-links to:
- `docs/design/llm-wiki.md` (the canonical deprecation decision)
- the new "Shared Memory vs LLM Wiki" section in `synapse-reference.md`

The body of the spec is preserved as-is — it remains a useful implementation reference for the existing code.

### `docs/synapse-reference.md` (+47 lines)

New section **"Shared Memory vs LLM Wiki"** placed between the command reference block and "Target Resolution". Contents:
- A side-by-side comparison table (status, data model, structuring, maintenance features, UI, page types, search, commands)
- Usage guidance: when to use LLM Wiki (almost always for knowledge accumulation), when Shared Memory is acceptable (legacy / very short-lived KV), and a clear "do not introduce Shared Memory in new projects" line
- Migration path: prefer `synapse wiki ingest` for new knowledge; existing memory entries can be manually migrated; note that the official MCP `synapse://instructions/default` still references SHARED MEMORY (aging documentation)

## Why split this from the runtime instruction fix

The `synapse://instructions/default` MCP resource still has a prominent "SHARED MEMORY" section that actively recommends `synapse memory save` to bootstrapped agents. Updating that requires touching `.synapse/default.md` and `synapse/templates/default.md` and is tracked separately in #527 as the actual root-cause fix.

This PR is the **documentation half** of that effort. It can ship independently because:
- Pure docs change, no code paths affected
- No risk of regression (zero CLI / API changes)
- Provides immediate cross-references that #527's eventual instruction update can build on

## Test plan

- [x] Markdown renders correctly on GitHub (preview before merging)
- [x] Cross-references resolve:
  - `docs/shared-memory-spec.md` → `design/llm-wiki.md` ✅
  - `docs/shared-memory-spec.md` → `synapse-reference.md#shared-memory-vs-llm-wiki` ✅
  - `docs/synapse-reference.md` → `design/llm-wiki.md` and `shared-memory-spec.md` ✅
- [x] No code changes, no test changes required
- [x] No CI gating beyond markdown lint (if configured)

## Related

- #527 — chore(instructions): remove SHARED MEMORY section from default agent instructions (the upstream root cause this PR documents)
- `docs/design/llm-wiki.md` § "Shared Memory の廃止" — the canonical design decision

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * Shared Memory仕様ドキュメントに非推奨通知を追加
  * LLM Wiki への置き換え情報とマイグレーションガイドを記載
  * Shared Memory と LLM Wiki の比較表と利用指針を追加
  * 既存機能の一時的な利用可能期間と新規導入方針を明確化

<!-- end of auto-generated comment: release notes by coderabbit.ai -->