### PR TITLE
chore(release): bump version to 0.25.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3335,7 +3335,8 @@ See v0.3.14 for reply PTY injection, CURRENT column, and history default changes
 - External agent connectivity vision document
 - PyPI publishing instructions
 
-[Unreleased]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.25.0...HEAD
+[Unreleased]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.25.1...HEAD
+[0.25.1]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.25.0...v0.25.1
 [0.25.0]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.24.2...v0.25.0
 [0.24.2]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.24.1...v0.24.2
 [0.24.1]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.24.0...v0.24.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.25.1] - 2026-04-12
+
+### Fixed
+
+- `synapse send` to Codex agents now handles HTTP 409 (agent busy) explicitly with a clear "Agent busy (working task). Retry after Ns" warning instead of silently failing as "local send failed" (#554)
+- `send_to_local()` now logs diagnostic warnings at every failure path (UDS transport errors, HTTP status errors, missing UDS socket, outer request exceptions) instead of returning `None` without explanation; set `SYNAPSE_LOG_LEVEL=DEBUG` to see details (#542)
+- `synapse send` now prints a clear warning when the sender agent cannot be auto-identified, advising users to set `SYNAPSE_AGENT_ID` or use `--from` (#543)
+- `--message-file`, `--task-file`, and `--stdin` inputs no longer trigger false shell-expansion warnings on backticks or `$()` — `_warn_shell_expansion()` is now only applied to positional arguments where shell expansion is actually possible (#544)
+- Codex agent status detection now uses hybrid idle detection (`strategy: "hybrid"` with `pattern_use: "startup_only"`) to avoid false READY transitions during LLM thinking time, while still avoiding the false positives that motivated the original timeout-only approach (#537)
+- `"local send failed"` error now hints at `SYNAPSE_LOG_LEVEL=DEBUG` for diagnostic details
+- Pre-existing mypy type error in `synapse/commands/spawn_cmd.py` (`port` variable redefinition) resolved
+
+### Added
+
+- `synapse send --task-file / -T PATH` flag reads a file as the message body, mirroring the flag on `synapse spawn` (#545)
+
+### Changed
+
+- `_resolve_message()` now returns `(message, source)` tuple so callers can branch on input source; `_warn_shell_expansion()` is skipped for non-positional sources
+- UDS 409 handler normalized to `Retry-After` header casing for consistency with the TCP path
+- `logger.warning` in the `retry_without_reply_to` 404 retry path converted from f-string to lazy `%s` formatting
+
+### Documentation
+
+- Document `--task-file` / `-T` flag across README, README.zh, `guides/usage.md`, `guides/references.md`, and `guides/a2a-communication.md`
+- Add troubleshooting guidance for 409 busy errors, missing `SYNAPSE_AGENT_ID`, and `SYNAPSE_LOG_LEVEL=DEBUG` diagnostic usage in `guides/troubleshooting.md`
+- Update `guides/profiles.md` Codex section to reflect hybrid idle detection configuration
+- Remove stale `--task` / `--callback` flag rows from `guides/references.md` (conflicted with new `-T` alias)
+
+### Tests
+
+- Add 29 new test cases across `test_a2a_client.py` (6), `test_send_message_file.py` (9), `test_tools_a2a.py` (1), `test_compound_signal.py` (4), `test_interactive_idle_detection.py` (1), covering all failure paths and new behaviors
+- Update existing `MagicMock`-based tests in `test_send_processing_wait.py` and `test_send_working_dir.py` to set `args.task_file = None` for the new `_resolve_message()` API
+
 ## [0.25.0] - 2026-04-11
 
 ### Added

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ site_url: https://s-hiraoku.github.io/synapse-a2a/
 site_description: Multi-agent collaboration framework using Google A2A Protocol
 site_author: s-hiraoku
 repo_url: https://github.com/s-hiraoku/synapse-a2a
-repo_name: s-hiraoku/synapse-a2a v0.25.0
+repo_name: s-hiraoku/synapse-a2a v0.25.1
 docs_dir: site-docs
 
 theme:

--- a/plugins/synapse-a2a/.claude-plugin/plugin.json
+++ b/plugins/synapse-a2a/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synapse-a2a",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "description": "Complete plugin for Synapse A2A multi-agent framework including inter-agent communication, file safety, and history management",
   "author": {
     "name": "s-hiraoku",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synapse-a2a"
-version = "0.25.0"
+version = "0.25.1"
 description = "Agent-to-Agent communication protocol for CLI agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/site-docs/changelog.md
+++ b/site-docs/changelog.md
@@ -4,6 +4,15 @@ For the complete changelog, see [CHANGELOG.md on GitHub](https://github.com/s-hi
 
 ## Recent Highlights
 
+### v0.25.1
+
+- **Fixed**: `synapse send` to Codex agents no longer fails with cryptic "local send failed" — HTTP 409 (agent busy) is now surfaced as "Agent busy (working task). Retry after Ns" (#554)
+- **Fixed**: `send_to_local()` logs diagnostic warnings at every failure path; set `SYNAPSE_LOG_LEVEL=DEBUG` for details (#542)
+- **Fixed**: `synapse send` warns when sender agent cannot be identified, advising to set `SYNAPSE_AGENT_ID` (#543)
+- **Fixed**: `--message-file`, `--task-file`, and `--stdin` inputs no longer trigger false backtick shell-expansion warnings (#544)
+- **Fixed**: Codex agent status uses hybrid idle detection with startup-only pattern matching, improving status accuracy during LLM thinking time (#537)
+- **Added**: `synapse send --task-file / -T PATH` flag mirroring the flag on `synapse spawn` (#545)
+
 ### v0.25.0
 
 - **Added**: Multi-agent coordination patterns engine — declarative YAML-based patterns with 5 built-in types (generator-verifier, orchestrator-subagent, agent-teams, message-bus, shared-state)

--- a/site-docs/concepts/a2a-protocol.md
+++ b/site-docs/concepts/a2a-protocol.md
@@ -17,7 +17,7 @@ Every A2A agent publishes a discovery document at `/.well-known/agent.json`:
   "name": "synapse-claude-8100",
   "description": "Claude Code agent managed by Synapse A2A",
   "url": "http://localhost:8100",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "capabilities": {
     "streaming": false,
     "pushNotifications": false

--- a/site-docs/getting-started/installation.md
+++ b/site-docs/getting-started/installation.md
@@ -58,7 +58,7 @@
 synapse --version
 ```
 
-You should see the version number (e.g., `0.25.0`).
+You should see the version number (e.g., `0.25.1`).
 
 ## Initialize Configuration
 

--- a/uv.lock
+++ b/uv.lock
@@ -1428,7 +1428,7 @@ wheels = [
 
 [[package]]
 name = "synapse-a2a"
-version = "0.25.0"
+version = "0.25.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

Patch release covering Codex A2A communication reliability fixes from PR #556.

Version: **0.25.0 → 0.25.1** (SemVer patch — bug fixes only, no breaking changes)

## Changes

- `pyproject.toml` — version bump
- `plugins/synapse-a2a/.claude-plugin/plugin.json` — plugin version sync
- `mkdocs.yml` — site header version
- `site-docs/getting-started/installation.md` — version example
- `site-docs/concepts/a2a-protocol.md` — Agent Card JSON example
- `CHANGELOG.md` — full 0.25.1 entry with all fixes, additions, docs, and test updates
- `site-docs/changelog.md` — Recent Highlights entry

## Fixed in this release

- #537 — Codex agent status stays READY during active task processing
- #542 — synapse send local delivery fails intermittently
- #543 — synapse send silently fails without SYNAPSE_AGENT_ID
- #544 — --message-file false backtick expansion warning
- #545 — synapse send --task-file support
- #554 — synapse send consistently fails on second message to Codex agents

## Test plan

- [x] Version strings consistent across pyproject.toml, plugin.json, mkdocs.yml, and site-docs
- [x] CHANGELOG.md follows Keep a Changelog format
- [x] Branch based on latest main (post #555, #553)

🤖 Generated with [Claude Code](https://claude.com/claude-code)