### PR TITLE
feat: auto-cleanup expired long-message temp files (#559)

### DIFF
--- a/synapse/long_message.py
+++ b/synapse/long_message.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 # Default configuration values
 DEFAULT_THRESHOLD = 200  # Characters (measured limit is 200-300)
 DEFAULT_TTL = 3600  # 1 hour
+DEFAULT_CLEANUP_INTERVAL = 300.0  # 5 minutes between lazy cleanup sweeps
 DEFAULT_MESSAGE_DIR = Path(tempfile.gettempdir()) / "synapse-a2a" / "messages"
 
 
@@ -56,6 +57,7 @@ class LongMessageStore:
         self.message_dir = message_dir
         self.threshold = threshold
         self.ttl = ttl
+        self._last_cleanup_ts: float = 0.0
 
         # Create directory if it doesn't exist
         self.message_dir.mkdir(parents=True, exist_ok=True)
@@ -106,6 +108,7 @@ class LongMessageStore:
                 temp_path.unlink()
             raise
 
+        self.maybe_cleanup_expired()
         return file_path
 
     def read_message(self, file_path: Path) -> str | None:
@@ -155,6 +158,27 @@ class LongMessageStore:
 
         return removed
 
+    def maybe_cleanup_expired(self, interval: float = DEFAULT_CLEANUP_INTERVAL) -> int:
+        """
+        Run cleanup_expired at most once per interval seconds.
+
+        Throttled lazy cleanup intended to be called from write paths
+        (e.g. store_message) so temp files do not accumulate between
+        explicit cleanup calls. The first invocation always runs because
+        the initial _last_cleanup_ts is 0.
+
+        Args:
+            interval: Minimum seconds between cleanup sweeps.
+
+        Returns:
+            Number of files removed in this call (0 when throttled).
+        """
+        now = time.time()
+        if now - self._last_cleanup_ts < interval:
+            return 0
+        self._last_cleanup_ts = now
+        return self.cleanup_expired()
+
 
 # Singleton instance
 _store_instance: LongMessageStore | None = None
@@ -189,6 +213,9 @@ def get_long_message_store() -> LongMessageStore:
             threshold=_get_env_int("SYNAPSE_LONG_MESSAGE_THRESHOLD", DEFAULT_THRESHOLD),
             ttl=_get_env_int("SYNAPSE_LONG_MESSAGE_TTL", DEFAULT_TTL),
         )
+        # Reclaim any stale files left behind by a previous process.
+        _store_instance.cleanup_expired()
+        _store_instance._last_cleanup_ts = time.time()
 
     return _store_instance
 

--- a/tests/test_docs_no_hardcoded_ids.py
+++ b/tests/test_docs_no_hardcoded_ids.py
@@ -31,13 +31,21 @@ AGENT_FACING_PATHS = [
 
 def _collect_files() -> list[Path]:
     """Collect all text files from agent-facing paths."""
+    # Exclude worktree-internal copies: they hold snapshots of older branches
+    # that are out of scope for this repo's main branch and must not fail the
+    # lint on this checkout.
+    worktrees_root = ROOT / ".synapse" / "worktrees"
     files: list[Path] = []
     for path in AGENT_FACING_PATHS:
         if path.is_file():
             files.append(path)
         elif path.is_dir():
             for ext in ("*.md", "*.txt", "*.yaml", "*.yml", "*.json"):
-                files.extend(path.rglob(ext))
+                for found in path.rglob(ext):
+                    try:
+                        found.relative_to(worktrees_root)
+                    except ValueError:
+                        files.append(found)
     return sorted(set(files))
 
 

--- a/tests/test_long_message.py
+++ b/tests/test_long_message.py
@@ -303,6 +303,178 @@ class TestCleanupExpired:
         assert removed == 0
 
 
+class TestMaybeCleanupExpired:
+    """Tests for the maybe_cleanup_expired throttled cleanup."""
+
+    def test_first_call_runs_cleanup(self, tmp_path: Path) -> None:
+        """First maybe_cleanup_expired call should run cleanup even though
+        no interval has elapsed, since _last_cleanup_ts starts at 0.
+        """
+        from synapse.long_message import LongMessageStore
+
+        message_dir = tmp_path / "messages"
+        store = LongMessageStore(
+            message_dir=message_dir,
+            threshold=200,
+            ttl=1,
+        )
+        # Create a stale file directly to bypass store_message's own
+        # maybe_cleanup_expired call, which would otherwise update
+        # _last_cleanup_ts before the assertion runs.
+        stale = message_dir / "stale.txt"
+        stale.write_text("old", encoding="utf-8")
+        past = time.time() - 10
+        os.utime(stale, (past, past))
+
+        removed = store.maybe_cleanup_expired()
+
+        assert removed == 1
+        assert not stale.exists()
+
+    def test_second_call_within_interval_is_noop(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """A second call before the interval elapses should skip cleanup."""
+        from synapse.long_message import LongMessageStore
+
+        message_dir = tmp_path / "messages"
+        store = LongMessageStore(
+            message_dir=message_dir,
+            threshold=200,
+            ttl=1,
+        )
+        base = 10_000.0
+        monkeypatch.setattr("synapse.long_message.time.time", lambda: base)
+
+        # First call establishes _last_cleanup_ts = base.
+        store.maybe_cleanup_expired(interval=300.0)
+
+        # Create an expired file after the first cleanup.
+        file_path = store.store_message("stale", "content")
+        os.utime(file_path, (base - 10, base - 10))
+
+        # Jump only 100 seconds — less than the 300s interval.
+        monkeypatch.setattr("synapse.long_message.time.time", lambda: base + 100)
+        removed = store.maybe_cleanup_expired(interval=300.0)
+
+        assert removed == 0
+        assert file_path.exists()
+
+    def test_call_after_interval_runs_cleanup(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """A call after the interval elapses should run cleanup again."""
+        from synapse.long_message import LongMessageStore
+
+        message_dir = tmp_path / "messages"
+        store = LongMessageStore(
+            message_dir=message_dir,
+            threshold=200,
+            ttl=1,
+        )
+        base = 10_000.0
+        monkeypatch.setattr("synapse.long_message.time.time", lambda: base)
+
+        # First call establishes _last_cleanup_ts = base.
+        store.maybe_cleanup_expired(interval=300.0)
+
+        file_path = store.store_message("stale", "content")
+        os.utime(file_path, (base - 10, base - 10))
+
+        # Jump forward by more than the interval.
+        monkeypatch.setattr("synapse.long_message.time.time", lambda: base + 400)
+        removed = store.maybe_cleanup_expired(interval=300.0)
+
+        assert removed == 1
+        assert not file_path.exists()
+
+
+class TestStoreMessageAutoCleanup:
+    """store_message should invoke maybe_cleanup_expired at the end."""
+
+    def test_store_message_triggers_maybe_cleanup(self, tmp_path: Path) -> None:
+        """Each store_message call should delegate to maybe_cleanup_expired."""
+        from synapse.long_message import LongMessageStore
+
+        store = LongMessageStore(
+            message_dir=tmp_path / "messages",
+            threshold=200,
+            ttl=3600,
+        )
+
+        calls: list[float] = []
+        original = store.maybe_cleanup_expired
+
+        def tracked(interval: float = 300.0) -> int:
+            calls.append(interval)
+            return original(interval)
+
+        # Replace after __init__ so constructor-side cleanup is not counted.
+        store.maybe_cleanup_expired = tracked  # type: ignore[method-assign]
+        store.store_message("task-1", "hello")
+
+        assert calls, "maybe_cleanup_expired should be called by store_message"
+
+
+class TestGetLongMessageStoreInitialCleanup:
+    """get_long_message_store should run one cleanup when creating the
+    singleton so stale files left by a previous process are reclaimed.
+    """
+
+    def test_singleton_creation_reclaims_stale_files(self, tmp_path: Path) -> None:
+        """get_long_message_store should delete stale files on first call."""
+        from synapse.long_message import get_long_message_store
+
+        message_dir = tmp_path / "messages"
+        message_dir.mkdir(parents=True)
+        stale = message_dir / "stale-task.txt"
+        stale.write_text("leftover", encoding="utf-8")
+        past = time.time() - 10_000
+        os.utime(stale, (past, past))
+
+        with patch.dict(
+            os.environ,
+            {
+                "SYNAPSE_LONG_MESSAGE_DIR": str(message_dir),
+                "SYNAPSE_LONG_MESSAGE_TTL": "3600",
+            },
+        ):
+            import synapse.long_message
+
+            synapse.long_message._store_instance = None
+            get_long_message_store()
+
+        assert not stale.exists()
+
+    def test_singleton_reuse_does_not_rerun_cleanup(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Only the first get_long_message_store call should trigger cleanup."""
+        import synapse.long_message
+        from synapse.long_message import LongMessageStore, get_long_message_store
+
+        synapse.long_message._store_instance = None
+
+        cleanup_calls: list[None] = []
+        original_cleanup = LongMessageStore.cleanup_expired
+
+        def tracked(self: LongMessageStore) -> int:
+            cleanup_calls.append(None)
+            return original_cleanup(self)
+
+        monkeypatch.setattr(LongMessageStore, "cleanup_expired", tracked)
+
+        with patch.dict(
+            os.environ,
+            {"SYNAPSE_LONG_MESSAGE_DIR": str(tmp_path / "messages")},
+        ):
+            get_long_message_store()
+            get_long_message_store()
+            get_long_message_store()
+
+        assert len(cleanup_calls) == 1
+
+
 class TestGetLongMessageStore:
     """Tests for the get_long_message_store factory function."""
 


### PR DESCRIPTION
## Summary

- `LongMessageStore.cleanup_expired()` existed but was never invoked at runtime, so temp files under `/tmp/synapse-a2a/messages` accumulated until manually purged.
- Wire a throttled lazy cleanup into the write path so files no longer pile up during normal operation.

## Changes

- `synapse/long_message.py`:
  - New `_last_cleanup_ts` instance field initialized to 0.
  - New `maybe_cleanup_expired(interval: float = 300.0) -> int` runs `cleanup_expired()` at most once per interval (default 5 min, 1/12 of the 1-hour TTL).
  - `store_message()` now calls `maybe_cleanup_expired()` after a successful write.
  - `get_long_message_store()` runs `cleanup_expired()` once when the singleton is created so stale files left by a previous process are reclaimed at startup.
- `tests/test_long_message.py`: 6 new tests covering the interval gate, store_message delegation, and singleton init cleanup (no changes to existing 22 tests).
- `tests/test_docs_no_hardcoded_ids.py`: exclude `.synapse/worktrees/**` from the lint scan so older worktree snapshots don't fail the main-branch check. Same environmental class of fix that PR #560 applied to `test_cli_file_safety.py`.

## Design notes

- **Preserve 1-hour TTL** so agents can retry reads on the same file (rate limits, PTY glitches, restart loops).
- **No background tasks** — keep behavior bounded and easy to test per the issue's "low-risk and bounded" guidance.
- **Cleanup is best-effort** — existing `cleanup_expired()` already logs and swallows per-file OSErrors, and the new `maybe_cleanup_expired` inherits that semantics.
- **history.db still holds the full message text**, so temp files are purely a PTY-injection convenience; purging them is lossless.

## Test plan

- [x] 6 new tests in `tests/test_long_message.py` (29 total in the file)
- [x] Full `pytest` (3951 passed / 47 skipped)
- [x] `ruff check synapse/long_message.py tests/test_long_message.py tests/test_docs_no_hardcoded_ids.py`
- [x] `ruff format --check …`
- [x] `mypy synapse/long_message.py`

Closes #559

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 期限切れメッセージの自動クリーンアップ機能を追加しました。メッセージ保存時に定期的なクリーンアップが実行されるようになります。
  * システム起動時に古いファイルが自動的に回収されるようになりました。

* **改善**
  * ファイル検出処理でワークツリーディレクトリを正しく除外するようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->