### PR TITLE
fix: treat input_required as transient for self-target workflow steps (#551)

### DIFF
--- a/synapse/workflow_runner.py
+++ b/synapse/workflow_runner.py
@@ -160,6 +160,7 @@ class _WorkflowHelper:
             task_id,
             wf_step,
             self.endpoint,
+            target_is_self=_is_self_target(wf_step.target, self.sender_info),
         )
 
     async def _ensure_started(self) -> tuple[bool, str | None]:
@@ -495,6 +496,8 @@ def _extract_task_output(task_data: dict) -> str:
 async def _poll_task_completion(
     endpoint: str,
     task_id: str,
+    *,
+    target_is_self: bool = False,
 ) -> tuple[str, str]:
     """Poll target agent's task until terminal state. Returns (status, output)."""
     from synapse.config import COMPLETED_TASK_STATES, TASK_POLL_INTERVAL
@@ -513,7 +516,7 @@ async def _poll_task_completion(
                 status = _extract_task_status(task_data)
                 if status in COMPLETED_TASK_STATES:
                     return status, _extract_task_output(task_data)
-                if status == "input_required":
+                if status == "input_required" and not target_is_self:
                     return "failed", (
                         "Agent requires permission approval"
                         " — check auto-approve configuration"
@@ -673,6 +676,7 @@ async def _apply_task_result(
     endpoint: str | None,
     *,
     humanize_target: str | None = None,
+    target_is_self: bool = False,
 ) -> None:
     """Apply send/poll results to a StepResult.
 
@@ -680,7 +684,11 @@ async def _apply_task_result(
     to avoid duplicating the returncode/status branching logic.
     """
     if returncode == 0 and wf_step.response_mode == "wait" and task_id and endpoint:
-        final_status, final_output = await _poll_task_completion(endpoint, task_id)
+        final_status, final_output = await _poll_task_completion(
+            endpoint,
+            task_id,
+            target_is_self=target_is_self,
+        )
         if final_status == "failed":
             step.status = "failed"
             step.error = final_output or "Agent task failed"
@@ -711,7 +719,8 @@ async def _execute_step(
     helper: _WorkflowHelper | None = None,
 ) -> None:
     """Execute a single workflow step via direct A2A HTTP send."""
-    if _is_self_target(wf_step.target, sender_info):
+    target_is_self = _is_self_target(wf_step.target, sender_info)
+    if target_is_self:
         if helper is None:
             step.status = "failed"
             step.error = "Workflow helper is unavailable"
@@ -757,6 +766,7 @@ async def _execute_step(
         wf_step,
         endpoint,
         humanize_target=wf_step.target,
+        target_is_self=target_is_self,
     )
 
 

--- a/tests/test_workflow_runner.py
+++ b/tests/test_workflow_runner.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -10,6 +12,7 @@ from synapse.workflow import Workflow, WorkflowStep
 from synapse.workflow_runner import (
     MAX_RUNS,
     StepResult,
+    _apply_task_result,
     _extract_task_output,
     _has_working_tasks,
     _is_self_target,
@@ -280,8 +283,9 @@ async def test_wait_mode_polls_until_completed(monkeypatch):
     _patch_workflow_send(monkeypatch, _mock_send)
 
     # Mock _poll_task_completion to return completed with output
-    async def _mock_poll(endpoint, task_id):
+    async def _mock_poll(endpoint, task_id, *, target_is_self=False):
         assert task_id == "task-wait-123"
+        assert target_is_self is False
         return "completed", "Final result from agent"
 
     monkeypatch.setattr("synapse.workflow_runner._poll_task_completion", _mock_poll)
@@ -313,7 +317,8 @@ async def test_wait_mode_agent_task_failed(monkeypatch):
 
     _patch_workflow_send(monkeypatch, _mock_send)
 
-    async def _mock_poll(endpoint, task_id):
+    async def _mock_poll(endpoint, task_id, *, target_is_self=False):
+        assert target_is_self is False
         return "failed", "Syntax error in generated code"
 
     monkeypatch.setattr("synapse.workflow_runner._poll_task_completion", _mock_poll)
@@ -345,7 +350,8 @@ async def test_wait_mode_agent_task_canceled(monkeypatch):
 
     _patch_workflow_send(monkeypatch, _mock_send)
 
-    async def _mock_poll(endpoint, task_id):
+    async def _mock_poll(endpoint, task_id, *, target_is_self=False):
+        assert target_is_self is False
         return "canceled", ""
 
     monkeypatch.setattr("synapse.workflow_runner._poll_task_completion", _mock_poll)
@@ -379,7 +385,7 @@ async def test_notify_mode_does_not_poll(monkeypatch):
 
     poll_called = False
 
-    async def _mock_poll(endpoint, task_id):
+    async def _mock_poll(endpoint, task_id, *, target_is_self=False):
         nonlocal poll_called
         poll_called = True
         return "completed", ""
@@ -960,6 +966,143 @@ async def test_poll_task_completion_input_required_returns_failed(monkeypatch):
     assert "permission" in output.lower()
 
 
+@pytest.mark.asyncio
+async def test_poll_task_completion_input_required_self_target_retries(monkeypatch):
+    """target_is_self=True: input_required is transient, polling continues."""
+    import httpx
+
+    call_count = 0
+
+    async def _mock_get(self, url, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            data = {"task": {"id": "t1", "status": {"state": "input_required"}}}
+        else:
+            data = {
+                "task": {
+                    "id": "t1",
+                    "status": {"state": "completed"},
+                    "artifacts": [{"parts": [{"type": "text", "text": "done"}]}],
+                }
+            }
+        return httpx.Response(200, json=data, request=httpx.Request("GET", url))
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", _mock_get)
+
+    async def _noop_sleep(_):
+        pass
+
+    monkeypatch.setattr("synapse.workflow_runner.asyncio.sleep", _noop_sleep)
+
+    status, output = await _poll_task_completion(
+        "http://localhost:8100",
+        "t1",
+        target_is_self=True,
+    )
+
+    assert status == "completed"
+    assert output == "done"
+    assert call_count >= 2
+
+
+@pytest.mark.asyncio
+async def test_poll_task_completion_input_required_self_target_timeout(monkeypatch):
+    """target_is_self=True: persistent input_required times out to completed/empty."""
+    import httpx
+
+    current_time = 100.0
+
+    async def _mock_get(self, url, **kwargs):
+        data = {"task": {"id": "t1", "status": {"state": "input_required"}}}
+        return httpx.Response(200, json=data, request=httpx.Request("GET", url))
+
+    async def _mock_sleep(delay):
+        nonlocal current_time
+        current_time += delay
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", _mock_get)
+    monkeypatch.setattr("synapse.workflow_runner.asyncio.sleep", _mock_sleep)
+    monkeypatch.setattr("synapse.workflow_runner.time.time", lambda: current_time)
+    monkeypatch.setattr("synapse.workflow_runner._POLL_TIMEOUT", 0.05)
+    monkeypatch.setattr("synapse.config.TASK_POLL_INTERVAL", 0.01)
+
+    status, output = await _poll_task_completion(
+        "http://localhost:8100",
+        "t1",
+        target_is_self=True,
+    )
+
+    assert status == "completed"
+    assert output == ""
+
+
+@pytest.mark.asyncio
+async def test_apply_task_result_passes_target_is_self_for_self_target(monkeypatch):
+    """_apply_task_result forwards target_is_self=True into polling."""
+
+    mock_poll = AsyncMock(return_value=("completed", "x"))
+    monkeypatch.setattr("synapse.workflow_runner._poll_task_completion", mock_poll)
+
+    step = StepResult(step_index=0, target="self", message="hi", status="running")
+    wf_step = SimpleNamespace(
+        target="self",
+        response_mode="wait",
+        message="hi",
+        priority=0,
+    )
+
+    await _apply_task_result(
+        step,
+        0,
+        "",
+        "",
+        "t1",
+        wf_step,
+        "http://localhost:9999",
+        target_is_self=True,
+    )
+
+    mock_poll.assert_awaited_once_with(
+        "http://localhost:9999",
+        "t1",
+        target_is_self=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_apply_task_result_passes_target_is_self_false_for_other(monkeypatch):
+    """_apply_task_result forwards target_is_self=False into polling."""
+
+    mock_poll = AsyncMock(return_value=("completed", "x"))
+    monkeypatch.setattr("synapse.workflow_runner._poll_task_completion", mock_poll)
+
+    step = StepResult(step_index=0, target="agent1", message="hi", status="running")
+    wf_step = SimpleNamespace(
+        target="agent1",
+        response_mode="wait",
+        message="hi",
+        priority=0,
+    )
+
+    await _apply_task_result(
+        step,
+        0,
+        "",
+        "",
+        "t1",
+        wf_step,
+        "http://localhost:9999",
+        target_is_self=False,
+    )
+
+    mock_poll.assert_awaited_once_with(
+        "http://localhost:9999",
+        "t1",
+        target_is_self=False,
+    )
+
+
 # ---------------------------------------------------------------------------
 # 17. _has_working_tasks treats input_required as blocking (#533)
 # ---------------------------------------------------------------------------
@@ -998,7 +1141,8 @@ async def test_wait_mode_input_required_fails_step(monkeypatch):
 
     _patch_workflow_send(monkeypatch, _mock_send)
 
-    async def _mock_poll(endpoint, task_id):
+    async def _mock_poll(endpoint, task_id, *, target_is_self=False):
+        assert target_is_self is False
         return (
             "failed",
             "Agent requires permission approval — check auto-approve configuration",


### PR DESCRIPTION
## Summary

- `synapse workflow run post-impl-codex` was failing at step 1 with
  `Agent requires permission approval — check auto-approve configuration`
  even though auto-approve was configured correctly.
- Root cause: `_poll_task_completion` treated the `input_required` task
  state as a terminal failure. For workflow steps with `target: self`,
  A2A self-injection produces a brief `input_required` window while the
  message is accepted; the agent itself processes the message on its
  next turn, so there is no external human to approve. The poller was
  killing the step at the first glimpse of that transient state.
- Fix: `_poll_task_completion` now accepts a keyword-only
  `target_is_self` flag. When true, `input_required` is treated as a
  transient state and the polling loop continues to the next iteration
  instead of short-circuiting to failure. `_apply_task_result` forwards
  the flag, which both call sites compute via the existing
  `_is_self_target(wf_step.target, sender_info)` helper — no
  reimplementation.
- For non-self targets, behavior is unchanged: `input_required` still
  fast-fails, preserving the "real human stuck" signal.

This brings `_poll_task_completion` into agreement with
`_wait_for_helper_idle`, which already treats `input_required` as a
blocking (not terminal) state via `BLOCKING_TASK_STATES`.

Fixes #551.

## Test plan

- [x] `pytest tests/test_workflow_runner.py -v -k input_required`: 5 passed
  - existing `test_poll_task_completion_input_required_returns_failed`
    still passes (non-self case, default `target_is_self=False`)
  - new `test_poll_task_completion_input_required_self_target_retries`
  - new `test_poll_task_completion_input_required_self_target_timeout`
  - existing `test_has_working_tasks_includes_input_required` unchanged
  - existing `test_wait_mode_input_required_fails_step` unchanged
    (uses `target="agent1"`, non-self)
- [x] `pytest`: 3955 passed, 47 skipped (no regressions)
- [x] `ruff check synapse/workflow_runner.py tests/test_workflow_runner.py`: clean
- [x] `ruff format --check synapse/workflow_runner.py tests/test_workflow_runner.py`: clean
- [x] `mypy synapse/workflow_runner.py`: clean
- [x] Also added `test_apply_task_result_passes_target_is_self_for_self_target`
  and `test_apply_task_result_passes_target_is_self_false_for_other` to
  pin the flag-forwarding contract.
- [x] Existing `_mock_poll` helpers in 5 pre-existing tests were updated
  to accept and assert `target_is_self=False`, which gives us a
  regression guard against future accidental flag leaks into non-self
  paths.

## Out of scope

- Per-step `step.timeout` override (still uses the global `_POLL_TIMEOUT`).
- Any change to non-self `input_required` handling.
- Any change to `BLOCKING_TASK_STATES` or `_has_working_tasks`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * セルフターゲットのワークフロータスク実行時に、「input_required」ステータスの処理動作を改善しました。入力が必要な状態では、タスクはすぐに失敗するのではなく、ポーリングを継続して完了を待つようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->