### PR TITLE
fix: revert task_store input_required on any exit from WAITING (#569)

### DIFF
--- a/synapse/a2a_compat.py
+++ b/synapse/a2a_compat.py
@@ -31,7 +31,7 @@ from synapse.config import (
     CONTEXT_RECENT_SIZE,
 )
 from synapse.controller import TerminalController
-from synapse.error_detector import detect_task_status, is_input_required
+from synapse.error_detector import detect_task_status
 from synapse.history import HistoryManager
 from synapse.long_message import (
     LongMessageStore,
@@ -1025,11 +1025,12 @@ def create_a2a_router(
                     _run_async_from_sync(coro)
                 return
 
-            if old == "WAITING" and new == "PROCESSING":
+            if old == "WAITING":
                 for task in task_store.list_tasks():
                     if task.status == "input_required":
                         task_store.update_status(task.id, "working")
-                return
+                # Fall through to the READY/DONE finalization below so
+                # that WAITING → READY completes working tasks normally.
 
             if new not in ("READY", "DONE"):
                 return
@@ -1791,10 +1792,15 @@ def create_a2a_router(
             synapse_status = controller.status
             context = controller.get_context()
 
-            # Check for input_required state first
-            if is_input_required(context):
-                task_store.update_status(task_id, "input_required")
-            elif synapse_status in ("READY", "DONE"):
+            # NOTE: the previous code checked ``is_input_required(context)``
+            # here and wrote ``input_required`` into task_store. That was a
+            # rogue write in a GET handler — a read-only endpoint should not
+            # have side effects. The ``_on_status_change`` callback is now
+            # the single writer for ``input_required`` transitions (issue
+            # #569). Removing this branch also prevents PTY context remnants
+            # from re-setting ``input_required`` after the controller has
+            # already exited WAITING.
+            if synapse_status in ("READY", "DONE"):
                 recent_context = context[-CONTEXT_RECENT_SIZE:]
                 updated_task = _finalize_working_task(task_id, context, recent_context)
 

--- a/tests/test_status_sync_569.py
+++ b/tests/test_status_sync_569.py
@@ -1,0 +1,187 @@
+"""Tests for issue #569: status sync between controller and task_store.
+
+The core bug: when the controller transitions WAITING → READY (e.g., the
+permission prompt disappears because the user accepted), the task_store
+does not revert from ``input_required`` back to ``working``. This makes
+``GET /tasks/{id}`` return a stale ``input_required`` and causes the
+Approval Gate loop to re-escalate.
+
+Additionally, the ``GET /tasks/{id}`` handler itself was a rogue writer:
+it called ``task_store.update_status(task_id, "input_required")`` when
+``is_input_required(context)`` was True, even when ``controller.status``
+was already READY. A GET handler should be side-effect-free.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from synapse.a2a_compat import create_a2a_router
+from synapse.task_store import TaskStore
+
+
+@pytest.fixture
+def mock_controller() -> MagicMock:
+    c = MagicMock()
+    c.status = "PROCESSING"
+    c.get_context.return_value = "Working on task..."
+    return c
+
+
+@pytest.fixture
+def task_store_instance() -> TaskStore:
+    return TaskStore()
+
+
+@pytest.fixture
+def app(mock_controller: MagicMock, task_store_instance: TaskStore) -> FastAPI:
+    app = FastAPI()
+    router = create_a2a_router(mock_controller, "codex", 8126, "\n")
+    app.include_router(router)
+    return app
+
+
+@pytest.fixture
+def client(app: FastAPI) -> TestClient:
+    return TestClient(app)
+
+
+class TestWaitingToReadyRevertsTaskStore:
+    """Fix 1: _on_status_change must revert input_required → working
+    when controller exits WAITING to any state, not just PROCESSING.
+    """
+
+    def test_waiting_to_ready_reverts_input_required_tasks(
+        self, mock_controller: MagicMock
+    ) -> None:
+        """When controller goes WAITING → READY (permission accepted and
+        new output arrived), all input_required tasks must become working
+        again. Pre-fix: only WAITING → PROCESSING was handled."""
+        app = FastAPI()
+        router = create_a2a_router(mock_controller, "codex", 8126, "\n")
+        app.include_router(router)
+        client = TestClient(app)
+
+        # Grab the task_store from the router closure — send a task
+        # to create one in the store.
+        resp = client.post(
+            "/tasks/send",
+            json={
+                "message": {"role": "user", "parts": [{"text": "hello"}]},
+            },
+        )
+        assert resp.status_code == 200
+        task_id = resp.json()["task"]["id"]
+
+        # Import the task_store singleton used by the router:
+        from synapse.a2a_compat import task_store
+
+        # Simulate the controller going WAITING
+        mock_controller.status = "WAITING"
+        callbacks = mock_controller.on_status_change.call_args_list
+        # The router registered a callback via controller.on_status_change
+        assert len(callbacks) >= 1
+        status_callback = callbacks[0][0][0]
+
+        status_callback("PROCESSING", "WAITING")
+        task = task_store.get(task_id)
+        assert task is not None
+        assert task.status == "input_required"
+
+        # Now simulate WAITING → READY (the missing path pre-fix)
+        mock_controller.status = "READY"
+        mock_controller.get_context.return_value = "New output after prompt cleared"
+        status_callback("WAITING", "READY")
+
+        task = task_store.get(task_id)
+        assert task is not None
+        assert task.status != "input_required", (
+            "task_store must revert from input_required when controller "
+            "exits WAITING to READY"
+        )
+
+    def test_waiting_to_done_reverts_input_required_tasks(
+        self, mock_controller: MagicMock
+    ) -> None:
+        """WAITING → DONE should also revert input_required tasks."""
+        app = FastAPI()
+        router = create_a2a_router(mock_controller, "codex", 8126, "\n")
+        app.include_router(router)
+        client = TestClient(app)
+
+        resp = client.post(
+            "/tasks/send",
+            json={
+                "message": {"role": "user", "parts": [{"text": "hello"}]},
+            },
+        )
+        task_id = resp.json()["task"]["id"]
+
+        from synapse.a2a_compat import task_store
+
+        callbacks = mock_controller.on_status_change.call_args_list
+        status_callback = callbacks[0][0][0]
+
+        mock_controller.status = "WAITING"
+        status_callback("PROCESSING", "WAITING")
+        assert task_store.get(task_id).status == "input_required"
+
+        mock_controller.status = "DONE"
+        mock_controller.get_context.return_value = "Task completed"
+        status_callback("WAITING", "DONE")
+
+        task = task_store.get(task_id)
+        assert task is not None
+        assert task.status != "input_required"
+
+
+class TestGetTasksNoRogueWrite:
+    """Fix 2: GET /tasks/{id} must not write to task_store.
+
+    Pre-fix, the handler called
+    ``task_store.update_status(task_id, "input_required")`` when
+    ``is_input_required(context)`` returned True, even when the
+    controller had already exited WAITING. A GET handler should be
+    side-effect-free.
+    """
+
+    def test_get_task_does_not_set_input_required(
+        self, mock_controller: MagicMock
+    ) -> None:
+        app = FastAPI()
+        router = create_a2a_router(mock_controller, "codex", 8126, "\n")
+        app.include_router(router)
+        client = TestClient(app)
+
+        # Create a task
+        resp = client.post(
+            "/tasks/send",
+            json={
+                "message": {"role": "user", "parts": [{"text": "hello"}]},
+            },
+        )
+        task_id = resp.json()["task"]["id"]
+
+        from synapse.a2a_compat import task_store
+
+        # Controller is READY but context still has permission remnant
+        mock_controller.status = "READY"
+        mock_controller.get_context.return_value = (
+            "Some old text with › 1. Yes, proceed remnant"
+        )
+
+        # GET the task — must NOT write input_required
+        with patch("synapse.a2a_compat.is_input_required", return_value=True):
+            resp = client.get(f"/tasks/{task_id}")
+
+        assert resp.status_code == 200
+        # Verify task_store was NOT updated to input_required
+        task = task_store.get(task_id)
+        assert task is not None
+        assert task.status != "input_required", (
+            "GET /tasks/{id} must not set input_required — it is a read-only endpoint"
+        )

--- a/tests/test_status_sync_569.py
+++ b/tests/test_status_sync_569.py
@@ -14,7 +14,7 @@ was already READY. A GET handler should be side-effect-free.
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 from fastapi import FastAPI
@@ -175,8 +175,7 @@ class TestGetTasksNoRogueWrite:
         )
 
         # GET the task — must NOT write input_required
-        with patch("synapse.a2a_compat.is_input_required", return_value=True):
-            resp = client.get(f"/tasks/{task_id}")
+        resp = client.get(f"/tasks/{task_id}")
 
         assert resp.status_code == 200
         # Verify task_store was NOT updated to input_required


### PR DESCRIPTION
## Summary

Two targeted fixes for the status sync divergence between `controller.status` and `task_store` captured during the Step D diagnostic (2026-04-15). Approach: **(a) task_store authority** — the `_on_status_change` callback is the single writer for `input_required` transitions; no other code path may set this state.

1. **Missing reverse path in `_on_status_change`**: the callback only reverted `input_required` → `working` on WAITING → PROCESSING. WAITING → READY and WAITING → DONE left tasks stuck in `input_required`, causing `/tasks` to report stale state and the Approval Gate to re-escalate indefinitely. Fix: widen the guard from `old == "WAITING" and new == "PROCESSING"` to `old == "WAITING"` and fall through to the existing READY/DONE finalization.
2. **Rogue write in `GET /tasks/{id}`**: the handler called `task_store.update_status(task_id, "input_required")` when `is_input_required(context)` returned True — even when `controller.status` had already exited WAITING. This re-introduced the stale state from PTY context remnants. Fix: remove the side effect. The GET endpoint is now read-only.

## Root cause trace

```
Controller: WAITING → READY (idle_detector transitions, registry updated)
Task_store:  input_required → ??? (no callback fires for WAITING → READY)
GET /tasks:  is_input_required(old PTY context) → true → re-writes input_required
             ↳ parent polls /tasks → sees input_required → re-escalates
```

The reverse path from `input_required` back to `working` was only wired for WAITING → PROCESSING (line 1028). WAITING → READY and WAITING → DONE fell through to the `if new not in ("READY", "DONE"): return` guard, which only operated on `task.status == "working"` — skipping `input_required` tasks entirely.

## Design decision

Chose **approach (a): task_store authority** per user's instruction. The `_on_status_change` callback is the single writer for `input_required` transitions. This is a ~15 line change that fixes the symptom without requiring a new StatusHub abstraction. If precision issues arise later, the plan is to escalate to a StatusHub (approach c).

## Not in scope

- **#571 Phase 3** (approval policy expansion) — separate PR
- **Dedicated BLOCKED state** (surfaced to `synapse list` / Canvas) — separate UX PR
- **StatusHub abstraction** — deferred unless (a) proves insufficient

## Test plan

- [x] `pytest tests/test_status_sync_569.py` — 3 new tests: WAITING → READY revert, WAITING → DONE revert, GET no rogue write
- [x] `pytest tests/test_a2a_compat.py tests/test_a2a_compat_extended.py tests/test_approval_gate.py tests/test_compound_signal.py tests/test_controller_pty.py tests/test_status_unification.py tests/test_controller_registry_sync.py` — 194 passed, 0 regressions
- [x] Full `pytest` (excluding 4 pre-existing env-dependent failures) — 3840 passed; the one flake (`test_force_skips_wait`) passes on re-run in isolation
- [x] Pre-commit (ruff + ruff-format + mypy) — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * タスクステータスの遷移時の処理が改善されました。WAITING から READY または DONE へ遷移する際、入力が必要なタスクが正しく処理されるようになりました
  * GETリクエストがタスク情報に意図しない変更を加えなくなりました

* **Tests**
  * タスク同期に関する回帰テストを追加しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->