### PR TITLE
feat: expand approval gate policy handling

### DIFF
--- a/guides/usage.md
+++ b/guides/usage.md
@@ -1359,6 +1359,8 @@ steps:
 - **`--auto-spawn` でスポーンされる子の権限フラグ** — workflow 経由で自動スポーンされる子エージェントには、プロファイルの `auto_approve.alternative_flags` の先頭が付与されます (例: codex なら `--dangerously-bypass-approvals-and-sandbox`)。バッチ実行されるワークフロー子は runtime permission prompt で止まらず走り切る必要があるため、`--full-auto` デフォルトではなく sandbox を解除した形で起動します。対話的に `synapse spawn` / `synapse team start` で起動する場合は従来通りの `--full-auto` デフォルトです。
 - **Busy retry** — 連続するステップの遷移期は、ターゲットが前ステップの finalization 中で短時間 busy になります。これを素早くリトライするため、runner は 409 応答を受けたら `/tasks` エンドポイントを 30 秒おきにポーリングして idle を待ち、最大 10 回 (約 5 分間) リトライします。ターゲットが idle になった瞬間に次の送信を走らせるので、無駄に sleep し続けることはありません。
 - **Approval Gate による自動承認** — 子エージェントが permission prompt で停止すると、子のサーバは親エージェントに構造化された escalation メッセージ (`permission_escalation` メタデータ付き) を送ります。親エージェントの受信ハンドラは `synapse/approval_gate.py` の Decision Engine に dispatch し、ポリシーに従って `POST /tasks/<id>/permission/approve` または `deny` を自動的に送り返します。親 PTY に人間への alert が出ることはなく、ポリシー経由で挙動を制御できます。
+- **Prompt classification と action 別ポリシー** — Approval Gate は子の `pty_context` を `permission_request` (通常の承認プロンプト)、`overwrite_confirm` (上書き確認)、`dangerous_command` (破壊的操作の警告)、`clarification_request` (追加情報の要求)、`blocked` (approve では解決しない停止状態)、`unknown` のいずれかに分類します。`profile_overrides` は従来通り `"claude": "escalate"` のような文字列も使えますが、エージェントタイプごとに class 別 action を指定する dict 形式も使えます。
+- **Risk classifier safety floor** — `rm -rf` / `sudo` / `DROP TABLE` / `WHERE` のない `DELETE FROM` / `main`・`master` への force push / `--no-verify` / `--no-gpg-sign` / `.env`・`credentials.json`・`id_rsa` などの credential path は高リスクとして扱われます。ポリシー解決後の action が `approve` でも、高リスクの場合は必ず `escalate` に引き上げられます。`deny` や明示的な `escalate` を弱めることはありません。
 - **Blocked-state 検出 と エスカレーション dedupe** — 子の `pty_context` が `hit your usage limit` / `Upgrade to Pro` / `try again at ... AM|PM` のような**approve で解決しない terminal 状態**を示している場合、Approval Gate はポリシー設定に関わらず自動で `escalate` に落とします。approve を送っても modal が受け取らず、子が同じ画面で新しい task_id を生成して無限に再エスカレーションするのを防ぎます。加えて `EscalationDeduper` (TTL 60 秒) が `(target_agent_id, hash(pty_context))` をキーに最近のエスカレーションを記録しており、同じ子が同じ画面で再送してきた場合は 2 回目以降を `approval_gate_deduped: True` として短絡します。
 - **`input_required` 時の待機セマンティクス** — `synapse send --wait` は、対象タスクが `input_required` に遷移した場合でも早期に exit せず、親エージェント (または Approval Gate) が介入してタスクが完了するまでポーリングを続けます。タイムアウトは `SYNAPSE_PARENT_INTERVENTION_TIMEOUT` 環境変数 (既定 1800 秒) で制御します。
 - **仮想ターミナルでの waiting_detection 評価 (#572)** — 子エージェントの PTY 出力はバイト列のまま regex にかけると、ratatui などの TUI が cursor motion (`\x1b[H`) で同じ座標を繰り返し書き換えるため `Working•Working•orking` のように破壊された文字列になっていました。現在は `pyte` ベースの仮想ターミナル (`synapse/pty_renderer.py`) に raw bytes をフィードし、レンダリング後の画面テキストに対して waiting_detection regex を評価しています。alt-screen buffer (`\x1b[?1049h/l`) の enter/leave もラッパー側で追跡しており、全画面オーバーレイの内容が正しく露出します。
@@ -1372,6 +1374,11 @@ steps:
     "enabled": true,
     "default_action": "approve",
     "profile_overrides": {
+      "codex": {
+        "default": "approve",
+        "dangerous_command": "escalate",
+        "overwrite_confirm": "approve"
+      },
       "claude": "escalate"
     }
   }
@@ -1379,7 +1386,7 @@ steps:
 ```
 
 - `default_action`: `approve` (デフォルト) / `deny` / `escalate` (人間介入を要求)
-- `profile_overrides`: エージェントタイプ別の上書き
+- `profile_overrides`: エージェントタイプ別の上書き。値が文字列なら従来通り全 class に適用されます。値が dict の場合は `prompt_class` (`permission_request` など) を先に見て、なければその profile の `default`、それもなければ global `default_action` にフォールバックします
 - `enabled: false` にすると Approval Gate は常に `escalate` を返し、既存の「親が手動で curl で承認」フローに戻ります
 
 #### Canvas からの実行

--- a/synapse/approval_gate.py
+++ b/synapse/approval_gate.py
@@ -54,6 +54,70 @@ _BLOCKED_STATE_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"try again at .+ (AM|PM)", re.IGNORECASE),
 )
 
+_PERMISSION_REQUEST_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"\bYes,\s*proceed\b", re.IGNORECASE),
+    re.compile(r"\bAllow\b.+\?", re.IGNORECASE | re.DOTALL),
+    re.compile(r"\[[Yy]/n\]|\[y/N\]", re.IGNORECASE),
+    re.compile(r"\bproceed\s*\([Yy]\)", re.IGNORECASE),
+)
+
+_OVERWRITE_CONFIRM_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"\boverwrite\b", re.IGNORECASE),
+    re.compile(r"\breplace\b", re.IGNORECASE),
+    re.compile(r"\balready exists\b", re.IGNORECASE),
+)
+
+_DANGEROUS_COMMAND_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"\brm\s+-[^\n;]*r", re.IGNORECASE),
+    re.compile(r"\bsudo\b", re.IGNORECASE),
+    re.compile(r"\bDROP\s+TABLE\b", re.IGNORECASE),
+    re.compile(r"\bDELETE\s+FROM\b", re.IGNORECASE),
+    re.compile(r"\bforce\s+push\b", re.IGNORECASE),
+    re.compile(r"\bgit\s+push\b[^\n;]*(--force|-f)\b", re.IGNORECASE),
+    re.compile(r"--no-verify\b", re.IGNORECASE),
+    re.compile(r"--no-gpg-sign\b", re.IGNORECASE),
+)
+
+_CLARIFICATION_REQUEST_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"\bWhich\b", re.IGNORECASE),
+    re.compile(r"\bChoose\b", re.IGNORECASE),
+    re.compile(r"\bSelect\b", re.IGNORECASE),
+    re.compile(r"\bPlease specify\b", re.IGNORECASE),
+)
+
+_SECRET_PATH_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"(^|[/\s])\.env(\b|$)", re.IGNORECASE),
+    re.compile(r"credentials\.json", re.IGNORECASE),
+    re.compile(r"id_rsa", re.IGNORECASE),
+)
+
+_RM_RECURSIVE_PATTERN = re.compile(
+    r"\brm\s+(?P<flags>-[^\s;]*r[^\s;]*)\s+(?P<path>[^\s;]+)",
+    re.IGNORECASE,
+)
+_DELETE_FROM_PATTERN = re.compile(r"\bDELETE\s+FROM\b", re.IGNORECASE)
+_GIT_FORCE_PUSH_MAIN_PATTERN = re.compile(
+    r"\bgit\s+push\b(?=[^\n;]*(?:--force|-f)\b)(?=[^\n;]*\b(?:main|master)\b)",
+    re.IGNORECASE,
+)
+
+
+def classify_prompt(pty_context: str) -> str:
+    """Classify a child PTY prompt into a policy action class."""
+    if not pty_context:
+        return "unknown"
+    if _is_blocked_state(pty_context):
+        return "blocked"
+    if any(p.search(pty_context) for p in _DANGEROUS_COMMAND_PATTERNS):
+        return "dangerous_command"
+    if any(p.search(pty_context) for p in _OVERWRITE_CONFIRM_PATTERNS):
+        return "overwrite_confirm"
+    if any(p.search(pty_context) for p in _PERMISSION_REQUEST_PATTERNS):
+        return "permission_request"
+    if any(p.search(pty_context) for p in _CLARIFICATION_REQUEST_PATTERNS):
+        return "clarification_request"
+    return "unknown"
+
 
 def _is_blocked_state(pty_context: str) -> bool:
     """True if *pty_context* looks like a non-permission terminal state.
@@ -64,6 +128,38 @@ def _is_blocked_state(pty_context: str) -> bool:
     if not pty_context:
         return False
     return any(p.search(pty_context) for p in _BLOCKED_STATE_PATTERNS)
+
+
+def _rm_recursive_targets_outside_cwd(pty_context: str) -> bool:
+    for match in _RM_RECURSIVE_PATTERN.finditer(pty_context):
+        path = match.group("path").strip("'\"")
+        if path.startswith(("/", "~", "..")):
+            return True
+    return False
+
+
+def _delete_from_without_where(pty_context: str) -> bool:
+    for match in _DELETE_FROM_PATTERN.finditer(pty_context):
+        tail = pty_context[match.end() :]
+        statement = tail.split(";", 1)[0]
+        if not re.search(r"\bWHERE\b", statement, re.IGNORECASE):
+            return True
+    return False
+
+
+def _is_high_risk(pty_context: str) -> bool:
+    """True when a prompt contains destructive intent that must escalate."""
+    if not pty_context:
+        return False
+    return (
+        _rm_recursive_targets_outside_cwd(pty_context)
+        or bool(re.search(r"\bsudo\b", pty_context, re.IGNORECASE))
+        or bool(re.search(r"\bDROP\s+TABLE\b", pty_context, re.IGNORECASE))
+        or _delete_from_without_where(pty_context)
+        or bool(_GIT_FORCE_PUSH_MAIN_PATTERN.search(pty_context))
+        or bool(re.search(r"--no-verify\b|--no-gpg-sign\b", pty_context, re.IGNORECASE))
+        or any(p.search(pty_context) for p in _SECRET_PATH_PATTERNS)
+    )
 
 
 class ApprovalDecision(str, Enum):
@@ -110,7 +206,13 @@ def _load_policy() -> dict[str, Any]:
         {
             "enabled": True,
             "default_action": "approve",
-            "profile_overrides": {"codex": "approve", "claude": "escalate"},
+            "profile_overrides": {
+                "codex": {
+                    "default": "approve",
+                    "dangerous_command": "escalate",
+                },
+                "claude": "escalate",
+            },
         }
 
     Any subset of keys may be present; missing keys fall back to built-in
@@ -143,13 +245,31 @@ def _load_policy() -> dict[str, Any]:
             merged["default_action"] = action
     overrides = policy.get("profile_overrides")
     if isinstance(overrides, dict):
-        clean_overrides = {
-            str(k): str(v).lower()
-            for k, v in overrides.items()
-            if str(v).lower() in {d.value for d in ApprovalDecision}
-        }
+        valid_actions = {d.value for d in ApprovalDecision}
+        clean_overrides: dict[str, str | dict[str, str]] = {}
+        for profile, override in overrides.items():
+            profile_key = str(profile)
+            if isinstance(override, dict):
+                clean_action_map = {
+                    str(prompt_class): str(action).lower()
+                    for prompt_class, action in override.items()
+                    if str(action).lower() in valid_actions
+                }
+                if clean_action_map:
+                    clean_overrides[profile_key] = clean_action_map
+                continue
+            action = str(override).lower()
+            if action in valid_actions:
+                clean_overrides[profile_key] = action
         merged["profile_overrides"] = clean_overrides
     return merged
+
+
+def _decision_from_value(value: Any) -> ApprovalDecision | None:
+    try:
+        return ApprovalDecision(str(value))
+    except ValueError:
+        return None
 
 
 def decide(request: ApprovalRequest) -> ApprovalDecision:
@@ -162,16 +282,19 @@ def decide(request: ApprovalRequest) -> ApprovalDecision:
        banner (e.g. OpenAI usage limit), escalate regardless of policy
        — approving would send ``y\\r`` to a modal that does not accept
        it and the child would re-escalate indefinitely.
-    3. Per-profile override (keyed by ``target_agent_type``) wins over
-       the default.
-    4. Fall back to the configured ``default_action`` (approve unless
-       settings say otherwise).
+    3. Per-profile string override (keyed by ``target_agent_type``) wins
+       over the default. Dict overrides first check the classified prompt
+       class, then a profile ``default`` key.
+    4. Fall back to the configured global ``default_action``.
+    5. If the resolved decision is approve but the prompt is high-risk,
+       escalate. Policy cannot lower this safety floor.
     """
     policy = _load_policy()
     if not policy.get("enabled", True):
         return ApprovalDecision.ESCALATE
 
-    if _is_blocked_state(request.pty_context):
+    prompt_class = classify_prompt(request.pty_context)
+    if prompt_class == "blocked":
         logger.info(
             "approval_gate: blocked-state detected on task %s (%s); escalating",
             request.task_id,
@@ -179,32 +302,48 @@ def decide(request: ApprovalRequest) -> ApprovalDecision:
         )
         return ApprovalDecision.ESCALATE
 
-    overrides: dict[str, str] = policy.get("profile_overrides") or {}
+    decision: ApprovalDecision | None = None
+    overrides: dict[str, Any] = policy.get("profile_overrides") or {}
     override = overrides.get(request.target_agent_type)
-    if override:
-        try:
-            return ApprovalDecision(override)
-        except ValueError:
+    if isinstance(override, dict):
+        for key in (prompt_class, "default"):
+            if key in override:
+                decision = _decision_from_value(override[key])
+                if decision is not None:
+                    break
+                logger.warning(
+                    "approval_gate: invalid override %r for profile %s class %s",
+                    override[key],
+                    request.target_agent_type,
+                    key,
+                )
+    elif override:
+        decision = _decision_from_value(override)
+        if decision is None:
             logger.warning(
                 "approval_gate: invalid override %r for profile %s",
                 override,
                 request.target_agent_type,
             )
 
-    default_action = str(policy.get("default_action", "approve"))
-    try:
-        return ApprovalDecision(default_action)
-    except ValueError:
-        # Malformed settings value. Prefer the safe side (escalate to a
-        # human) rather than silently auto-approving based on a typo —
-        # mirrors the ``disabled`` branch above. The ``_load_policy`` loader
-        # normally filters bad values out, so this path only fires when a
-        # caller bypasses the loader (e.g., tests or direct monkeypatch).
+    if decision is None:
+        default_action = str(policy.get("default_action", "approve"))
+        decision = _decision_from_value(default_action)
+    if decision is None:
         logger.warning(
             "approval_gate: invalid default_action %r, escalating",
-            default_action,
+            policy.get("default_action"),
+        )
+        decision = ApprovalDecision.ESCALATE
+
+    if decision is ApprovalDecision.APPROVE and _is_high_risk(request.pty_context):
+        logger.info(
+            "approval_gate: high-risk prompt detected on task %s (%s); escalating",
+            request.task_id,
+            request.target_agent_id,
         )
         return ApprovalDecision.ESCALATE
+    return decision
 
 
 def apply(

--- a/tests/test_approval_gate.py
+++ b/tests/test_approval_gate.py
@@ -17,7 +17,9 @@ from synapse.approval_gate import (
     ApprovalDecision,
     ApprovalRequest,
     EscalationDeduper,
+    _is_high_risk,
     apply,
+    classify_prompt,
     decide,
     decide_and_apply,
     get_default_deduper,
@@ -179,6 +181,208 @@ class TestApprovalGateBlockedStates:
         monkeypatch.setattr("synapse.approval_gate._load_policy", _policy)
         ctx = "■ You've hit your usage limit."
         assert decide(_req(pty_context=ctx)) is ApprovalDecision.ESCALATE
+
+
+class TestPromptClassification:
+    def test_permission_request_matches_yes_proceed_prompt(self) -> None:
+        assert classify_prompt("› 1. Yes, proceed (y)") == "permission_request"
+
+    def test_permission_request_matches_allow_prompt(self) -> None:
+        assert (
+            classify_prompt(
+                "Allow Bash to run pytest tests/test_approval_gate.py? [Y/n]"
+            )
+            == "permission_request"
+        )
+
+    def test_overwrite_confirm_matches_overwrite_prompt(self) -> None:
+        assert classify_prompt("File exists. overwrite?") == "overwrite_confirm"
+
+    def test_overwrite_confirm_matches_replace_prompt(self) -> None:
+        assert (
+            classify_prompt("Destination already exists, replace it?")
+            == "overwrite_confirm"
+        )
+
+    def test_dangerous_command_matches_destructive_warning(self) -> None:
+        assert classify_prompt("About to run rm -rf /tmp/build") == "dangerous_command"
+
+    def test_dangerous_command_matches_no_verify(self) -> None:
+        assert classify_prompt("Run git commit --no-verify?") == "dangerous_command"
+
+    def test_clarification_request_matches_choice_prompt(self) -> None:
+        assert classify_prompt("Which branch should I use?") == "clarification_request"
+
+    def test_clarification_request_matches_specify_prompt(self) -> None:
+        assert (
+            classify_prompt("Please specify the deployment target.")
+            == "clarification_request"
+        )
+
+    def test_blocked_state_classification_reuses_blocked_detector(self) -> None:
+        assert classify_prompt("You've hit your usage limit.") == "blocked"
+
+    def test_unknown_is_fallback_for_empty_or_unmatched_text(self) -> None:
+        assert classify_prompt("") == "unknown"
+        assert classify_prompt("pytest is running") == "unknown"
+
+
+class TestPerActionPolicy:
+    def test_dict_override_uses_prompt_class_action(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "synapse.approval_gate._load_policy",
+            lambda: {
+                "enabled": True,
+                "default_action": "approve",
+                "profile_overrides": {
+                    "codex": {
+                        "default": "approve",
+                        "dangerous_command": "escalate",
+                        "overwrite_confirm": "deny",
+                    }
+                },
+            },
+        )
+
+        assert (
+            decide(_req(pty_context="Run git commit --no-verify?"))
+            is ApprovalDecision.ESCALATE
+        )
+        assert (
+            decide(_req(pty_context="File already exists, overwrite?"))
+            is ApprovalDecision.DENY
+        )
+
+    def test_dict_override_falls_back_to_profile_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "synapse.approval_gate._load_policy",
+            lambda: {
+                "enabled": True,
+                "default_action": "approve",
+                "profile_overrides": {"codex": {"default": "escalate"}},
+            },
+        )
+
+        assert decide(_req(pty_context="1. Yes, proceed")) is ApprovalDecision.ESCALATE
+
+    def test_dict_override_falls_back_to_global_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "synapse.approval_gate._load_policy",
+            lambda: {
+                "enabled": True,
+                "default_action": "deny",
+                "profile_overrides": {"codex": {"dangerous_command": "escalate"}},
+            },
+        )
+
+        assert decide(_req(pty_context="1. Yes, proceed")) is ApprovalDecision.DENY
+
+    def test_string_override_remains_backwards_compatible(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "synapse.approval_gate._load_policy",
+            lambda: {
+                "enabled": True,
+                "default_action": "approve",
+                "profile_overrides": {"codex": "escalate"},
+            },
+        )
+
+        assert decide(_req(pty_context="1. Yes, proceed")) is ApprovalDecision.ESCALATE
+
+    def test_invalid_dict_action_falls_back_to_profile_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "synapse.approval_gate._load_policy",
+            lambda: {
+                "enabled": True,
+                "default_action": "deny",
+                "profile_overrides": {
+                    "codex": {
+                        "default": "approve",
+                        "permission_request": "maybe",
+                    }
+                },
+            },
+        )
+
+        assert decide(_req(pty_context="1. Yes, proceed")) is ApprovalDecision.APPROVE
+
+
+class TestRiskClassifier:
+    @pytest.mark.parametrize(
+        "pty_context",
+        [
+            "Run rm -rf /tmp/synapse-build?",
+            "sudo launchctl unload system service",
+            "Execute DROP TABLE users;",
+            "Execute DELETE FROM audit_log;",
+            "git push --force origin main",
+            "git push -f origin master",
+            "git commit --no-verify",
+            "git commit --no-gpg-sign",
+            "Edit .env with production credentials",
+            "Read credentials.json",
+            "chmod 600 ~/.ssh/id_rsa",
+        ],
+    )
+    def test_high_risk_patterns_are_detected(self, pty_context: str) -> None:
+        assert _is_high_risk(pty_context) is True
+
+    @pytest.mark.parametrize(
+        "pty_context",
+        [
+            "Run rm -r ./build?",
+            "DELETE FROM audit_log WHERE created_at < now() - interval '30 days'",
+            "DELETE FROM audit_log\nWHERE created_at < now() - interval '30 days'",
+            "git push origin feature/approval-gate",
+            "pytest tests/test_approval_gate.py",
+        ],
+    )
+    def test_safe_commands_are_not_high_risk(self, pty_context: str) -> None:
+        assert _is_high_risk(pty_context) is False
+
+    def test_high_risk_approve_policy_escalates(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "synapse.approval_gate._load_policy",
+            lambda: {
+                "enabled": True,
+                "default_action": "approve",
+                "profile_overrides": {"codex": {"dangerous_command": "approve"}},
+            },
+        )
+
+        assert (
+            decide(_req(pty_context="git push --force origin main"))
+            is ApprovalDecision.ESCALATE
+        )
+
+    def test_high_risk_does_not_override_deny_policy(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "synapse.approval_gate._load_policy",
+            lambda: {
+                "enabled": True,
+                "default_action": "deny",
+                "profile_overrides": {"codex": {"dangerous_command": "deny"}},
+            },
+        )
+
+        assert (
+            decide(_req(pty_context="git push --force origin main"))
+            is ApprovalDecision.DENY
+        )
 
 
 class TestEscalationDeduper:


### PR DESCRIPTION
## Summary
- add prompt classification for permission, overwrite, dangerous, clarification, blocked, and unknown PTY contexts
- support dict-style per-action `approval_gate.profile_overrides` while preserving string override behavior
- add high-risk prompt detection that escalates approve decisions for destructive operations and credential paths
- document prompt classes, per-action policy config, and the risk-classifier safety floor
- address CodeRabbit's multiline `DELETE FROM ... WHERE` false-positive with a regression test

## Tests
- `pytest tests/test_approval_gate.py -v` (56 passed before CodeRabbit follow-up)
- `pytest tests/test_approval_gate.py -q` (57 passed after CodeRabbit follow-up)
- `uv run ruff check synapse/approval_gate.py tests/test_approval_gate.py` (passed)
- `uv run mypy synapse/approval_gate.py` (passed)
- GitHub Actions `Test`: Python 3.10, 3.11, 3.12, 3.13, and 3.14 experimental all passed
- Local `pytest` full suite in the live Synapse workspace failed with 10 environment-coupled failures outside this change: occupied live Synapse ports in `tests/test_auto_spawn.py`, missing package version in `tests/test_canvas_process.py`, file-safety default/settings leakage in `tests/test_file_safety.py`, global wiki/instruction leakage in `tests/test_learning_mode.py` and `tests/test_settings.py`