### PR TITLE
chore(release): bump version to 0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.26.0] - 2026-04-17
+
+### Added
+
+- **Approval Gate policy expansion (#571 Phase 3, #578):** `classify_prompt` categorises PTY context into `permission_request`, `overwrite_confirm`, `dangerous_command`, `clarification_request`, `blocked`, or `unknown`. `profile_overrides` now accept a dict-of-dicts for per-prompt-class policy. `_is_high_risk` adds a safety floor that escalates destructive commands (`rm -rf`, `sudo`, `DROP TABLE`, `git push --force`) regardless of policy.
+- **Pyte-backed virtual terminal for waiting_detection (#572, #575):** raw PTY output is replayed through a `pyte.Screen` so cursor-motion CSI sequences resolve to the final cell state before regex evaluation. Alt-screen buffer enter/leave is tracked. New `GET /debug/pty` endpoint exposes the rendered screen as JSON. New dependency: `pyte>=0.8.2`.
+- **Multiagent patterns usability improvements (#574):** plan preview, samples, and guide for built-in coordination patterns.
+
+### Fixed
+
+- **Approval Gate escalation flood on blocked child states (#576):** blocked-state floor detects non-recoverable banners (`hit your usage limit`, `Upgrade to Pro`, `try again at … AM|PM`) and forces ESCALATE. `EscalationDeduper` (TTL 60s, keyed on `target_agent_id + sha1(pty_context)`) suppresses identical re-escalations.
+- **Status sync divergence between controller and task_store (#569, #577):** `_on_status_change` now reverts `input_required` tasks to `working` on any exit from WAITING (previously only WAITING→PROCESSING was handled). Removed rogue write in `GET /tasks/{id}` that re-set `input_required` from stale PTY context.
+- **Codex waiting_detection regex widened** to match the `hit your usage limit` OpenAI quota banner.
+
 ## [0.25.2] - 2026-04-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3372,7 +3372,8 @@ See v0.3.14 for reply PTY injection, CURRENT column, and history default changes
 - External agent connectivity vision document
 - PyPI publishing instructions
 
-[Unreleased]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.25.1...HEAD
+[Unreleased]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.26.0...HEAD
+[0.26.0]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.25.2...v0.26.0
 [0.25.2]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.25.1...v0.25.2
 [0.25.1]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.25.0...v0.25.1
 [0.25.0]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.24.2...v0.25.0

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ site_url: https://s-hiraoku.github.io/synapse-a2a/
 site_description: Multi-agent collaboration framework using Google A2A Protocol
 site_author: s-hiraoku
 repo_url: https://github.com/s-hiraoku/synapse-a2a
-repo_name: s-hiraoku/synapse-a2a v0.25.2
+repo_name: s-hiraoku/synapse-a2a v0.26.0
 docs_dir: site-docs
 
 theme:

--- a/plugins/synapse-a2a/.claude-plugin/plugin.json
+++ b/plugins/synapse-a2a/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synapse-a2a",
-  "version": "0.25.2",
+  "version": "0.26.0",
   "description": "Complete plugin for Synapse A2A multi-agent framework including inter-agent communication, file safety, and history management",
   "author": {
     "name": "s-hiraoku",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synapse-a2a"
-version = "0.25.2"
+version = "0.26.0"
 description = "Agent-to-Agent communication protocol for CLI agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/site-docs/changelog.md
+++ b/site-docs/changelog.md
@@ -4,6 +4,13 @@ For the complete changelog, see [CHANGELOG.md on GitHub](https://github.com/s-hi
 
 ## Recent Highlights
 
+### v0.26.0
+
+- **Added**: Approval Gate policy expansion — prompt classification (`classify_prompt`), per-action dict-style `profile_overrides`, and risk classifier safety floor for destructive commands (#571 Phase 3, #578)
+- **Added**: Pyte-backed virtual terminal for `waiting_detection` — resolves ratatui cursor-motion garbling, tracks alt-screen buffer, adds `GET /debug/pty` endpoint (#572, #575)
+- **Fixed**: Approval Gate escalation flood — blocked-state floor + `EscalationDeduper` prevent children stuck on quota banners from flooding the parent inbox (#576)
+- **Fixed**: Status sync between controller and task_store — `input_required` tasks now revert on any exit from WAITING, and `GET /tasks/{id}` no longer writes side effects (#569, #577)
+
 ### v0.25.2
 
 - **Fixed**: Parent-side permission handling no longer deadlocks on child `input_required` prompts — children now send structured escalation metadata, the Approval Gate can auto-dispatch approve/deny/escalate, and `synapse send --wait` stays alive until parent intervention or timeout (#571)

--- a/site-docs/concepts/a2a-protocol.md
+++ b/site-docs/concepts/a2a-protocol.md
@@ -17,7 +17,7 @@ Every A2A agent publishes a discovery document at `/.well-known/agent.json`:
   "name": "synapse-claude-8100",
   "description": "Claude Code agent managed by Synapse A2A",
   "url": "http://localhost:8100",
-  "version": "0.25.2",
+  "version": "0.26.0",
   "capabilities": {
     "streaming": false,
     "pushNotifications": false

--- a/site-docs/getting-started/installation.md
+++ b/site-docs/getting-started/installation.md
@@ -58,7 +58,7 @@
 synapse --version
 ```
 
-You should see the version number (e.g., `0.25.2`).
+You should see the version number (e.g., `0.26.0`).
 
 ## Initialize Configuration
 

--- a/uv.lock
+++ b/uv.lock
@@ -1439,7 +1439,7 @@ wheels = [
 
 [[package]]
 name = "synapse-a2a"
-version = "0.25.2"
+version = "0.26.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

Bump version `0.25.2` → `0.26.0` (minor — contains `feat:` commits).

### What's in 0.26.0

**Added:**
- Approval Gate policy expansion — prompt classification, per-action dict-style profile_overrides, risk classifier safety floor (#571 Phase 3, #578)
- Pyte-backed virtual terminal for waiting_detection — resolves ratatui cursor-motion garbling, alt-screen tracking, `GET /debug/pty` (#572, #575)
- Multiagent patterns usability improvements (#574)

**Fixed:**
- Approval Gate escalation flood on blocked child states — blocked-state floor + EscalationDeduper (#576)
- Status sync divergence — WAITING→READY reverse path + GET rogue write removal (#569, #577)
- Codex waiting_detection regex widened for usage-limit banner

### Files bumped
- `pyproject.toml` — `0.25.2` → `0.26.0`
- `plugins/synapse-a2a/.claude-plugin/plugin.json` — version sync
- `mkdocs.yml` — `repo_name` header
- `site-docs/getting-started/installation.md` — version example
- `site-docs/concepts/a2a-protocol.md` — Agent Card example
- `site-docs/changelog.md` — v0.26.0 highlights
- `CHANGELOG.md` — full entry
- `uv.lock` — lockfile sync

After merge, tag `v0.26.0` on the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート v0.26.0

* **新機能**
  * 承認ゲートのプロンプト分類機能を拡張
  * プロフィールオーバーライド設定の対応を拡張
  * 危険なコマンドに対する安全性エスカレーション機能を追加
  * 仮想ターミナルの待機検出レンダリング機能を追加
  * デバッグ用PTYエンドポイント（`GET /debug/pty`）を新規追加

* **バグ修正**
  * 承認ゲートの重複エスカレーション問題を修正
  * コントローラーとタスクストアの状態同期を改善
  * 待機検出の正規表現を拡張

* **ドキュメント**
  * バージョン情報を0.26.0に更新

<!-- end of auto-generated comment: release notes by coderabbit.ai -->