### PR TITLE
docs: refresh Claude Code permission-mode spec (6 modes, --permission-mode)

### DIFF
--- a/.agents/skills/synapse-manager/references/auto-approve-flags.md
+++ b/.agents/skills/synapse-manager/references/auto-approve-flags.md
@@ -21,14 +21,16 @@ Use `--no-auto-approve` to disable this behavior.
 
 ### Claude Code
 
-6-level permission modes (toggle with `Shift+Tab` during session):
+6 permission modes (launch with `--permission-mode <mode>`; settings key `permissions.defaultMode`; Shift+Tab cycles default → acceptEdits → plan during a session):
 
 | Mode | Description |
 |------|-------------|
-| `default` | Ask before every tool use |
-| `acceptEdits` | Auto-approve file edits only; bash commands still require confirmation |
-| `auto` | AI classifier (Sonnet 4.6) evaluates each action before execution; blocks dangerous ops. Requires `--enable-auto-mode` |
-| `bypassPermissions` | Skip all permission prompts. **`--dangerously-skip-permissions`**. Sandbox-only |
+| `default` | Launch default; prompts before edits and commands, while reads are allowed. |
+| `acceptEdits` | Auto-approves file edits and fs commands (mkdir/mv/cp/touch/rm/rmdir/sed); bash still prompts. |
+| `plan` | Read-only planning mode; proposes changes without applying them. |
+| `auto` | Background classifier safety checks (Research Preview; Sonnet/Opus 4.6+, eligible plans only). |
+| `dontAsk` | Denies all tools except `permissions.allow` rules and read-only Bash. |
+| `bypassPermissions` | Skips all checks except protected paths; **`--dangerously-skip-permissions`** is the alias for `--permission-mode bypassPermissions`. Isolated containers only. |
 
 v2.0+ recommends **Hooks** (PreToolUse events) as a safer alternative to `--dangerously-skip-permissions`.
 

--- a/.claude/skills/synapse-manager/references/auto-approve-flags.md
+++ b/.claude/skills/synapse-manager/references/auto-approve-flags.md
@@ -21,14 +21,16 @@ Use `--no-auto-approve` to disable this behavior.
 
 ### Claude Code
 
-6-level permission modes (toggle with `Shift+Tab` during session):
+6 permission modes (launch with `--permission-mode <mode>`; settings key `permissions.defaultMode`; Shift+Tab cycles default → acceptEdits → plan during a session):
 
 | Mode | Description |
 |------|-------------|
-| `default` | Ask before every tool use |
-| `acceptEdits` | Auto-approve file edits only; bash commands still require confirmation |
-| `auto` | AI classifier (Sonnet 4.6) evaluates each action before execution; blocks dangerous ops. Requires `--enable-auto-mode` |
-| `bypassPermissions` | Skip all permission prompts. **`--dangerously-skip-permissions`**. Sandbox-only |
+| `default` | Launch default; prompts before edits and commands, while reads are allowed. |
+| `acceptEdits` | Auto-approves file edits and fs commands (mkdir/mv/cp/touch/rm/rmdir/sed); bash still prompts. |
+| `plan` | Read-only planning mode; proposes changes without applying them. |
+| `auto` | Background classifier safety checks (Research Preview; Sonnet/Opus 4.6+, eligible plans only). |
+| `dontAsk` | Denies all tools except `permissions.allow` rules and read-only Bash. |
+| `bypassPermissions` | Skips all checks except protected paths; **`--dangerously-skip-permissions`** is the alias for `--permission-mode bypassPermissions`. Isolated containers only. |
 
 v2.0+ recommends **Hooks** (PreToolUse events) as a safer alternative to `--dangerously-skip-permissions`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.26.1] - 2026-04-17
+
+### Documentation
+
+- **Claude Code permission-mode spec update:** Refresh docs to reflect the six current permission modes (`default`, `acceptEdits`, `plan`, `auto`, `dontAsk`, `bypassPermissions`) and document the new `--permission-mode <mode>` launch flag and `permissions.defaultMode` settings key. `--dangerously-skip-permissions` continues to work as an alias for `--permission-mode bypassPermissions`, so Synapse's auto-approve injection is unchanged. Updates `docs/agent-permission-modes.md`, `site-docs/guide/agent-permission-modes.md`, the `synapse-manager` skill reference in all three mirrors (`.agents/`, `.claude/`, `plugins/synapse-a2a/`), and a clarifying comment in `synapse/profiles/claude.yaml`.
+
 ## [0.26.0] - 2026-04-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3378,7 +3378,8 @@ See v0.3.14 for reply PTY injection, CURRENT column, and history default changes
 - External agent connectivity vision document
 - PyPI publishing instructions
 
-[Unreleased]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.26.0...HEAD
+[Unreleased]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.26.1...HEAD
+[0.26.1]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.26.0...v0.26.1
 [0.26.0]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.25.2...v0.26.0
 [0.25.2]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.25.1...v0.25.2
 [0.25.1]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.25.0...v0.25.1

--- a/docs/agent-permission-modes.md
+++ b/docs/agent-permission-modes.md
@@ -20,7 +20,7 @@ synapse team start claude gemini --no-auto-approve
 
 | CLI | 自動承認フラグ | サンドボックス | セッション中切替 | 設定ファイル |
 |-----|--------------|-------------|----------------|------------|
-| Claude Code | `--dangerously-skip-permissions` | なし | `Shift+Tab` | Hooks (PreToolUse) |
+| Claude Code | `--dangerously-skip-permissions` (= `--permission-mode bypassPermissions`) | なし | `Shift+Tab` | Hooks (PreToolUse) |
 | Codex CLI | `--full-auto` | ワークスペース制限 | なし | `~/.codex/config.toml` |
 | Gemini CLI | `--yolo` | Docker (デフォルト) | `Ctrl+Y` | `~/.gemini/settings.json` |
 | OpenCode | env var | なし | なし | `opencode.json` |
@@ -28,12 +28,19 @@ synapse team start claude gemini --no-auto-approve
 
 ## Claude Code
 
-6段階のパーミッションモード:
+パーミッションモード:
 
-1. **default** — 全ツール使用前に確認
-2. **acceptEdits** — ファイル編集のみ自動承認、bash コマンドは確認
-3. **auto** — AI クラシファイア（Sonnet 4.6）が各アクションを評価。`--enable-auto-mode` で起動。Team/Enterprise/API プラン限定
-4. **bypassPermissions** — `--dangerously-skip-permissions` で全承認バイパス。サンドボックス環境専用
+1. **default** — 起動時のデフォルト。編集とコマンド実行前に確認、読み取りは許可。
+2. **acceptEdits** — ファイル編集と fs 系コマンド (mkdir/mv/cp/touch/rm/rmdir/sed) を自動承認、bash は確認。
+3. **plan** — 読み取り専用の計画モード。変更を適用せず提案のみ。
+4. **auto** — バックグラウンドクラシファイアによる安全性チェック (Research Preview; Sonnet/Opus 4.6+、対象プランのみ)。
+5. **dontAsk** — `permissions.allow` と読み取り専用 Bash 以外を全拒否。
+6. **bypassPermissions** — 保護パス以外の承認をすべてバイパス。隔離環境 (VM/コンテナ) 専用。
+
+起動フラグ: `--permission-mode <mode>` (例 `--permission-mode acceptEdits`)。
+`--dangerously-skip-permissions` は `--permission-mode bypassPermissions` のエイリアス。
+設定ファイル: `settings.json` の `permissions.defaultMode` に同名の文字列を指定。
+セッション中 `Shift+Tab` で default → acceptEdits → plan を循環 (起動時に bypassPermissions / auto を有効にすると末尾に追加; dontAsk は循環対象外)。
 
 **Synapse での動作:** `--dangerously-skip-permissions` が自動注入される。WAITING 検知時は `y` + Enter を送信。
 

--- a/docs/agent-permission-modes.md
+++ b/docs/agent-permission-modes.md
@@ -39,7 +39,7 @@ synapse team start claude gemini --no-auto-approve
 
 起動フラグ: `--permission-mode <mode>` (例 `--permission-mode acceptEdits`)。
 `--dangerously-skip-permissions` は `--permission-mode bypassPermissions` のエイリアス。
-設定ファイル: `settings.json` の `permissions.defaultMode` に同名の文字列を指定。
+設定ファイル: Claude Code の `settings.json` の `permissions.defaultMode` に同名の文字列を指定（Synapse の `~/.synapse/settings.json` とは別物）。
 セッション中 `Shift+Tab` で default → acceptEdits → plan を循環 (起動時に bypassPermissions / auto を有効にすると末尾に追加; dontAsk は循環対象外)。
 
 **Synapse での動作:** `--dangerously-skip-permissions` が自動注入される。WAITING 検知時は `y` + Enter を送信。
@@ -155,7 +155,7 @@ synapse team start claude gemini --no-auto-approve
 SYNAPSE_AUTO_APPROVE=false synapse spawn claude
 
 # 手動フラグ指定（auto-approve の CLI フラグ注入をスキップし、自分で指定）
-synapse spawn claude --no-auto-approve -- --enable-auto-mode
+synapse spawn claude --no-auto-approve -- --permission-mode auto
 
 # auto-approve は有効のまま別系統の承認フラグへ差し替え（Codex 例）
 # alternative_flags にマッチするため --full-auto は注入されない

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ site_url: https://s-hiraoku.github.io/synapse-a2a/
 site_description: Multi-agent collaboration framework using Google A2A Protocol
 site_author: s-hiraoku
 repo_url: https://github.com/s-hiraoku/synapse-a2a
-repo_name: s-hiraoku/synapse-a2a v0.26.0
+repo_name: s-hiraoku/synapse-a2a v0.26.1
 docs_dir: site-docs
 
 theme:

--- a/plugins/synapse-a2a/.claude-plugin/plugin.json
+++ b/plugins/synapse-a2a/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synapse-a2a",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "description": "Complete plugin for Synapse A2A multi-agent framework including inter-agent communication, file safety, and history management",
   "author": {
     "name": "s-hiraoku",

--- a/plugins/synapse-a2a/skills/synapse-manager/references/auto-approve-flags.md
+++ b/plugins/synapse-a2a/skills/synapse-manager/references/auto-approve-flags.md
@@ -21,14 +21,16 @@ Use `--no-auto-approve` to disable this behavior.
 
 ### Claude Code
 
-6-level permission modes (toggle with `Shift+Tab` during session):
+6 permission modes (launch with `--permission-mode <mode>`; settings key `permissions.defaultMode`; Shift+Tab cycles default → acceptEdits → plan during a session):
 
 | Mode | Description |
 |------|-------------|
-| `default` | Ask before every tool use |
-| `acceptEdits` | Auto-approve file edits only; bash commands still require confirmation |
-| `auto` | AI classifier (Sonnet 4.6) evaluates each action before execution; blocks dangerous ops. Requires `--enable-auto-mode` |
-| `bypassPermissions` | Skip all permission prompts. **`--dangerously-skip-permissions`**. Sandbox-only |
+| `default` | Launch default; prompts before edits and commands, while reads are allowed. |
+| `acceptEdits` | Auto-approves file edits and fs commands (mkdir/mv/cp/touch/rm/rmdir/sed); bash still prompts. |
+| `plan` | Read-only planning mode; proposes changes without applying them. |
+| `auto` | Background classifier safety checks (Research Preview; Sonnet/Opus 4.6+, eligible plans only). |
+| `dontAsk` | Denies all tools except `permissions.allow` rules and read-only Bash. |
+| `bypassPermissions` | Skips all checks except protected paths; **`--dangerously-skip-permissions`** is the alias for `--permission-mode bypassPermissions`. Isolated containers only. |
 
 v2.0+ recommends **Hooks** (PreToolUse events) as a safer alternative to `--dangerously-skip-permissions`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synapse-a2a"
-version = "0.26.0"
+version = "0.26.1"
 description = "Agent-to-Agent communication protocol for CLI agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/site-docs/changelog.md
+++ b/site-docs/changelog.md
@@ -4,6 +4,10 @@ For the complete changelog, see [CHANGELOG.md on GitHub](https://github.com/s-hi
 
 ## Recent Highlights
 
+### v0.26.1
+
+- **Documentation**: Claude Code permission-mode docs refreshed to match the current 6-mode spec (`default`, `acceptEdits`, `plan`, `auto`, `dontAsk`, `bypassPermissions`), the new `--permission-mode <mode>` launch flag, and the `permissions.defaultMode` settings key. `--dangerously-skip-permissions` remains valid as an alias for `--permission-mode bypassPermissions`, so Synapse's auto-approve injection is unaffected.
+
 ### v0.26.0
 
 - **Added**: Approval Gate policy expansion — prompt classification (`classify_prompt`), per-action dict-style `profile_overrides`, and risk classifier safety floor for destructive commands (#571 Phase 3, #578)

--- a/site-docs/concepts/a2a-protocol.md
+++ b/site-docs/concepts/a2a-protocol.md
@@ -17,7 +17,7 @@ Every A2A agent publishes a discovery document at `/.well-known/agent.json`:
   "name": "synapse-claude-8100",
   "description": "Claude Code agent managed by Synapse A2A",
   "url": "http://localhost:8100",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "capabilities": {
     "streaming": false,
     "pushNotifications": false

--- a/site-docs/getting-started/installation.md
+++ b/site-docs/getting-started/installation.md
@@ -58,7 +58,7 @@
 synapse --version
 ```
 
-You should see the version number (e.g., `0.26.0`).
+You should see the version number (e.g., `0.26.1`).
 
 ## Initialize Configuration
 

--- a/site-docs/guide/agent-permission-modes.md
+++ b/site-docs/guide/agent-permission-modes.md
@@ -20,7 +20,7 @@ synapse team start claude gemini --no-auto-approve
 
 | CLI | 自動承認フラグ | サンドボックス | セッション中切替 | 設定ファイル |
 |-----|--------------|-------------|----------------|------------|
-| Claude Code | `--dangerously-skip-permissions` | なし | `Shift+Tab` | Hooks (PreToolUse) |
+| Claude Code | `--dangerously-skip-permissions` (= `--permission-mode bypassPermissions`) | なし | `Shift+Tab` | Hooks (PreToolUse) |
 | Codex CLI | `--full-auto` | ワークスペース制限 | なし | `~/.codex/config.toml` |
 | Gemini CLI | `--yolo` | Docker (デフォルト) | `Ctrl+Y` | `~/.gemini/settings.json` |
 | OpenCode | env var | なし | なし | `opencode.json` |
@@ -28,12 +28,19 @@ synapse team start claude gemini --no-auto-approve
 
 ## Claude Code
 
-6段階のパーミッションモード:
+パーミッションモード:
 
-1. **default** — 全ツール使用前に確認
-2. **acceptEdits** — ファイル編集のみ自動承認、bash コマンドは確認
-3. **auto** — AI クラシファイア（Sonnet 4.6）が各アクションを評価。`--enable-auto-mode` で起動。Team/Enterprise/API プラン限定
-4. **bypassPermissions** — `--dangerously-skip-permissions` で全承認バイパス。サンドボックス環境専用
+1. **default** — 起動時のデフォルト。編集とコマンド実行前に確認、読み取りは許可。
+2. **acceptEdits** — ファイル編集と fs 系コマンド (mkdir/mv/cp/touch/rm/rmdir/sed) を自動承認、bash は確認。
+3. **plan** — 読み取り専用の計画モード。変更を適用せず提案のみ。
+4. **auto** — バックグラウンドクラシファイアによる安全性チェック (Research Preview; Sonnet/Opus 4.6+、対象プランのみ)。
+5. **dontAsk** — `permissions.allow` と読み取り専用 Bash 以外を全拒否。
+6. **bypassPermissions** — 保護パス以外の承認をすべてバイパス。隔離環境 (VM/コンテナ) 専用。
+
+起動フラグ: `--permission-mode <mode>` (例 `--permission-mode acceptEdits`)。
+`--dangerously-skip-permissions` は `--permission-mode bypassPermissions` のエイリアス。
+設定ファイル: `settings.json` の `permissions.defaultMode` に同名の文字列を指定。
+セッション中 `Shift+Tab` で default → acceptEdits → plan を循環 (起動時に bypassPermissions / auto を有効にすると末尾に追加; dontAsk は循環対象外)。
 
 **Synapse での動作:** `--dangerously-skip-permissions` が自動注入される。WAITING 検知時は `y` + Enter を送信。
 

--- a/site-docs/guide/agent-permission-modes.md
+++ b/site-docs/guide/agent-permission-modes.md
@@ -39,7 +39,7 @@ synapse team start claude gemini --no-auto-approve
 
 起動フラグ: `--permission-mode <mode>` (例 `--permission-mode acceptEdits`)。
 `--dangerously-skip-permissions` は `--permission-mode bypassPermissions` のエイリアス。
-設定ファイル: `settings.json` の `permissions.defaultMode` に同名の文字列を指定。
+設定ファイル: Claude Code の `settings.json` の `permissions.defaultMode` に同名の文字列を指定（Synapse の `~/.synapse/settings.json` とは別物）。
 セッション中 `Shift+Tab` で default → acceptEdits → plan を循環 (起動時に bypassPermissions / auto を有効にすると末尾に追加; dontAsk は循環対象外)。
 
 **Synapse での動作:** `--dangerously-skip-permissions` が自動注入される。WAITING 検知時は `y` + Enter を送信。
@@ -155,7 +155,7 @@ synapse team start claude gemini --no-auto-approve
 SYNAPSE_AUTO_APPROVE=false synapse spawn claude
 
 # 手動フラグ指定（auto-approve の CLI フラグ注入をスキップし、自分で指定）
-synapse spawn claude --no-auto-approve -- --enable-auto-mode
+synapse spawn claude --no-auto-approve -- --permission-mode auto
 
 # auto-approve は有効のまま別系統の承認フラグへ差し替え（Codex 例）
 # alternative_flags にマッチするため --full-auto は注入されない

--- a/synapse/profiles/claude.yaml
+++ b/synapse/profiles/claude.yaml
@@ -33,7 +33,10 @@ waiting_detection:
   waiting_expiry: 10                           # Auto-clear WAITING after 10s
 
 # Auto-approve configuration (used by synapse spawn / team start)
-# cli_flag: Injected as tool_arg to skip permission prompts at launch
+# cli_flag: Injected as tool_arg to skip permission prompts at launch.
+#   Claude Code v2+ accepts `--permission-mode <mode>`; the legacy
+#   `--dangerously-skip-permissions` is an alias for `--permission-mode bypassPermissions`
+#   and remains supported, so we keep using it here for maximum compatibility.
 # runtime_response: Sent to PTY when WAITING status detected during execution
 auto_approve:
   cli_flag: "--dangerously-skip-permissions"


### PR DESCRIPTION
## Summary

- Claude Code now documents **six** permission modes. Update our docs/skill references to match: `default`, `acceptEdits`, `plan`, `auto`, `dontAsk`, `bypassPermissions`. Our previous copy claimed "6段階" / "6-level" but listed only four (missing `plan` and `dontAsk`).
- Document the new `--permission-mode <mode>` launch flag and `permissions.defaultMode` settings.json key. Note that `--dangerously-skip-permissions` is now an **alias** for `--permission-mode bypassPermissions` — Synapse's auto-approve injection is therefore unaffected.
- Capture the Shift+Tab cycle order (`default → acceptEdits → plan`, with `bypassPermissions` / `auto` appended only when enabled at launch; `dontAsk` is never in the cycle).
- Add a clarifying comment in `synapse/profiles/claude.yaml` explaining why we keep using `--dangerously-skip-permissions` as the `cli_flag`.
- Release bump 0.26.0 → 0.26.1 (docs-only change).

Official spec reference: https://code.claude.com/docs/en/permission-modes.md

### Files touched
| Kind | Files |
|------|-------|
| Docs (ja primary) | `docs/agent-permission-modes.md`, `site-docs/guide/agent-permission-modes.md` |
| Skill reference (3 mirrors) | `.agents/`, `.claude/`, `plugins/synapse-a2a/` under `skills/synapse-manager/references/auto-approve-flags.md` |
| Profile comment | `synapse/profiles/claude.yaml` |
| Release bump | `pyproject.toml`, `plugins/synapse-a2a/.claude-plugin/plugin.json`, `mkdocs.yml`, `CHANGELOG.md`, `site-docs/changelog.md`, `site-docs/getting-started/installation.md`, `site-docs/concepts/a2a-protocol.md` |

No code logic changed; `cli_flag` remains `--dangerously-skip-permissions`.

## Test plan

- [x] `uv run pytest tests/test_skill_docs.py tests/test_auto_approve.py` → 72 passed
- [x] `diff` across the 3 skill-ref mirrors produces no output (byte-identical)
- [x] Japanese docs vs site-docs guide mirror symmetric (only diff-header names differ)
- [x] `grep -n "6段階\|6-level"` across the repo returns no matches (stale phrasing removed)
- [x] `git diff --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Claude Codeのパーミッションモード仕様を刷新しました。起動フラグでモード選択する新フローと、デフォルト設定キーの導入を記載。モード一覧を再定義（defaultは読み取り許可、acceptEditsは特定ファイル操作の自動承認、planは読み取り専用提案、autoはバックグラウンド安全判定、dontAskは全拒否、bypassPermissionsは保護パス以外をスキップ）。Shift+Tabのセッション循環範囲も明記。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->