### PR TITLE
docs/mcp: instruct agents to skip file lock inside worktrees

### DIFF
--- a/.agents/skills/synapse-a2a/SKILL.md
+++ b/.agents/skills/synapse-a2a/SKILL.md
@@ -76,7 +76,7 @@ Skip this gate for small/medium tasks where the overhead exceeds the benefit.
 | Feature | Why It Matters | Commands |
 |---------|---------------|----------|
 | **Shared Memory** | Collective knowledge survives agent restarts | `synapse memory save/search/list` |
-| **File Safety** | Locking prevents data loss when two agents edit the same file | `synapse file-safety lock/unlock/locks` |
+| **File Safety** | Locking prevents data loss when two agents edit the same file -- skip inside worktrees (`SYNAPSE_WORKTREE_PATH`) | `synapse file-safety lock/unlock/locks` |
 | **Worktree** | File isolation eliminates merge conflicts in parallel editing | `synapse spawn --worktree` |
 | **Broadcast** | Team-wide announcements reach all agents instantly | `synapse broadcast "<msg>"` |
 | **History** | Audit trail tracks what happened and when | `synapse history list/show/stats` |
@@ -184,7 +184,7 @@ When you receive a task from a manager:
 ### On Task Receipt
 1. Start work immediately (`[REPLY EXPECTED]` requires a reply; otherwise no reply needed)
 2. Check shared knowledge: `synapse memory search "<task topic>"`
-3. Lock files before editing: `synapse file-safety lock <file> $SYNAPSE_AGENT_ID`
+3. Lock files before editing (**skip if SYNAPSE_WORKTREE_PATH is set**): `synapse file-safety lock <file> $SYNAPSE_AGENT_ID`
 
 ### During Work
 - Report progress if task takes >5 minutes: `synapse send <manager> "Progress: <update>" --silent`

--- a/.agents/skills/synapse-a2a/references/file-safety.md
+++ b/.agents/skills/synapse-a2a/references/file-safety.md
@@ -2,7 +2,22 @@
 
 File Safety prevents conflicts when multiple agents edit the same files.
 
-## MANDATORY: Checklist Before Edit/Write
+## Skip Locking in a Worktree
+
+`SYNAPSE_WORKTREE_PATH` is the signal that the current agent is running inside
+an isolated git worktree. For edits inside that worktree tree, skip
+`synapse file-safety lock/unlock/record` because the worktree is exclusive to
+that agent.
+
+```bash
+[ -n "$SYNAPSE_WORKTREE_PATH" ] && echo "worktree: skip locks" || echo "main repo: lock as usual"
+```
+
+This exemption only applies inside the worktree. Still lock shared paths outside
+the worktree, such as `$HOME` config, the parent repo's registry, and
+cross-worktree databases like `~/.synapse/file_safety.db`.
+
+## MANDATORY: Checklist Before Edit/Write (non-worktree only)
 
 Before using Edit, Write, sed, awk, or ANY file modification:
 
@@ -177,7 +192,7 @@ Error: File is locked by gemini (expires: 2026-01-09T12:00:00)
 - Without locks, two agents editing the same file = DATA LOSS
 - Your changes may be overwritten without warning
 - Other agents' work may be destroyed
-- **EVERY EDIT NEEDS A LOCK. NO EXCEPTIONS.**
+- **EVERY EDIT OUTSIDE A WORKTREE NEEDS A LOCK.** See "Skip Locking in a Worktree" above.
 
 ## Storage
 

--- a/.claude/skills/synapse-a2a/SKILL.md
+++ b/.claude/skills/synapse-a2a/SKILL.md
@@ -76,7 +76,7 @@ Skip this gate for small/medium tasks where the overhead exceeds the benefit.
 | Feature | Why It Matters | Commands |
 |---------|---------------|----------|
 | **Shared Memory** | Collective knowledge survives agent restarts | `synapse memory save/search/list` |
-| **File Safety** | Locking prevents data loss when two agents edit the same file | `synapse file-safety lock/unlock/locks` |
+| **File Safety** | Locking prevents data loss when two agents edit the same file -- skip inside worktrees (`SYNAPSE_WORKTREE_PATH`) | `synapse file-safety lock/unlock/locks` |
 | **Worktree** | File isolation eliminates merge conflicts in parallel editing | `synapse spawn --worktree` |
 | **Broadcast** | Team-wide announcements reach all agents instantly | `synapse broadcast "<msg>"` |
 | **History** | Audit trail tracks what happened and when | `synapse history list/show/stats` |
@@ -184,7 +184,7 @@ When you receive a task from a manager:
 ### On Task Receipt
 1. Start work immediately (`[REPLY EXPECTED]` requires a reply; otherwise no reply needed)
 2. Check shared knowledge: `synapse memory search "<task topic>"`
-3. Lock files before editing: `synapse file-safety lock <file> $SYNAPSE_AGENT_ID`
+3. Lock files before editing (**skip if SYNAPSE_WORKTREE_PATH is set**): `synapse file-safety lock <file> $SYNAPSE_AGENT_ID`
 
 ### During Work
 - Report progress if task takes >5 minutes: `synapse send <manager> "Progress: <update>" --silent`

--- a/.claude/skills/synapse-a2a/references/file-safety.md
+++ b/.claude/skills/synapse-a2a/references/file-safety.md
@@ -2,7 +2,22 @@
 
 File Safety prevents conflicts when multiple agents edit the same files.
 
-## MANDATORY: Checklist Before Edit/Write
+## Skip Locking in a Worktree
+
+`SYNAPSE_WORKTREE_PATH` is the signal that the current agent is running inside
+an isolated git worktree. For edits inside that worktree tree, skip
+`synapse file-safety lock/unlock/record` because the worktree is exclusive to
+that agent.
+
+```bash
+[ -n "$SYNAPSE_WORKTREE_PATH" ] && echo "worktree: skip locks" || echo "main repo: lock as usual"
+```
+
+This exemption only applies inside the worktree. Still lock shared paths outside
+the worktree, such as `$HOME` config, the parent repo's registry, and
+cross-worktree databases like `~/.synapse/file_safety.db`.
+
+## MANDATORY: Checklist Before Edit/Write (non-worktree only)
 
 Before using Edit, Write, sed, awk, or ANY file modification:
 
@@ -177,7 +192,7 @@ Error: File is locked by gemini (expires: 2026-01-09T12:00:00)
 - Without locks, two agents editing the same file = DATA LOSS
 - Your changes may be overwritten without warning
 - Other agents' work may be destroyed
-- **EVERY EDIT NEEDS A LOCK. NO EXCEPTIONS.**
+- **EVERY EDIT OUTSIDE A WORKTREE NEEDS A LOCK.** See "Skip Locking in a Worktree" above.
 
 ## Storage
 

--- a/docs/file-safety.md
+++ b/docs/file-safety.md
@@ -18,6 +18,21 @@
 
 ## 概要
 
+### Worktree ではロックを省略できる
+
+`SYNAPSE_WORKTREE_PATH` が設定されている場合、そのエージェントは
+`synapse spawn --worktree` で作成された専用の git worktree 内で実行されています。
+その worktree ツリー内の編集では、`synapse file-safety lock/unlock/record` を省略できます。
+
+```bash
+[ -n "$SYNAPSE_WORKTREE_PATH" ] && echo "worktree: skip locks" || echo "main repo: lock as usual"
+```
+
+この省略は worktree 内のパスだけに適用されます。`$HOME` 配下の設定、
+親リポジトリ側のレジストリ、`~/.synapse/file_safety.db` のような
+worktree 間で共有されるデータベースなど、worktree 外の共有パスを編集する場合は
+通常どおりロックしてください。
+
 ### 背景
 
 マルチエージェント環境では、複数のエージェント（Claude、Gemini、Codex など）が同じファイルを同時に編集しようとする場合があります。これにより以下の問題が発生する可能性があります：

--- a/plugins/synapse-a2a/skills/synapse-a2a/SKILL.md
+++ b/plugins/synapse-a2a/skills/synapse-a2a/SKILL.md
@@ -76,7 +76,7 @@ Skip this gate for small/medium tasks where the overhead exceeds the benefit.
 | Feature | Why It Matters | Commands |
 |---------|---------------|----------|
 | **Shared Memory** | Collective knowledge survives agent restarts | `synapse memory save/search/list` |
-| **File Safety** | Locking prevents data loss when two agents edit the same file | `synapse file-safety lock/unlock/locks` |
+| **File Safety** | Locking prevents data loss when two agents edit the same file -- skip inside worktrees (`SYNAPSE_WORKTREE_PATH`) | `synapse file-safety lock/unlock/locks` |
 | **Worktree** | File isolation eliminates merge conflicts in parallel editing | `synapse spawn --worktree` |
 | **Broadcast** | Team-wide announcements reach all agents instantly | `synapse broadcast "<msg>"` |
 | **History** | Audit trail tracks what happened and when | `synapse history list/show/stats` |
@@ -184,7 +184,7 @@ When you receive a task from a manager:
 ### On Task Receipt
 1. Start work immediately (`[REPLY EXPECTED]` requires a reply; otherwise no reply needed)
 2. Check shared knowledge: `synapse memory search "<task topic>"`
-3. Lock files before editing: `synapse file-safety lock <file> $SYNAPSE_AGENT_ID`
+3. Lock files before editing (**skip if SYNAPSE_WORKTREE_PATH is set**): `synapse file-safety lock <file> $SYNAPSE_AGENT_ID`
 
 ### During Work
 - Report progress if task takes >5 minutes: `synapse send <manager> "Progress: <update>" --silent`

--- a/plugins/synapse-a2a/skills/synapse-a2a/references/file-safety.md
+++ b/plugins/synapse-a2a/skills/synapse-a2a/references/file-safety.md
@@ -2,7 +2,22 @@
 
 File Safety prevents conflicts when multiple agents edit the same files.
 
-## MANDATORY: Checklist Before Edit/Write
+## Skip Locking in a Worktree
+
+`SYNAPSE_WORKTREE_PATH` is the signal that the current agent is running inside
+an isolated git worktree. For edits inside that worktree tree, skip
+`synapse file-safety lock/unlock/record` because the worktree is exclusive to
+that agent.
+
+```bash
+[ -n "$SYNAPSE_WORKTREE_PATH" ] && echo "worktree: skip locks" || echo "main repo: lock as usual"
+```
+
+This exemption only applies inside the worktree. Still lock shared paths outside
+the worktree, such as `$HOME` config, the parent repo's registry, and
+cross-worktree databases like `~/.synapse/file_safety.db`.
+
+## MANDATORY: Checklist Before Edit/Write (non-worktree only)
 
 Before using Edit, Write, sed, awk, or ANY file modification:
 
@@ -177,7 +192,7 @@ Error: File is locked by gemini (expires: 2026-01-09T12:00:00)
 - Without locks, two agents editing the same file = DATA LOSS
 - Your changes may be overwritten without warning
 - Other agents' work may be destroyed
-- **EVERY EDIT NEEDS A LOCK. NO EXCEPTIONS.**
+- **EVERY EDIT OUTSIDE A WORKTREE NEEDS A LOCK.** See "Skip Locking in a Worktree" above.
 
 ## Storage
 

--- a/site-docs/guide/file-safety.md
+++ b/site-docs/guide/file-safety.md
@@ -4,6 +4,16 @@
 
 File Safety prevents multi-agent file conflicts with exclusive locking, change tracking, and modification history. When multiple agents work on the same project, File Safety ensures they don't overwrite each other's changes.
 
+## Skip Locking in a Worktree
+
+When `SYNAPSE_WORKTREE_PATH` is set, the agent is running inside an isolated git worktree created by `synapse spawn --worktree`. For edits inside that worktree tree, skip `synapse file-safety lock/unlock/record` because the worktree is exclusive to that agent.
+
+```bash
+[ -n "$SYNAPSE_WORKTREE_PATH" ] && echo "worktree: skip locks" || echo "main repo: lock as usual"
+```
+
+This exemption only applies inside the worktree. Still lock shared paths outside the worktree, such as `$HOME` config, the parent repo's registry, and cross-worktree databases like `~/.synapse/file_safety.db`.
+
 ## Enabling File Safety
 
 ```bash
@@ -39,8 +49,8 @@ synapse file-safety lock src/auth.py claude \
   --duration 300    # 5 minutes (default: 300 seconds)
 ```
 
-!!! danger "Always Lock Before Editing"
-    Two agents editing the same file simultaneously causes **data loss**. Changes are overwritten without warning. Every edit needs a lock -- no exceptions.
+!!! danger "Lock Before Editing Shared Paths"
+    Two agents editing the same shared file simultaneously causes **data loss**. Changes are overwritten without warning. Every edit outside a worktree needs a lock.
 
 ### Release a Lock
 

--- a/synapse/mcp/server.py
+++ b/synapse/mcp/server.py
@@ -195,7 +195,7 @@ class SynapseMCPServer:
             "file-safety.md": MCPResource(
                 uri="synapse://instructions/file-safety",
                 name="File Safety Instructions",
-                description="Multi-agent file locking and modification safety rules.",
+                description="Multi-agent file locking rules, with worktree-local edits exempt.",
             ),
             "wiki.md": MCPResource(
                 uri="synapse://instructions/wiki",

--- a/synapse/templates/.synapse/file-safety.md
+++ b/synapse/templates/.synapse/file-safety.md
@@ -3,6 +3,9 @@ FILE SAFETY (Multi-Agent File Locking):
 You are {{agent_id}}. When multiple agents are running, lock files before
 editing to prevent conflicts.
 
+Worktree note: if `SYNAPSE_WORKTREE_PATH` is set, this agent is running in an
+isolated git worktree and may skip locks for edits inside that worktree.
+
 WHEN TO LOCK:
 - Multiple agents are active AND you're modifying an existing shared file
 - Another agent might be editing the same file concurrently
@@ -11,6 +14,10 @@ WHEN LOCKING IS NOT NEEDED:
 - You're the only running agent (check: synapse list --json)
 - Creating a new file (no conflict possible)
 - Read-only operations
+- `SYNAPSE_WORKTREE_PATH` is set AND you're editing inside that worktree tree
+
+Still lock shared paths outside the worktree, such as $HOME config, parent repo
+registries, or cross-worktree databases like ~/.synapse/file_safety.db.
 
 WORKFLOW:
 

--- a/tests/test_mcp_bootstrap.py
+++ b/tests/test_mcp_bootstrap.py
@@ -14,6 +14,8 @@ import pytest
 from synapse.mcp.server import SynapseMCPServer, UnknownMCPResourceError
 from synapse.settings import SynapseSettings
 
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
 
 def _create_settings(root: Path) -> SynapseSettings:
     synapse_dir = root / ".synapse"
@@ -155,6 +157,12 @@ def test_list_resources_always_includes_default() -> None:
     resources = server.list_resources()
 
     assert any(item.uri == "synapse://instructions/default" for item in resources)
+
+
+def test_file_safety_instruction_template_mentions_worktree_signal() -> None:
+    template = REPO_ROOT / "synapse" / "templates" / ".synapse" / "file-safety.md"
+
+    assert "SYNAPSE_WORKTREE_PATH" in template.read_text(encoding="utf-8")
 
 
 def test_bootstrap_agent_wraps_settings_load_value_error() -> None:


### PR DESCRIPTION
## Summary

Instruct every agent role (MCP resource template, plugin skill, and
derived skill copies) to **skip `synapse file-safety lock/unlock/record`
for edits inside a git worktree** — the worktree is exclusive to the
agent, so locking is pure overhead. Locks are still required for edits
to shared paths outside the worktree.

## Motivation

Per user request:

> 自身がworktree環境で実行されているときは、file lock しなくていいので、
> 全エージェントでそのように指示するようにMCP, skillsを修正して。

The signal is `SYNAPSE_WORKTREE_PATH`, which `synapse/spawn.py:183-189`
sets alongside `SYNAPSE_WORKTREE_BRANCH` / `SYNAPSE_WORKTREE_BASE_BRANCH`
whenever spawn includes `--worktree`. So every worktree-resident agent
can detect its own state with:

```bash
[ -n "$SYNAPSE_WORKTREE_PATH" ] && echo "worktree: skip locks" || echo "main repo: lock as usual"
```

## Scope carve-out (explicit in every updated file)

Locking is only skippable for edits **inside** the worktree tree.
Edits to paths **outside** (e.g. `$HOME` config, the parent repo's
registry, cross-worktree DBs like `~/.synapse/file_safety.db`) still
need normal locking.

## Changes

Single logical commit (`6ddf5ae`) across 11 files:

- `synapse/templates/.synapse/file-safety.md` — MCP-served template (authoritative).
- `synapse/mcp/server.py` — resource description line mentions worktree skip.
- `plugins/synapse-a2a/skills/synapse-a2a/references/file-safety.md` — adds "Skip Locking in a Worktree" section; reworded "MANDATORY" to "non-worktree only"; updated the "EVERY EDIT NEEDS A LOCK" closer.
- `plugins/synapse-a2a/skills/synapse-a2a/SKILL.md` — File Safety row in "Use Synapse Features Actively" plus Worker Agent Guide "On Task Receipt" step 3.
- `.agents/skills/synapse-a2a/**` + `.claude/skills/synapse-a2a/**` — derivative copies kept in sync.
- `docs/file-safety.md`, `site-docs/guide/file-safety.md` — project docs mirror.
- `tests/test_mcp_bootstrap.py` — asserts the served `file-safety` instruction text contains `SYNAPSE_WORKTREE_PATH` so this guidance cannot silently regress.

## Testing

- `pytest tests/test_mcp_bootstrap.py -v` — **16 passed**.
- `pytest tests/test_site_docs.py tests/test_plugin_skills.py tests/test_skill_structure.py -q` — **139 passed / 18 skipped**.
- `pytest` (full) — **4095 passed / 5 failed**. The 5 failures are the same pre-existing environmental leakage documented in #584 (user `~/.synapse/wiki.md` + file_safety/learning settings bleed in). Unrelated to this PR, passes with isolated HOME.

## Follow-ups

- No repo-specific site-doc sync command found; `site-docs/guide/file-safety.md` was hand-edited. If a sync tool exists elsewhere it should take over.
- Test-environment isolation (same as #584).