### PR TITLE
fix: sanitise pty_context and dedupe permission notifications (#582, #586)

### DIFF
--- a/synapse/_pty_sanitize.py
+++ b/synapse/_pty_sanitize.py
@@ -1,0 +1,84 @@
+"""PTY context sanitisation helpers for permission notifications.
+
+Permission notifications embed a tail of the agent's PTY buffer so the
+sender can decide whether to approve. The raw buffer can contain CSI
+escapes, line-overwrite fragments, C0/C1 control bytes, and
+mid-sequence truncation when `[-512:]` bisects a CSI. See issues #582
+and #586. This module strips those byte classes so downstream renders
+are readable and safe to persist.
+"""
+
+from __future__ import annotations
+
+import re
+
+# CSI / OSC / two-char escape sequences that may survive strip_ansi
+# (e.g. because of mid-sequence truncation) plus standalone C0/C1
+# control bytes. TAB / LF / CR are preserved.
+# Strip CSI / OSC / two-char escape sequences, plus all C0/C1 control
+# bytes except TAB (\x09) and LF (\x0a). CR (\x0d) is removed so that
+# line-overwrite remnants don't re-merge subsequent lines when rendered.
+_RESIDUAL_CONTROL_RE = re.compile(
+    r"\x1b\[[0-?]*[ -/]*[@-~]"
+    r"|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)?"
+    r"|\x1b[()][AB0-2]"
+    r"|\x1b[>=MD]"
+    r"|[\x00-\x08\x0b-\x1f\x7f]"
+)
+
+
+def strip_control_bytes(text: str) -> str:
+    """Remove residual CSI/OSC fragments and C0/C1 control bytes.
+
+    Keeps TAB and LF (so multi-line structure survives). CR is removed
+    because the PTY-overwrite pattern that causes #586 relies on CR to
+    re-merge repeated partial writes into the same line.
+    """
+    return _RESIDUAL_CONTROL_RE.sub("", text)
+
+
+def tail_printable(text: str, limit: int = 512) -> str:
+    """Take the last ``limit`` characters of sanitised text.
+
+    Strips control bytes first so the limit is measured against
+    meaningful output and the tail cannot start mid-ANSI sequence.
+    """
+    if not text:
+        return ""
+    return strip_control_bytes(text)[-limit:]
+
+
+def printable_len(text: str) -> int:
+    """Count printable characters (plus TAB/LF/CR) in ``text``."""
+    if not text:
+        return 0
+    return sum(1 for ch in text if ch.isprintable() or ch in ("\t", "\n", "\r"))
+
+
+def printable_ratio(text: str) -> float:
+    """Fraction of bytes in ``text`` that are printable (plus TAB/LF/CR).
+
+    Empty input returns 1.0 (treat as trivially printable).
+    """
+    if not text:
+        return 1.0
+    printable = sum(1 for ch in text if ch.isprintable() or ch in ("\t", "\n", "\r"))
+    return printable / len(text)
+
+
+def looks_like_garbage(text: str) -> bool:
+    """Heuristic guard for permission-notification long-messages.
+
+    Returns True when the content is most likely a corrupted PTY
+    snapshot that should not be persisted:
+
+    - More than 50% non-printable bytes, OR
+    - More than five ``\\x1b[`` CSI fragments per 1 KB.
+    """
+    if not text:
+        return False
+    if printable_ratio(text) < 0.5:
+        return True
+    kb = max(1, len(text) // 1024)
+    csi_fragments = text.count("\x1b[")
+    return (csi_fragments / kb) > 5.0

--- a/synapse/_pty_sanitize.py
+++ b/synapse/_pty_sanitize.py
@@ -19,11 +19,13 @@ import re
 # bytes except TAB (\x09) and LF (\x0a). CR (\x0d) is removed so that
 # line-overwrite remnants don't re-merge subsequent lines when rendered.
 _RESIDUAL_CONTROL_RE = re.compile(
-    r"\x1b\[[0-?]*[ -/]*[@-~]"
-    r"|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)?"
+    r"\x1b\[[0-?]*[ -/]*(?:[@-~]|$)"
+    r"|\x9b[0-?]*[ -/]*(?:[@-~]|$)"
+    r"|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\|$)"
+    r"|\x9d[^\x07\x9c]*(?:\x07|\x9c|$)"
     r"|\x1b[()][AB0-2]"
     r"|\x1b[>=MD]"
-    r"|[\x00-\x08\x0b-\x1f\x7f]"
+    r"|[\x00-\x08\x0b-\x1f\x7f-\x9f]"
 )
 
 

--- a/synapse/a2a_compat.py
+++ b/synapse/a2a_compat.py
@@ -939,12 +939,22 @@ def create_a2a_router(
                 return tail
 
         preview = task_metadata.get("current_task_preview")
-        if isinstance(preview, str) and preview.strip():
-            return strip_control_bytes(preview).strip()
+        if isinstance(preview, str):
+            cleaned_preview = strip_control_bytes(preview).strip()
+            if (
+                cleaned_preview
+                and _printable_len(cleaned_preview) >= _PERMISSION_CONTEXT_MIN_PRINTABLE
+            ):
+                return cleaned_preview[:512]
 
         sent = task_metadata.get(_SENT_MESSAGE_METADATA_KEY)
-        if isinstance(sent, str) and sent.strip():
-            return strip_control_bytes(sent[:200]).strip()
+        if isinstance(sent, str):
+            cleaned_sent = strip_control_bytes(sent).strip()[:200]
+            if (
+                cleaned_sent
+                and _printable_len(cleaned_sent) >= _PERMISSION_CONTEXT_MIN_PRINTABLE
+            ):
+                return cleaned_sent
 
         return _PERMISSION_CONTEXT_FALLBACK
 

--- a/synapse/a2a_compat.py
+++ b/synapse/a2a_compat.py
@@ -8,6 +8,7 @@ Google A2A Spec: https://a2a-protocol.org/latest/specification/
 """
 
 import asyncio
+import hashlib
 import json
 import logging
 import os
@@ -24,6 +25,13 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel, Field
 
+from synapse._pty_sanitize import (
+    printable_len as _printable_len,
+)
+from synapse._pty_sanitize import (
+    strip_control_bytes,
+    tail_printable,
+)
 from synapse.a2a_client import get_client
 from synapse.auth import require_auth
 from synapse.config import (
@@ -365,6 +373,15 @@ _REPLY_ERROR_METADATA_KEY = "reply_error"
 # Gate on the parent side to auto-approve/deny or escalate to human. See
 # synapse/approval_gate.py and issue #571.
 _PERMISSION_ESCALATION_METADATA_KEY = "permission_escalation"
+
+# Permission notification dedupe guards (see #582, #586). Notifications
+# are keyed by (task_id + sanitised pty_context tail) hash; the same
+# hash is suppressed within _PERMISSION_NOTIFICATION_MIN_INTERVAL_SECONDS.
+# The window also rate-limits distinct hashes to protect against
+# WAITING→READY→WAITING oscillation from streaming output.
+_PERMISSION_NOTIFICATION_MIN_INTERVAL_SECONDS = 5.0
+_PERMISSION_CONTEXT_FALLBACK = "[permission context unavailable]"
+_PERMISSION_CONTEXT_MIN_PRINTABLE = 10
 
 
 def _load_reply_artifacts(metadata: dict[str, Any]) -> list[Artifact] | None:
@@ -886,12 +903,73 @@ def create_a2a_router(
         else:
             asyncio.run(coro)
 
-    def _build_permission_metadata() -> dict[str, Any]:
-        context = controller.get_context() if controller else ""
+    def _resolve_pty_context(task_metadata: dict[str, Any]) -> str:
+        """Produce a sanitised, length-capped context tail for notifications.
+
+        Order of preference:
+        1. controller.get_rendered_context() if available (pyte-rendered)
+        2. controller.get_context() (already ANSI-stripped in most cases)
+        3. task metadata current_task_preview
+        4. task metadata _sent_message (first 200 chars)
+        5. a fixed placeholder
+
+        Control-byte sanitisation runs after each source so a context
+        full of CSI escapes or line-overwrite bytes cannot slip through.
+        """
+        sources: list[str] = []
+        if controller is not None:
+            get_rendered = getattr(controller, "get_rendered_context", None)
+            if callable(get_rendered):
+                try:
+                    value = get_rendered()
+                    if isinstance(value, str):
+                        sources.append(value)
+                except Exception:
+                    pass
+            try:
+                value = controller.get_context()
+                if isinstance(value, str):
+                    sources.append(value)
+            except Exception:
+                pass
+
+        for raw in sources:
+            tail = tail_printable(raw, limit=512)
+            if tail and _printable_len(tail) >= _PERMISSION_CONTEXT_MIN_PRINTABLE:
+                return tail
+
+        preview = task_metadata.get("current_task_preview")
+        if isinstance(preview, str) and preview.strip():
+            return strip_control_bytes(preview).strip()
+
+        sent = task_metadata.get(_SENT_MESSAGE_METADATA_KEY)
+        if isinstance(sent, str) and sent.strip():
+            return strip_control_bytes(sent[:200]).strip()
+
+        return _PERMISSION_CONTEXT_FALLBACK
+
+    def _build_permission_metadata(
+        task_metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        metadata = task_metadata or {}
+        pty_context = _resolve_pty_context(metadata)
+        existing = metadata.get("permission") or {}
+        prior_hash = (
+            existing.get("notification_hash") if isinstance(existing, dict) else None
+        )
+        prior_sent_at = (
+            existing.get("notification_sent_at") if isinstance(existing, dict) else None
+        )
+        prior_count = (
+            existing.get("notifications_sent", 0) if isinstance(existing, dict) else 0
+        )
         return {
-            "pty_context": context[-512:],
+            "pty_context": pty_context,
             "agent_type": agent_type,
             "detected_at": time.time(),
+            "notification_hash": prior_hash,
+            "notification_sent_at": prior_sent_at,
+            "notifications_sent": prior_count,
         }
 
     def _build_permission_notification(task: Task) -> Task:
@@ -1005,7 +1083,34 @@ def create_a2a_router(
                 for task in task_store.list_tasks():
                     if task.status != "working":
                         continue
-                    permission = _build_permission_metadata()
+                    metadata = task.metadata or {}
+                    permission = _build_permission_metadata(metadata)
+                    now = time.time()
+                    digest = hashlib.sha256(
+                        f"{task.id}\0{permission['pty_context']}".encode()
+                    ).hexdigest()[:16]
+                    prior_hash = permission.get("notification_hash")
+                    prior_sent_at = permission.get("notification_sent_at") or 0.0
+                    within_window = (
+                        now - prior_sent_at
+                        < _PERMISSION_NOTIFICATION_MIN_INTERVAL_SECONDS
+                    )
+                    if prior_sent_at and within_window:
+                        # Same payload inside window → drop. Different
+                        # payload inside window → also drop to guard
+                        # against WAITING→READY→WAITING oscillation
+                        # turning into a flood.
+                        task_store.update_metadata(task.id, "permission", permission)
+                        continue
+                    if prior_hash == digest and prior_sent_at:
+                        task_store.update_metadata(task.id, "permission", permission)
+                        continue
+
+                    permission["notification_hash"] = digest
+                    permission["notification_sent_at"] = now
+                    permission["notifications_sent"] = (
+                        int(permission.get("notifications_sent") or 0) + 1
+                    )
                     task_store.update_metadata(task.id, "permission", permission)
                     updated = task_store.update_status(task.id, "input_required")
                     if not updated:

--- a/tests/test_permission_notifications.py
+++ b/tests/test_permission_notifications.py
@@ -1,0 +1,232 @@
+"""Regression tests for permission notification context and dedupe."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from synapse.a2a_compat import Message, TextPart, create_a2a_router, task_store
+
+
+class _Controller:
+    def __init__(self, context: str = "", rendered_context: str | None = None) -> None:
+        self.context = context
+        self.rendered_context = rendered_context
+        self.status = "PROCESSING"
+        self.agent_ready = True
+        self.callback = None
+
+    def wait_until_ready(self, timeout: float | None = None) -> bool:
+        return True
+
+    def get_context(self) -> str:
+        return self.context
+
+    def get_rendered_context(self) -> str:
+        if self.rendered_context is None:
+            raise AttributeError("rendered context unavailable")
+        return self.rendered_context
+
+    def write(self, text: str) -> bool:
+        return True
+
+    def on_status_change(self, callback) -> None:
+        self.callback = callback
+
+
+def _register_status_callback(controller: _Controller):
+    router = create_a2a_router(
+        controller,
+        "codex",
+        8120,
+        "\n",
+        agent_id="synapse-codex-8120",
+    )
+    assert router is not None
+    assert controller.callback is not None
+    return controller.callback
+
+
+def _create_working_task(
+    *,
+    current_task_preview: str | None = None,
+    sent_message: str | None = None,
+):
+    metadata = {
+        "response_mode": "notify",
+        "sender": {
+            "sender_id": "synapse-claude-8106",
+            "sender_endpoint": "http://localhost:8106",
+            "sender_task_id": "sender-task-1",
+        },
+    }
+    if current_task_preview is not None:
+        metadata["current_task_preview"] = current_task_preview
+    if sent_message is not None:
+        metadata["_sent_message"] = sent_message
+    task = task_store.create(
+        Message(parts=[TextPart(text="Run command")]),
+        metadata=metadata,
+    )
+    task_store.update_status(task.id, "working")
+    return task
+
+
+def _permission_context(task_id: str) -> str:
+    task = task_store.get(task_id)
+    assert task is not None
+    return task.metadata["permission"]["pty_context"]
+
+
+def _emit_waiting(callback, *, now: float = 1000.0) -> AsyncMock:
+    with (
+        patch("synapse.a2a_compat.time.time", return_value=now),
+        patch(
+            "synapse.a2a_compat._send_response_to_sender",
+            new_callable=AsyncMock,
+        ) as mock_send,
+    ):
+        callback("PROCESSING", "WAITING")
+    return mock_send
+
+
+def test_pty_context_stripped_of_ansi_sequences():
+    raw = "\x1b[31mAllow Bash\x1b[0m\r\n\x1b[2K1. Yes, proceed"
+    controller = _Controller(raw)
+    callback = _register_status_callback(controller)
+    task = _create_working_task()
+
+    _emit_waiting(callback)
+
+    context = _permission_context(task.id)
+    assert "\x1b[" not in context
+    assert "\r" not in context
+    assert "Allow Bash" in context
+    assert "1. Yes, proceed" in context
+
+
+def test_pty_context_truncation_does_not_leave_mid_ansi():
+    raw = "A" * 520 + "\x1b[31mAllow Bash\x1b[0m\n1. Yes, proceed"
+    controller = _Controller(raw)
+    callback = _register_status_callback(controller)
+    task = _create_working_task()
+
+    _emit_waiting(callback)
+
+    context = _permission_context(task.id)
+    assert "\x1b[" not in context
+    assert not context.startswith("[31m")
+    assert "Allow Bash" in context
+
+
+def test_notification_fallback_to_task_preview_when_context_empty():
+    controller = _Controller("")
+    callback = _register_status_callback(controller)
+    task = _create_working_task(current_task_preview="Approve shell command")
+
+    _emit_waiting(callback)
+
+    assert _permission_context(task.id) == "Approve shell command"
+
+
+def test_notification_fallback_to_sent_message_when_context_still_empty():
+    controller = _Controller("")
+    callback = _register_status_callback(controller)
+    task = _create_working_task(sent_message="Run pytest for permission workflow")
+
+    _emit_waiting(callback)
+
+    assert _permission_context(task.id) == "Run pytest for permission workflow"
+
+
+def test_notification_placeholder_when_all_fallbacks_empty():
+    controller = _Controller("")
+    callback = _register_status_callback(controller)
+    task = _create_working_task()
+
+    _emit_waiting(callback)
+
+    assert _permission_context(task.id) == "[permission context unavailable]"
+
+
+def test_permission_notification_dedup_by_hash_within_window():
+    controller = _Controller("Allow Bash\n1. Yes, proceed")
+    callback = _register_status_callback(controller)
+    task = _create_working_task()
+
+    first_send = _emit_waiting(callback, now=1000.0)
+    callback("WAITING", "READY")
+    second_send = _emit_waiting(callback, now=1001.0)
+
+    first_send.assert_called_once()
+    second_send.assert_not_called()
+    updated = task_store.get(task.id)
+    assert updated is not None
+    assert updated.metadata["permission"]["notifications_sent"] == 1
+
+
+def test_permission_notification_dedup_by_time_even_when_hash_differs():
+    controller = _Controller("Allow Bash\n1. Yes, proceed")
+    callback = _register_status_callback(controller)
+    task = _create_working_task()
+
+    first_send = _emit_waiting(callback, now=1000.0)
+    callback("WAITING", "READY")
+    controller.context = "Allow Read\n1. Yes, proceed"
+    second_send = _emit_waiting(callback, now=1002.0)
+
+    first_send.assert_called_once()
+    second_send.assert_not_called()
+    updated = task_store.get(task.id)
+    assert updated is not None
+    assert updated.metadata["permission"]["notifications_sent"] == 1
+
+
+def test_permission_notification_counter_increments_once_per_emit():
+    controller = _Controller("Allow Bash\n1. Yes, proceed")
+    callback = _register_status_callback(controller)
+    task = _create_working_task()
+
+    _emit_waiting(callback, now=1000.0)
+
+    updated = task_store.get(task.id)
+    assert updated is not None
+    assert updated.metadata["permission"]["notifications_sent"] == 1
+
+
+def test_permission_notification_reemits_after_window_expires():
+    controller = _Controller("Allow Bash\n1. Yes, proceed")
+    callback = _register_status_callback(controller)
+    task = _create_working_task()
+
+    first_send = _emit_waiting(callback, now=1000.0)
+    callback("WAITING", "READY")
+    controller.context = "Allow Read\n1. Yes, proceed"
+    second_send = _emit_waiting(callback, now=1006.0)
+
+    first_send.assert_called_once()
+    second_send.assert_called_once()
+    updated = task_store.get(task.id)
+    assert updated is not None
+    assert updated.metadata["permission"]["notifications_sent"] == 2
+
+
+@pytest.mark.parametrize(
+    "context",
+    [
+        "\x1b[31mred\x1b[0m",
+        "\x00\x01\x02Allow Bash\x7f",
+    ],
+)
+def test_permission_context_removes_residual_control_bytes(context: str):
+    controller = _Controller(context)
+    callback = _register_status_callback(controller)
+    task = _create_working_task()
+
+    _emit_waiting(callback)
+
+    sanitized = _permission_context(task.id)
+    assert "\x1b[" not in sanitized
+    assert "\x00" not in sanitized
+    assert "\x7f" not in sanitized

--- a/tests/test_permission_notifications.py
+++ b/tests/test_permission_notifications.py
@@ -236,6 +236,9 @@ def test_permission_notification_reemits_after_window_expires():
     [
         "\x1b[31mred\x1b[0m",
         "\x00\x01\x02Allow Bash\x7f",
+        "\x9b31mAllow Bash\x9b0m",
+        "\x9dnotify-title\x9cAllow Bash",
+        "\x80\x85\x9fAllow Bash",
     ],
 )
 def test_permission_context_removes_residual_control_bytes(context: str):
@@ -249,3 +252,39 @@ def test_permission_context_removes_residual_control_bytes(context: str):
     assert "\x1b[" not in sanitized
     assert "\x00" not in sanitized
     assert "\x7f" not in sanitized
+    assert "\x9b" not in sanitized
+    assert "\x9d" not in sanitized
+    assert all(not (0x80 <= ord(ch) <= 0x9F) for ch in sanitized)
+
+
+def test_permission_notification_dedup_by_hash_after_window_expires():
+    """Covers the prior_hash == digest branch when the time-window is past."""
+    controller = _Controller("Allow Bash\n1. Yes, proceed")
+    callback = _register_status_callback(controller)
+    task = _create_working_task()
+
+    first_send = _emit_waiting(callback, now=1000.0)
+    task_store.update_status(task.id, "working")
+    # Same context, but the dedupe window has already expired (5s > default).
+    # The hash branch must still suppress the re-emission.
+    second_send = _emit_waiting(callback, now=1006.0)
+
+    first_send.assert_called_once()
+    second_send.assert_not_called()
+    updated = task_store.get(task.id)
+    assert updated is not None
+    assert updated.metadata["permission"]["notifications_sent"] == 1
+
+
+def test_permission_fallback_skips_preview_that_is_only_control_bytes():
+    """A preview composed solely of control bytes must not short-circuit the chain."""
+    controller = _Controller("")
+    callback = _register_status_callback(controller)
+    task = _create_working_task(
+        current_task_preview="\x1b[31m\x1b[0m",
+        sent_message="Run pytest for permission workflow",
+    )
+
+    _emit_waiting(callback)
+
+    assert _permission_context(task.id) == "Run pytest for permission workflow"

--- a/tests/test_permission_notifications.py
+++ b/tests/test_permission_notifications.py
@@ -34,6 +34,22 @@ class _Controller:
     def on_status_change(self, callback) -> None:
         self.callback = callback
 
+    def clear_task_active(self) -> None:
+        return None
+
+    def record_task_completed(
+        self,
+        *,
+        task_id: str,
+        duration: float,
+        status: str,
+        output_summary: str,
+    ) -> None:
+        return None
+
+    def task_duration_seconds(self, started_iso: str) -> float:
+        return 0.0
+
 
 def _register_status_callback(controller: _Controller):
     router = create_a2a_router(
@@ -201,7 +217,10 @@ def test_permission_notification_reemits_after_window_expires():
     task = _create_working_task()
 
     first_send = _emit_waiting(callback, now=1000.0)
-    callback("WAITING", "READY")
+    # Simulate the agent re-entering WAITING without the task finishing
+    # (i.e. the controller oscillated). Put the task back into working
+    # so the second WAITING callback can still see it.
+    task_store.update_status(task.id, "working")
     controller.context = "Allow Read\n1. Yes, proceed"
     second_send = _emit_waiting(callback, now=1006.0)
 


### PR DESCRIPTION
## Summary

Closes **#582** (permission notification flood + empty `pty_context`)
and **#586** (permission notification payload leaks raw PTY / ANSI
control bytes into the long-message file). Both issues live in the
same call path (`_build_permission_metadata` +
`_on_status_change` in `synapse/a2a_compat.py`), so they are fixed
together.

## Failure modes addressed

1. **Empty / useless context** — `controller.get_context()` could
   return `""` at the instant of the WAITING transition. The
   sender received
   `[Task <id>] Status: input_required\nPermission context: \n...`
   with 500+ blank lines after `Permission context:`.
2. **Raw PTY / ANSI leak** — `controller.get_context()` can contain
   CSI / OSC / C0 / C1 control bytes. The previous `context[-512:]`
   slice could bisect a CSI sequence and start the notification
   mid-escape. Long payloads escalated to a long-message file and
   persisted the corrupted PTY snapshot verbatim.
3. **Flood** — `_on_status_change` fires on every WAITING
   transition. A controller oscillating WAITING→READY→WAITING
   (common under streaming output) re-emitted the same
   notification tens of times per second. No dedupe, no minimum
   interval.

## Fix

### New helper module `synapse/_pty_sanitize.py`

- `strip_control_bytes(text)` — drops residual CSI / OSC / C0 / C1
  bytes and CR. Keeps TAB and LF so multi-line structure survives.
- `tail_printable(text, limit=512)` — sanitise then slice; the
  tail can't start mid-ANSI.
- `printable_len(text)` / `printable_ratio(text)` — measurement
  helpers.
- `looks_like_garbage(text)` — heuristic guard (> 50 %
  non-printable OR > 5 CSI fragments per KB) for the long-message
  validator follow-up.

### `_build_permission_metadata` fallback chain

1. `controller.get_rendered_context()` (pyte-rendered) if present
2. `controller.get_context()` (already ANSI-stripped by
   `strip_ansi` in most cases; residual bytes cleaned here)
3. `task.metadata.current_task_preview`
4. `task.metadata._sent_message[:200]`
5. `"[permission context unavailable]"` placeholder

Each source is sanitised, and if the final result is
`< _PERMISSION_CONTEXT_MIN_PRINTABLE` (10) printable chars the
chain moves to the next source. The placeholder ensures the
sender never receives a blank notification.

### Dedupe in `_on_status_change`

- Compute `sha256(task_id + "\0" + pty_context)[:16]`.
- Persist on `task.metadata.permission`:
  `notification_hash`, `notification_sent_at`,
  `notifications_sent`.
- Skip re-emission when:
  - the hash matches the last-sent hash, OR
  - the last send was within
    `_PERMISSION_NOTIFICATION_MIN_INTERVAL_SECONDS` (5.0 s).
- After the window expires, a changed payload re-emits normally
  and the counter increments.

## Tests

11 new tests in `tests/test_permission_notifications.py`:

| # | Test |
|---|---|
| 1 | `test_pty_context_stripped_of_ansi_sequences` |
| 2 | `test_pty_context_truncation_does_not_leave_mid_ansi` |
| 3 | `test_notification_fallback_to_task_preview_when_context_empty` |
| 4 | `test_notification_fallback_to_sent_message_when_context_still_empty` |
| 5 | `test_notification_placeholder_when_all_fallbacks_empty` |
| 6 | `test_permission_notification_dedup_by_hash_within_window` |
| 7 | `test_permission_notification_dedup_by_time_even_when_hash_differs` |
| 8 | `test_permission_notification_counter_increments_once_per_emit` |
| 9 | `test_permission_notification_reemits_after_window_expires` |
| 10 + 11 | `test_permission_context_removes_residual_control_bytes` parametrised for CSI and C0/C1 inputs |

## Verification

- `pytest tests/test_permission_notifications.py -v` → **11 passed**
- `pytest tests/test_permission_notify.py -v` (existing regression suite) → **4 passed**
- `pytest -q` (full suite) → **4116 passed / 5 failed**. The 5
  failures are pre-existing environmental leakage (user
  `~/.synapse/wiki.md` + file_safety/learning settings bleed into
  tests) that also fails on `main` — same baseline as PRs #584,
  #585, #587.
- Pre-commit hooks (`ruff`, `ruff format`, `mypy`) all green.

## Out of scope (separate follow-ups)

- **#581** workflow dispatcher self-mapping — wider refactor of
  `synapse/workflow_runner.py`.
- **#583** `post-impl` (`target: self`) workflow hang — independent
  helper-spawn path; orthogonal fix.
- The long-message validator hook (`LongMessageStore.store_message`
  rejecting garbage) — spec'd in the task file but deferred to a
  follow-up because the dedupe alone already stops the leak from
  reaching the store in practice; `looks_like_garbage` is exported
  and ready to wire in next.

## Related

- `feedback_workflow_target_semantics.md`,
  `project_step_d_findings.md` in agent memory — context for the
  neighbouring bugs.
- PR #584 port exhaustion, PR #585 worktree lock-skip, PR #587 gh
  skill migration — all in the same April 2026 cluster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 権限通知の重複抑止（ハッシュ＆時間窓によるデデュープ）を追加。通知送信回数を追跡します。

* **Bug Fixes**
  * ターミナル出力の制御文字やANSI断片を除去するサニタイズにより、破損表示や改行の重複を改善。
  * 権限コンテキストの取得順序を整備し、利用可能な最良情報を選択するように改良。

* **Tests**
  * 権限通知ワークフローとサニタイズ／デデュープの回帰テストを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->