### PR TITLE
fix(codex): detect permissions/host/patch approval overlays (#529)

### DIFF
--- a/synapse/profiles/codex.yaml
+++ b/synapse/profiles/codex.yaml
@@ -28,8 +28,9 @@ input_ready_pattern: "›"                       # Codex shows › when ready fo
 # codex keeps introducing new prompt variants and the numbered-selector
 # shape is the most stable signal we have. See issue tracking the deeper
 # waiting_detection / alternate-screen-buffer fix for the longer-term plan.
+# Also matches permissions, host allow/block, patch, and continue-without overlays introduced in newer codex builds.
 waiting_detection:
-  regex: "›\\s+\\d+\\.|Yes, proceed|Yes, and don't ask again|No, and tell Codex|Press [Ee]nter to confirm|Would you like to|Approaching rate limits|Switch to gpt-|Keep current model|You've hit your usage limit"
+  regex: "›\\s+\\d+\\.|Yes, proceed|Yes, and don't ask again|No, and tell Codex|Press [Ee]nter to confirm|Would you like to|Approaching rate limits|Switch to gpt-|Keep current model|You've hit your usage limit|grant these permissions|continue without permissions|allow this host in the future|block this host in the future|continue without running it|don't ask again for these files|don't ask again for this command"
   require_idle: true
   idle_timeout: 0.5
   waiting_expiry: 30                           # Auto-clear WAITING after 30s to give the parent a realistic window to intervene

--- a/tests/test_codex_profile.py
+++ b/tests/test_codex_profile.py
@@ -81,6 +81,26 @@ class TestCodexWaitingDetection:
         regex = re.compile(codex_profile["waiting_detection"]["regex"])
         assert regex.search("› 1. Some brand new prompt text")
 
+    def test_matches_permissions_and_host_overlays(self, codex_profile: dict) -> None:
+        """Issue #529: Codex renders several approval overlays beyond
+        the classic exec overlay (permissions, host allow/block,
+        patch-files, and "continue without running it"). Each must
+        trigger WAITING so the parent agent receives an
+        ``input_required`` notification instead of silently stalling."""
+        regex = re.compile(codex_profile["waiting_detection"]["regex"])
+        variants = [
+            "  1. Yes, grant these permissions",
+            "  2. Yes, grant these permissions for this session",
+            "  3. No, continue without permissions",
+            "  1. Yes, and allow this host in the future",
+            "  2. No, block this host in the future",
+            "  2. No, continue without running it",
+            "  2. Yes, and don't ask again for these files",
+            "  2. Yes, and don't ask again for this command in this session",
+        ]
+        for line in variants:
+            assert regex.search(line), f"regex missed overlay line: {line!r}"
+
     def test_waiting_expiry_long_enough_for_parent_intervention(
         self, codex_profile: dict
     ) -> None:


### PR DESCRIPTION
## Summary

- Fixes #529. The codex profile's `waiting_detection.regex` missed several newer Codex CLI approval overlays, so agents silently stayed `READY` while the PTY was blocked on a selection prompt — no `input_required` notification was ever sent to the parent.
- Adds literal-phrase alternatives for the **permissions overlay** (`grant these permissions`, `continue without permissions`), the **host allow/block overlay** (`allow this host in the future`, `block this host in the future`), the **exec "continue without running it"** option, and the **patch-files overlay** (`don't ask again for these files` / `...for this command`).
- Option labels verified against `openai/codex` → `codex-rs/tui/src/bottom_pane/approval_overlay.rs` on 2026-04-19 (all apostrophes ASCII, no curly quotes).

## Changes

| File | Delta |
|------|-------|
| `synapse/profiles/codex.yaml` | +1/-1 line: extend waiting_detection regex alternation and update the preceding comment |
| `tests/test_codex_profile.py` | +20 lines: new TDD-driven test `test_matches_permissions_and_host_overlays` asserting every new overlay variant matches |

## Test plan

- [x] New test fails on pre-fix regex (captured in agent report)
- [x] `pytest tests/test_codex_profile.py -v` — 8/8 pass
- [x] No changes to `idle_detector.py`, `pty_renderer.py`, or `controller.py`
- [x] No regressions in codex-profile suite
- [ ] CI green (pending)

### Unrelated test failures (pre-existing on main — not touched)

6 failures observed in full suite that are unrelated to this regex change:
- `tests/test_file_safety.py::TestFileSafetyFromEnv::{test_from_env_db_path_falls_back_to_arg,test_from_env_malformed_settings}`
- `tests/test_learning_mode.py::TestLearningModeInstructionInjection::test_learning_instruction_not_appended_when_disabled`
- `tests/test_send_processing_wait.py::TestSendProcessingWait::test_silent_mode_skips_wait`
- `tests/test_settings.py::TestInstructionFilePaths::{test_file_in_project_directory_only,test_file_not_found_in_either_location}`

## Implementation note

Delegated to a spawned `codex-529` agent (test-first TDD, 2-file scope), then verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)