### PR TITLE
Fix workflow target self dispatch and endpoint fallback

### DIFF
--- a/synapse/canvas/server.py
+++ b/synapse/canvas/server.py
@@ -41,6 +41,8 @@ from synapse.paths import (
     get_history_db_path,
     get_shared_memory_db_path,
 )
+from synapse.registry import is_process_running
+from synapse.tools.a2a_helpers import _normalize_working_dir
 
 logger = logging.getLogger(__name__)
 
@@ -133,13 +135,38 @@ def _get_registry_dir() -> str:
     return os.path.expanduser("~/.a2a/registry")
 
 
-def _resolve_agent_endpoint(target: str) -> str | None:
+def _is_live_registry_entry(candidate: dict[str, Any]) -> bool:
+    """Return False for stale registry entries with dead PIDs."""
+    pid = candidate.get("pid")
+    if not pid:
+        return True
+    try:
+        return is_process_running(int(pid))
+    except (TypeError, ValueError):
+        return False
+
+
+def _log_type_fallback(target: str, candidate: dict[str, Any]) -> None:
+    logger.warning(
+        "Agent target '%s' resolved by type fallback to %s",
+        target,
+        candidate.get("agent_id") or candidate.get("name") or candidate.get("endpoint"),
+    )
+
+
+def _resolve_agent_endpoint(
+    target: str,
+    *,
+    caller_working_dir: str | None = None,
+) -> str | None:
     """Resolve an agent target to its HTTP endpoint.
 
     Searches registry files by agent_id, name, or agent_type.
 
     Args:
         target: Agent ID, name, or type to resolve.
+        caller_working_dir: Optional caller directory used to prefer same-dir
+            type fallback matches.
 
     Returns:
         HTTP endpoint URL, or None if not found.
@@ -154,7 +181,8 @@ def _resolve_agent_endpoint(target: str) -> str | None:
             data = json.loads(Path(file_path).read_text(encoding="utf-8"))
         except (json.JSONDecodeError, OSError, UnicodeDecodeError):
             continue
-        candidates.append(data)
+        if _is_live_registry_entry(data):
+            candidates.append(data)
 
     # Exact agent_id match
     for c in candidates:
@@ -168,7 +196,19 @@ def _resolve_agent_endpoint(target: str) -> str | None:
 
     # Agent type match (only if unique)
     type_matches = [c for c in candidates if c.get("agent_type") == target]
+    if caller_working_dir:
+        caller_dir = _normalize_working_dir(caller_working_dir)
+        same_dir_matches = [
+            c
+            for c in type_matches
+            if _normalize_working_dir(c.get("working_dir")) == caller_dir
+        ]
+        if len(same_dir_matches) == 1:
+            _log_type_fallback(target, same_dir_matches[0])
+            return same_dir_matches[0].get("endpoint")
+
     if len(type_matches) == 1:
+        _log_type_fallback(target, type_matches[0])
         return type_matches[0].get("endpoint")
 
     return None

--- a/synapse/workflow_runner.py
+++ b/synapse/workflow_runner.py
@@ -468,9 +468,13 @@ def _candidate_self_endpoint(sender_info: dict[str, str] | None) -> str | None:
 
 async def _is_endpoint_reachable(endpoint: str) -> bool:
     """Check that a direct self endpoint can receive workflow requests."""
+    # Probe the actual HTTP server because sender metadata can be stale, and
+    # non-loopback hostnames in that metadata may stall in local DNS/mDNS.
     try:
-        async with httpx.AsyncClient(timeout=2.0) as client:
-            response = await client.get(f"{endpoint.rstrip('/')}/tasks")
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            response = await client.get(
+                f"{endpoint.rstrip('/')}/.well-known/agent.json"
+            )
     except httpx.HTTPError:
         return False
     return bool(response.status_code < 500)

--- a/synapse/workflow_runner.py
+++ b/synapse/workflow_runner.py
@@ -15,18 +15,19 @@ import logging
 import os
 import sqlite3
 import subprocess
+import sys
 import time
 import uuid
 from collections import OrderedDict
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
+from urllib.parse import urlsplit, urlunsplit
 
 import httpx
 
 from synapse.config import BLOCKING_TASK_STATES
 from synapse.registry import AgentRegistry
-from synapse.tools.a2a_helpers import _normalize_working_dir
 from synapse.workflow import Workflow, WorkflowError
 from synapse.workflow_db import WorkflowRunDB
 
@@ -41,6 +42,7 @@ _HELPER_ENV_MARKER = "SYNAPSE_WORKFLOW_HELPER"
 _HELPER_PARENT_ENV = "SYNAPSE_WORKFLOW_HELPER_PARENT"
 _HELPER_DEPTH_ENV = "SYNAPSE_WORKFLOW_HELPER_DEPTH"
 _MAX_HELPER_DEPTH = 1
+_HELPER_SPAWN_TIMEOUT = 60.0
 
 # Lazily initialised DB singleton — set to None for tests that don't need it.
 _db: WorkflowRunDB | None = None
@@ -184,11 +186,20 @@ class _WorkflowHelper:
         }
 
         try:
-            result = await asyncio.to_thread(
-                self._spawn_helper_agent,
-                agent_type,
-                working_dir,
-                extra_env,
+            result = await asyncio.wait_for(
+                asyncio.to_thread(
+                    self._spawn_helper_agent,
+                    agent_type,
+                    working_dir,
+                    extra_env,
+                ),
+                timeout=_HELPER_SPAWN_TIMEOUT,
+            )
+        except TimeoutError:
+            return (
+                False,
+                f"Workflow helper spawn timed out after "
+                f"{int(_HELPER_SPAWN_TIMEOUT)} seconds",
             )
         except (OSError, subprocess.SubprocessError, RuntimeError) as exc:
             logger.warning(
@@ -362,6 +373,17 @@ def _evict_old_runs(keep_id: str | None = None) -> None:
         del _workflow_runs[victim]
 
 
+def _configure_stdout_line_buffering() -> None:
+    """Make workflow startup output visible under non-TTY parents."""
+    reconfigure = getattr(sys.stdout, "reconfigure", None)
+    if reconfigure is None:
+        return
+    try:
+        reconfigure(line_buffering=True)
+    except (OSError, ValueError):
+        logger.debug("Failed to enable stdout line buffering", exc_info=True)
+
+
 async def run_workflow(
     workflow: Workflow,
     on_update: Callable[[], None] | None = None,
@@ -373,6 +395,11 @@ async def run_workflow(
     Returns the run_id immediately. The workflow runs asynchronously.
     """
     _raise_if_helper_execution_forbidden()
+    _configure_stdout_line_buffering()
+    print(
+        f"Starting workflow {workflow.name} ({len(workflow.steps)} steps)...",
+        flush=True,
+    )
 
     run_id = str(uuid.uuid4())
     steps = [
@@ -409,6 +436,57 @@ def _resolve_target_endpoint(target: str) -> str | None:
     return _resolve_agent_endpoint(target)
 
 
+def _force_loopback_endpoint(endpoint: str) -> str:
+    """Use 127.0.0.1 for self-targeted URLs to avoid hostname/mDNS stalls."""
+    parsed = urlsplit(endpoint)
+    if not parsed.scheme or not parsed.netloc:
+        return endpoint
+    port = f":{parsed.port}" if parsed.port is not None else ""
+    return urlunsplit(
+        (
+            parsed.scheme,
+            f"127.0.0.1{port}",
+            parsed.path,
+            parsed.query,
+            parsed.fragment,
+        )
+    )
+
+
+def _candidate_self_endpoint(sender_info: dict[str, str] | None) -> str | None:
+    """Return a loopback URL for the caller endpoint when metadata has one."""
+    if not sender_info:
+        return None
+    endpoint = sender_info.get("endpoint") or sender_info.get("sender_endpoint")
+    if endpoint:
+        return _force_loopback_endpoint(endpoint)
+    port = sender_info.get("port") or sender_info.get("sender_port")
+    if port:
+        return f"http://127.0.0.1:{port}"
+    return None
+
+
+async def _is_endpoint_reachable(endpoint: str) -> bool:
+    """Check that a direct self endpoint can receive workflow requests."""
+    try:
+        async with httpx.AsyncClient(timeout=2.0) as client:
+            response = await client.get(f"{endpoint.rstrip('/')}/tasks")
+    except httpx.HTTPError:
+        return False
+    return bool(response.status_code < 500)
+
+
+async def _resolve_self_target_endpoint(
+    sender_info: dict[str, str] | None,
+) -> str | None:
+    endpoint = _candidate_self_endpoint(sender_info)
+    if not endpoint:
+        return None
+    if await _is_endpoint_reachable(endpoint):
+        return endpoint
+    return None
+
+
 def _is_self_target(
     target: str,
     sender_info: dict[str, str] | None,
@@ -417,33 +495,10 @@ def _is_self_target(
     if not sender_info or not target:
         return False
 
-    sender_id = sender_info.get("agent_id") or sender_info.get("sender_id")
-    sender_type = sender_info.get("agent_type") or sender_info.get("sender_type")
     if target == "self":
         return True
-    if sender_id and target == sender_id:
-        return True
-    if not sender_type or target != sender_type:
-        return False
-
-    sender_dir = _normalize_working_dir(
-        sender_info.get("working_dir") or sender_info.get("sender_working_dir")
-    )
-    agents = AgentRegistry().list_agents().values()
-    same_type = [
-        agent
-        for agent in agents
-        if agent.get("agent_type") == sender_type
-        and _normalize_working_dir(agent.get("working_dir")) == sender_dir
-    ]
-    if len(same_type) == 1 and same_type[0].get("agent_id") == sender_id:
-        logger.warning(
-            "Workflow target '%s' auto-detected as self for agent %s",
-            target,
-            sender_id,
-        )
-        return True
-    return False
+    sender_id = sender_info.get("agent_id") or sender_info.get("sender_id")
+    return bool(sender_id and target == sender_id)
 
 
 def _build_canvas_workflow_request(
@@ -517,6 +572,10 @@ async def _poll_task_completion(
                 if status in COMPLETED_TASK_STATES:
                     return status, _extract_task_output(task_data)
                 if status == "input_required" and not target_is_self:
+                    # Self-target sends can be transiently input_required while
+                    # local PTY injection settles. External targets cannot
+                    # progress from workflow context without approval, so fail
+                    # fast with a clear permission error.
                     return "failed", (
                         "Agent requires permission approval"
                         " — check auto-approve configuration"
@@ -721,6 +780,23 @@ async def _execute_step(
     """Execute a single workflow step via direct A2A HTTP send."""
     target_is_self = _is_self_target(wf_step.target, sender_info)
     if target_is_self:
+        endpoint = await _resolve_self_target_endpoint(sender_info)
+        if endpoint:
+            returncode, stdout, stderr, task_id = await _send_workflow_request(
+                endpoint, wf_step, sender_info
+            )
+            await _apply_task_result(
+                step,
+                returncode,
+                stdout,
+                stderr,
+                task_id,
+                wf_step,
+                endpoint,
+                target_is_self=True,
+            )
+            return
+
         if helper is None:
             step.status = "failed"
             step.error = "Workflow helper is unavailable"
@@ -806,7 +882,11 @@ async def _execute_workflow(
             step.started_at = time.time()
             _notify(on_update)
 
-            if _is_self_target(wf_step.target, sender_info) and helper is None:
+            if (
+                _is_self_target(wf_step.target, sender_info)
+                and helper is None
+                and await _resolve_self_target_endpoint(sender_info) is None
+            ):
                 try:
                     helper = _WorkflowHelper(workflow.name, sender_info)
                 except (OSError, subprocess.SubprocessError, RuntimeError) as exc:

--- a/synapse/workflow_runner.py
+++ b/synapse/workflow_runner.py
@@ -195,7 +195,7 @@ class _WorkflowHelper:
                 ),
                 timeout=_HELPER_SPAWN_TIMEOUT,
             )
-        except TimeoutError:
+        except (TimeoutError, asyncio.TimeoutError):
             return (
                 False,
                 f"Workflow helper spawn timed out after "

--- a/tests/test_canvas_server.py
+++ b/tests/test_canvas_server.py
@@ -1643,6 +1643,138 @@ class TestLinkPreview:
         assert resp.status_code == 201
 
 
+class TestResolveAgentEndpoint:
+    """Tests for resolving registry targets to live agent endpoints."""
+
+    def _write_agent(self, registry_dir, filename: str, payload: dict) -> None:
+        (registry_dir / filename).write_text(json.dumps(payload), encoding="utf-8")
+
+    def test_resolve_endpoint_skips_stale_pid(self, tmp_path, monkeypatch):
+        """Dead registry entries should not resolve by type fallback."""
+        from synapse.canvas import server as canvas_server
+
+        registry_dir = tmp_path / "registry"
+        registry_dir.mkdir()
+        self._write_agent(
+            registry_dir,
+            "stale.json",
+            {
+                "agent_id": "synapse-claude-8100",
+                "agent_type": "claude",
+                "name": "stale-claude",
+                "endpoint": "http://localhost:8100",
+                "pid": 999999,
+            },
+        )
+
+        monkeypatch.setattr(
+            canvas_server,
+            "_get_registry_dir",
+            lambda: str(registry_dir),
+        )
+        monkeypatch.setattr(
+            canvas_server,
+            "is_process_running",
+            lambda pid: False,
+            raising=False,
+        )
+
+        assert canvas_server._resolve_agent_endpoint("claude") is None
+
+    def test_resolve_endpoint_prefers_same_working_dir(self, tmp_path, monkeypatch):
+        """When resolving by type, same working directory should win."""
+        from synapse.canvas import server as canvas_server
+
+        registry_dir = tmp_path / "registry"
+        registry_dir.mkdir()
+        self._write_agent(
+            registry_dir,
+            "other.json",
+            {
+                "agent_id": "synapse-claude-8100",
+                "agent_type": "claude",
+                "name": "other-claude",
+                "endpoint": "http://localhost:8100",
+                "pid": 100,
+                "working_dir": "/repo/other",
+            },
+        )
+        self._write_agent(
+            registry_dir,
+            "same.json",
+            {
+                "agent_id": "synapse-claude-8101",
+                "agent_type": "claude",
+                "name": "same-claude",
+                "endpoint": "http://localhost:8101",
+                "pid": 101,
+                "working_dir": "/repo/current",
+            },
+        )
+
+        monkeypatch.setattr(
+            canvas_server,
+            "_get_registry_dir",
+            lambda: str(registry_dir),
+        )
+        monkeypatch.setattr(
+            canvas_server,
+            "is_process_running",
+            lambda pid: True,
+            raising=False,
+        )
+
+        assert (
+            canvas_server._resolve_agent_endpoint(
+                "claude",
+                caller_working_dir="/repo/current",
+            )
+            == "http://localhost:8101"
+        )
+
+    def test_resolve_endpoint_unique_type_fallback_warns(
+        self,
+        tmp_path,
+        monkeypatch,
+        caplog,
+    ):
+        """Unique type fallback should be visible in logs."""
+        from synapse.canvas import server as canvas_server
+
+        registry_dir = tmp_path / "registry"
+        registry_dir.mkdir()
+        self._write_agent(
+            registry_dir,
+            "agent.json",
+            {
+                "agent_id": "synapse-gemini-8110",
+                "agent_type": "gemini",
+                "name": "researcher",
+                "endpoint": "http://localhost:8110",
+                "pid": 110,
+                "working_dir": "/repo/current",
+            },
+        )
+
+        monkeypatch.setattr(
+            canvas_server,
+            "_get_registry_dir",
+            lambda: str(registry_dir),
+        )
+        monkeypatch.setattr(
+            canvas_server,
+            "is_process_running",
+            lambda pid: True,
+            raising=False,
+        )
+
+        with caplog.at_level("WARNING", logger="synapse.canvas.server"):
+            endpoint = canvas_server._resolve_agent_endpoint("gemini")
+
+        assert endpoint == "http://localhost:8110"
+        assert "type fallback" in caplog.text.lower()
+
+
 class TestSSE:
     """Tests for GET /api/stream (SSE)."""
 

--- a/tests/test_workflow_runner.py
+++ b/tests/test_workflow_runner.py
@@ -1045,6 +1045,64 @@ async def test_self_target_uses_caller_endpoint_when_healthy(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_endpoint_reachability_probe_uses_agent_card(monkeypatch):
+    """Self endpoint health checks should use the stable A2A discovery route."""
+    import httpx
+
+    seen: dict[str, object] = {}
+
+    class FakeAsyncClient:
+        def __init__(self, *, timeout):
+            seen["timeout"] = timeout
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def get(self, url):
+            seen["url"] = url
+            return httpx.Response(
+                200,
+                json={"name": "test-agent"},
+                request=httpx.Request("GET", url),
+            )
+
+    monkeypatch.setattr(httpx, "AsyncClient", FakeAsyncClient)
+
+    from synapse.workflow_runner import _is_endpoint_reachable
+
+    assert await _is_endpoint_reachable("http://127.0.0.1:8120")
+    assert seen == {
+        "timeout": 5.0,
+        "url": "http://127.0.0.1:8120/.well-known/agent.json",
+    }
+
+
+def test_endpoint_reachability_probe_route_exists_on_a2a_router():
+    """The self endpoint probe route should exist on Synapse A2A servers."""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from synapse.a2a_compat import create_a2a_router
+
+    app = FastAPI()
+    app.include_router(
+        create_a2a_router(
+            controller=None,
+            agent_type="codex",
+            port=8120,
+            agent_id="synapse-codex-8120",
+        )
+    )
+
+    response = TestClient(app).get("/.well-known/agent.json")
+
+    assert response.status_code < 500
+
+
+@pytest.mark.asyncio
 async def test_workflow_helper_spawn_failure_marks_step_failed_no_crash(monkeypatch):
     """Helper spawn failures should fail only the self-target step."""
     monkeypatch.setattr(

--- a/tests/test_workflow_runner.py
+++ b/tests/test_workflow_runner.py
@@ -517,8 +517,8 @@ def test_is_self_target_matches_sender_agent_id():
     assert _is_self_target("synapse-claude-8103", sender_info)
 
 
-def test_is_self_target_type_match_sole_agent_of_type(monkeypatch):
-    """Legacy type target should map to self when it is the only local match."""
+def test_target_type_does_not_map_to_self_via_dir_fallback(monkeypatch):
+    """Type targets should not self-map through same-dir registry fallback."""
     sender_info = {
         "agent_id": "synapse-claude-8103",
         "agent_type": "claude",
@@ -542,7 +542,18 @@ def test_is_self_target_type_match_sole_agent_of_type(monkeypatch):
         lambda: type("Registry", (), {"list_agents": lambda self: agents})(),
     )
 
-    assert _is_self_target("claude", sender_info)
+    assert not _is_self_target("claude", sender_info)
+
+
+def test_self_target_still_self_without_auto_spawn():
+    """Literal self remains the only type-independent self target."""
+    sender_info = {
+        "agent_id": "synapse-claude-8103",
+        "agent_type": "claude",
+        "working_dir": "/repo",
+    }
+
+    assert _is_self_target("self", sender_info)
 
 
 def test_is_self_target_type_match_multiple_agents_returns_false(monkeypatch):
@@ -822,6 +833,68 @@ async def test_workflow_no_self_steps_does_not_spawn_helper(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_auto_spawn_forces_new_agent_even_when_caller_matches_type_and_dir(
+    monkeypatch,
+):
+    """auto_spawn target:type should spawn a fresh agent instead of mapping to self."""
+    helpers: list[_FakeHelper] = []
+    _patch_helper_factory(monkeypatch, helpers)
+
+    spawned_targets: list[str] = []
+    send_endpoints: list[str] = []
+
+    def _resolve(target: str) -> str | None:
+        if spawned_targets and target == "claude":
+            return "http://localhost:8104"
+        return None
+
+    async def _mock_send(endpoint, *args, **kwargs):
+        send_endpoints.append(endpoint)
+        return 0, "spawned ok", "", "task-abc123"
+
+    def _spawn(target: str) -> bool:
+        spawned_targets.append(target)
+        return True
+
+    sender_info = {
+        "agent_id": "synapse-claude-8103",
+        "agent_type": "claude",
+        "working_dir": "/repo",
+    }
+    agents = {
+        "synapse-claude-8103": {
+            "agent_id": "synapse-claude-8103",
+            "agent_type": "claude",
+            "working_dir": "/repo",
+        }
+    }
+
+    monkeypatch.setattr(
+        "synapse.workflow_runner.AgentRegistry",
+        lambda: type("Registry", (), {"list_agents": lambda self: agents})(),
+    )
+    monkeypatch.setattr("synapse.workflow_runner._resolve_target_endpoint", _resolve)
+    monkeypatch.setattr("synapse.workflow_runner._send_workflow_request", _mock_send)
+    monkeypatch.setattr("synapse.workflow_runner._try_spawn_and_wait", _spawn)
+
+    wf = Workflow(
+        name="auto-spawn-type",
+        steps=[WorkflowStep(target="claude", message="do work")],
+        scope="project",
+        auto_spawn=True,
+    )
+    run_id = await run_workflow(wf, sender_info=sender_info)
+    await asyncio.sleep(0.1)
+
+    run = get_run(run_id)
+    assert run is not None
+    assert run.status == "completed"
+    assert helpers == []
+    assert spawned_targets == ["claude"]
+    assert send_endpoints == ["http://localhost:8104"]
+
+
+@pytest.mark.asyncio
 async def test_run_workflow_in_helper_env_raises_error(monkeypatch):
     """Nested workflow execution must be blocked inside helper agents."""
     monkeypatch.setenv("SYNAPSE_WORKFLOW_HELPER", "1")
@@ -835,6 +908,140 @@ async def test_run_workflow_in_helper_env_raises_error(monkeypatch):
 
     with pytest.raises(Exception, match="Nested workflow execution is forbidden"):
         await run_workflow(wf, sender_info=_make_sender_info())
+
+
+@pytest.mark.asyncio
+async def test_run_workflow_emits_banner_before_helper_spawn(monkeypatch, capsys):
+    """Workflow startup should be visible before any helper spawn can block."""
+    helper_started = False
+
+    def _factory(*args, **kwargs):
+        nonlocal helper_started
+        helper_started = True
+        return _FakeHelper()
+
+    monkeypatch.setattr(
+        "synapse.workflow_runner._WorkflowHelper",
+        _factory,
+        raising=False,
+    )
+
+    wf = Workflow(
+        name="visible-start",
+        steps=[WorkflowStep(target="self", message="/release")],
+        scope="project",
+    )
+    await run_workflow(wf, sender_info=_make_sender_info())
+
+    captured = capsys.readouterr()
+    assert "Starting workflow visible-start (1 steps)..." in captured.out
+    assert helper_started is False
+
+
+@pytest.mark.asyncio
+async def test_run_workflow_inserts_db_row_immediately(monkeypatch):
+    """A run row should exist before self-target helper startup completes."""
+    import synapse.workflow_runner as wr
+
+    class BlockingHelper:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        async def execute_step(self, wf_step, step: StepResult) -> None:
+            await asyncio.sleep(0.2)
+
+        def kill(self) -> None:
+            pass
+
+    monkeypatch.setattr(
+        "synapse.workflow_runner._WorkflowHelper",
+        BlockingHelper,
+        raising=False,
+    )
+
+    wf = Workflow(
+        name="visible-in-db",
+        steps=[WorkflowStep(target="self", message="/release")],
+        scope="project",
+    )
+    run_id = await run_workflow(wf, sender_info=_make_sender_info())
+
+    row = wr._get_db().get_run(run_id)
+    assert row is not None
+    assert row["status"] == "running"
+    assert row["completed_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_helper_spawn_times_out_cleanly(monkeypatch):
+    """A helper spawn timeout should fail the step with a clear timeout error."""
+
+    async def _timeout_to_thread(*args, **kwargs):
+        raise asyncio.TimeoutError
+
+    monkeypatch.setattr("synapse.workflow_runner.asyncio.to_thread", _timeout_to_thread)
+
+    wf = Workflow(
+        name="spawn-timeout",
+        steps=[WorkflowStep(target="self", message="/release")],
+        scope="project",
+    )
+    run_id = await run_workflow(wf, sender_info=_make_sender_info())
+    await asyncio.sleep(0.1)
+
+    run = get_run(run_id)
+    assert run is not None
+    assert run.status == "failed"
+    assert run.steps[0].status == "failed"
+    assert "timed out" in (run.steps[0].error or "").lower()
+
+
+@pytest.mark.asyncio
+async def test_self_target_uses_caller_endpoint_when_healthy(monkeypatch):
+    """Healthy self targets should use the caller endpoint instead of a helper."""
+    send_endpoints: list[str] = []
+
+    def _helper_factory(*args, **kwargs):
+        raise AssertionError("self target should not spawn a workflow helper")
+
+    async def _mock_send(endpoint, *args, **kwargs):
+        send_endpoints.append(endpoint)
+        return 0, "sent to self", "", "task-self-001"
+
+    monkeypatch.setattr(
+        "synapse.workflow_runner._WorkflowHelper",
+        _helper_factory,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "synapse.workflow_runner._wait_for_helper_idle",
+        lambda endpoint: asyncio.sleep(0, result=True),
+    )
+    monkeypatch.setattr(
+        "synapse.workflow_runner._is_endpoint_reachable",
+        lambda endpoint: asyncio.sleep(0, result=True),
+    )
+    monkeypatch.setattr("synapse.workflow_runner._send_workflow_request", _mock_send)
+
+    sender_info = _make_sender_info(
+        "synapse-codex-8120",
+        agent_type="codex",
+        working_dir="/repo",
+    )
+    sender_info["endpoint"] = "http://Mac-mini.local:8120"
+
+    wf = Workflow(
+        name="self-endpoint",
+        steps=[WorkflowStep(target="self", message="/release")],
+        scope="project",
+    )
+    run_id = await run_workflow(wf, sender_info=sender_info)
+    await asyncio.sleep(0.1)
+
+    run = get_run(run_id)
+    assert run is not None
+    assert run.status == "completed"
+    assert send_endpoints == ["http://127.0.0.1:8120"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Remove type-based same-directory self mapping so `target: claude` remains an agent type target and `auto_spawn` creates a new agent.
- Add startup workflow visibility, helper spawn timeout errors, and direct loopback dispatch for reachable self targets.
- Harden Canvas endpoint resolution by skipping stale PIDs, preferring same-directory type matches, and warning on type fallback.

## Tests
- `uv run pytest tests/test_workflow_runner.py tests/test_canvas_server.py -v`
- `uv run ruff check synapse/workflow_runner.py synapse/canvas/server.py tests/test_workflow_runner.py tests/test_canvas_server.py`
- `uv run pytest` (fails only in unrelated existing tests: `tests/test_file_safety.py::TestFileSafetyFromEnv::test_from_env_db_path_falls_back_to_arg`, `tests/test_file_safety.py::TestFileSafetyFromEnv::test_from_env_malformed_settings`, `tests/test_learning_mode.py::TestLearningModeInstructionInjection::test_learning_instruction_not_appended_when_disabled`, `tests/test_settings.py::TestInstructionFilePaths::test_file_in_project_directory_only`, `tests/test_settings.py::TestInstructionFilePaths::test_file_not_found_in_either_location`)

Closes #581
Closes #583

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * ワークフローヘルパーのスポーン時にタイムアウト処理を追加しました。

* **Bug Fixes**
  * レジストリフィルタリングを改善し、実行中でないエージェント入力を排除するようになりました。
  * 自己ターゲット実行の信頼性を向上させ、より正確なエンドポイント解決を実現しました。
  * ワークフロー実行のステータス管理を最適化しました。

* **Tests**
  * エンドポイント解決とワークフロー実行制御に関する包括的なテストカバレッジを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->