### PR TITLE
fix(idle_detector): generic prompt heuristic safety net + waiting confidence (#572)

### DIFF
--- a/synapse/a2a_compat.py
+++ b/synapse/a2a_compat.py
@@ -961,10 +961,36 @@ def create_a2a_router(
     def _build_permission_metadata(
         task_metadata: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
+        metadata = task_metadata or {}
+        raw_confidence = (
+            getattr(controller, "last_waiting_confidence", None)
+            if controller is not None
+            else None
+        )
+        if not isinstance(raw_confidence, (int, float)):
+            raw_confidence = metadata.get("waiting_confidence", 0.0)
+        try:
+            waiting_confidence = max(0.0, min(1.0, float(raw_confidence)))
+        except (TypeError, ValueError):
+            waiting_confidence = 0.0
+
+        raw_source = (
+            getattr(controller, "last_waiting_source", None)
+            if controller is not None
+            else None
+        )
+        if raw_source not in {"regex", "heuristic", "none"}:
+            raw_source = metadata.get("waiting_source", "none")
+        waiting_source = (
+            raw_source if raw_source in {"regex", "heuristic", "none"} else "none"
+        )
+
         return {
-            "pty_context": _resolve_pty_context(task_metadata or {}),
+            "pty_context": _resolve_pty_context(metadata),
             "agent_type": agent_type,
             "detected_at": time.time(),
+            "waiting_confidence": waiting_confidence,
+            "waiting_source": waiting_source,
         }
 
     def _build_permission_notification(task: Task) -> Task:

--- a/synapse/controller.py
+++ b/synapse/controller.py
@@ -170,6 +170,8 @@ class TerminalController(StatusObserverMixin):
         self._waiting_idle_timeout = self._idle_detector.waiting_idle_timeout
         self._waiting_pattern_time: float | None = None  # When pattern was last seen
         self._waiting_expiry = self._idle_detector.waiting_expiry
+        self.last_waiting_confidence = 0.0
+        self.last_waiting_source = "none"
 
         # Compound signal: task_active flag (#314)
         self._task_active_count: int = 0
@@ -651,14 +653,23 @@ class TerminalController(StatusObserverMixin):
         Returns:
             True if in WAITING state, False otherwise.
         """
-        is_waiting, self._waiting_pattern_time = (
-            self._idle_detector.check_waiting_state(
-                new_data=new_data,
-                output_buffer=self.output_buffer,
-                last_output_time=self._last_output_time,
-                waiting_pattern_time=self._waiting_pattern_time,
-            )
+        (
+            is_waiting,
+            self._waiting_pattern_time,
+            waiting_confidence,
+            waiting_source,
+        ) = self._idle_detector.check_waiting_state(
+            new_data=new_data,
+            output_buffer=self.output_buffer,
+            last_output_time=self._last_output_time,
+            waiting_pattern_time=self._waiting_pattern_time,
         )
+        if is_waiting:
+            self.last_waiting_confidence = waiting_confidence
+            self.last_waiting_source = waiting_source
+        else:
+            self.last_waiting_confidence = 0.0
+            self.last_waiting_source = "none"
         return is_waiting
 
     def _check_idle_state(self, new_data: bytes) -> None:
@@ -691,6 +702,12 @@ class TerminalController(StatusObserverMixin):
                 return
             self._pattern_detected = evaluation.pattern_detected
             self._waiting_pattern_time = evaluation.waiting_pattern_time
+            if evaluation.is_waiting:
+                self.last_waiting_confidence = evaluation.waiting_confidence
+                self.last_waiting_source = evaluation.waiting_source
+            else:
+                self.last_waiting_confidence = 0.0
+                self.last_waiting_source = "none"
             if evaluation.clear_done_time:
                 self._done_time = None
             is_idle = evaluation.is_idle

--- a/synapse/idle_detector.py
+++ b/synapse/idle_detector.py
@@ -12,6 +12,24 @@ from synapse.status import DONE_TIMEOUT_SECONDS
 
 logger = logging.getLogger(__name__)
 
+_GENERIC_PROMPT_PATTERNS: tuple[str, ...] = (
+    r"^[›❯●>]\s+\d+\.\s",
+    r"\[[Yy]/[Nn]\]",
+    r"\([Yy]/[Nn]\)",
+    r"\bPress Enter\b",
+    r"\bDo you want to\b",
+    r"\bWould you like to\b",
+    r"\bAllow .{0,40}\?",
+    r"^\s*\d+\.\s+(Yes|No|Allow|Deny|Approve|Skip)\b",
+)
+
+_HEURISTIC_REGEX = re.compile(
+    "|".join(f"(?:{pattern})" for pattern in _GENERIC_PROMPT_PATTERNS),
+    re.MULTILINE,
+)
+_HEURISTIC_CONFIDENCE = 0.6
+_PRIMARY_CONFIDENCE = 1.0
+
 
 @dataclass(frozen=True)
 class StatusDecision:
@@ -29,6 +47,8 @@ class IdleStateEvaluation:
     clear_done_time: bool
     pattern_detected: bool
     waiting_pattern_time: float | None
+    waiting_confidence: float = 0.0
+    waiting_source: str = "none"
 
 
 class IdleDetector:
@@ -53,6 +73,9 @@ class IdleDetector:
 
         self.waiting_config = waiting_detection or {}
         self.waiting_regex = self._compile_waiting_regex()
+        self.heuristic_fallback = bool(
+            self.waiting_config.get("heuristic_fallback", True)
+        )
         self.waiting_require_idle = self.waiting_config.get("require_idle", True)
         self.waiting_idle_timeout = float(self.waiting_config.get("idle_timeout", 0.5))
         self.waiting_expiry = float(
@@ -60,6 +83,8 @@ class IdleDetector:
         )
         self._strip_ansi = strip_ansi_fn or (lambda text: text)
         self._renderer = renderer
+        self._waiting_source = "none"
+        self._waiting_confidence = 0.0
 
     def _compile_idle_regex(self) -> re.Pattern[bytes] | None:
         if self.idle_strategy not in ("pattern", "hybrid"):
@@ -181,32 +206,44 @@ class IdleDetector:
         output_buffer: bytes,
         last_output_time: float | None,
         waiting_pattern_time: float | None,
-    ) -> tuple[bool, float | None]:
-        if not self.waiting_regex:
-            return False, waiting_pattern_time
+    ) -> tuple[bool, float | None, float, str]:
+        if not self.waiting_regex and not self.heuristic_fallback:
+            self._waiting_source = "none"
+            self._waiting_confidence = 0.0
+            return False, waiting_pattern_time, 0.0, "none"
 
         # Quiet-tick fast path: no new bytes and nothing previously
         # detected — skip the render/strip work entirely.
         if not new_data and waiting_pattern_time is None:
-            return False, None
+            self._waiting_source = "none"
+            self._waiting_confidence = 0.0
+            return False, None, 0.0, "none"
 
         if new_data:
             if self._renderer is not None:
                 self._renderer.feed(new_data)
                 # renderer path: match against the full rendered screen
-                pattern_visible = bool(
-                    self.waiting_regex.search(self._renderer.render_text())
+                pattern_visible, confidence, source = self._match_waiting_prompt(
+                    self._renderer.render_text()
                 )
             else:
                 new_text = self._strip_ansi(new_data.decode("utf-8", errors="replace"))
-                pattern_visible = bool(self.waiting_regex.search(new_text))
+                pattern_visible, confidence, source = self._match_waiting_prompt(
+                    new_text
+                )
         else:
             pattern_visible = False
+            confidence = self._waiting_confidence
+            source = self._waiting_source
 
         if pattern_visible:
             waiting_pattern_time = time.time()
+            self._waiting_confidence = confidence
+            self._waiting_source = source
         elif waiting_pattern_time is None:
-            return False, None
+            self._waiting_source = "none"
+            self._waiting_confidence = 0.0
+            return False, None, 0.0, "none"
 
         if waiting_pattern_time is not None:
             elapsed = time.time() - waiting_pattern_time
@@ -217,7 +254,10 @@ class IdleDetector:
                 buffer_text = self._strip_ansi(
                     output_buffer[-512:].decode("utf-8", errors="replace")
                 )
-                still_visible = bool(self.waiting_regex.search(buffer_text))
+                still_visible, confidence, source = self._match_waiting_prompt(
+                    buffer_text,
+                    preferred_source=self._waiting_source,
+                )
                 # When a renderer is available, the pattern must also
                 # be present on the rendered screen. AND semantics: if
                 # *either* source loses the pattern the WAITING state
@@ -226,22 +266,59 @@ class IdleDetector:
                 # has moved on (e.g. the test replaces output_buffer
                 # directly without feeding the renderer).
                 if self._renderer is not None and still_visible:
-                    still_visible = bool(
-                        self.waiting_regex.search(self._renderer.render_text())
+                    still_visible, confidence, source = self._match_waiting_prompt(
+                        self._renderer.render_text(),
+                        preferred_source=source,
                     )
                 if still_visible:
                     waiting_pattern_time = time.time()
+                    self._waiting_confidence = confidence
+                    self._waiting_source = source
                 else:
-                    return False, None
+                    self._waiting_source = "none"
+                    self._waiting_confidence = 0.0
+                    return False, None, 0.0, "none"
 
         if not self.waiting_require_idle:
-            return True, waiting_pattern_time
+            return (
+                True,
+                waiting_pattern_time,
+                self._waiting_confidence,
+                self._waiting_source,
+            )
 
         if not (waiting_pattern_time and last_output_time):
-            return False, waiting_pattern_time
+            return False, waiting_pattern_time, 0.0, "none"
 
         time_since_output = time.time() - last_output_time
-        return time_since_output >= self.waiting_idle_timeout, waiting_pattern_time
+        is_waiting = time_since_output >= self.waiting_idle_timeout
+        if not is_waiting:
+            return False, waiting_pattern_time, 0.0, "none"
+        return (
+            True,
+            waiting_pattern_time,
+            self._waiting_confidence,
+            self._waiting_source,
+        )
+
+    def _match_waiting_prompt(
+        self,
+        text: str,
+        *,
+        preferred_source: str = "regex",
+    ) -> tuple[bool, float, str]:
+        if preferred_source == "heuristic":
+            if self.heuristic_fallback and _HEURISTIC_REGEX.search(text):
+                return True, _HEURISTIC_CONFIDENCE, "heuristic"
+            if self.waiting_regex and self.waiting_regex.search(text):
+                return True, _PRIMARY_CONFIDENCE, "regex"
+            return False, 0.0, "none"
+
+        if self.waiting_regex and self.waiting_regex.search(text):
+            return True, _PRIMARY_CONFIDENCE, "regex"
+        if self.heuristic_fallback and _HEURISTIC_REGEX.search(text):
+            return True, _HEURISTIC_CONFIDENCE, "heuristic"
+        return False, 0.0, "none"
 
     def check_idle_state(
         self,
@@ -263,12 +340,17 @@ class IdleDetector:
             pattern_detected=pattern_detected,
         )
         is_idle = self.evaluate_idle_status(pattern_match, timeout_idle)
-        is_waiting, waiting_pattern_time = self.check_waiting_state(
-            new_data=new_data,
-            output_buffer=output_buffer,
-            last_output_time=last_output_time,
-            waiting_pattern_time=waiting_pattern_time,
+        is_waiting, waiting_pattern_time, waiting_confidence, waiting_source = (
+            self.check_waiting_state(
+                new_data=new_data,
+                output_buffer=output_buffer,
+                last_output_time=last_output_time,
+                waiting_pattern_time=waiting_pattern_time,
+            )
         )
+        if not is_waiting:
+            waiting_confidence = 0.0
+            waiting_source = "none"
         decision = self.determine_new_status(
             current_status=current_status,
             is_idle=is_idle,
@@ -286,4 +368,6 @@ class IdleDetector:
             clear_done_time=decision.clear_done_time,
             pattern_detected=pattern_detected,
             waiting_pattern_time=waiting_pattern_time,
+            waiting_confidence=waiting_confidence,
+            waiting_source=waiting_source,
         )

--- a/synapse/profiles/claude.yaml
+++ b/synapse/profiles/claude.yaml
@@ -28,6 +28,7 @@ idle_detection:
 # Re-enabled with #140 fix: now uses new_data only + auto-expiry
 waiting_detection:
   regex: "^❯\\s+.+|^[☐☑]\\s+|\\[[Yy]/[Nn]\\]"
+  heuristic_fallback: true
   require_idle: true
   idle_timeout: 0.3
   waiting_expiry: 10                           # Auto-clear WAITING after 10s

--- a/synapse/profiles/codex.yaml
+++ b/synapse/profiles/codex.yaml
@@ -31,6 +31,7 @@ input_ready_pattern: "›"                       # Codex shows › when ready fo
 # Also matches permissions, host allow/block, patch, and continue-without overlays introduced in newer codex builds.
 waiting_detection:
   regex: "›\\s+\\d+\\.|Yes, proceed|Yes, and don't ask again|No, and tell Codex|Press [Ee]nter to confirm|Would you like to|Approaching rate limits|Switch to gpt-|Keep current model|You've hit your usage limit|grant these permissions|continue without permissions|allow this host in the future|block this host in the future|continue without running it|don't ask again for these files|don't ask again for this command"
+  heuristic_fallback: true
   require_idle: true
   idle_timeout: 0.5
   waiting_expiry: 30                           # Auto-clear WAITING after 30s to give the parent a realistic window to intervene

--- a/synapse/profiles/copilot.yaml
+++ b/synapse/profiles/copilot.yaml
@@ -42,6 +42,7 @@ input_ready_pattern: "❯"                       # Copilot shows ❯ when ready 
 #      3. No, and tell Copilot what to do differently (Esc)
 waiting_detection:
   regex: "^\\s*\\d+\\.\\s+.+$|^\\s*[>\\*]\\s+.+$|\\[[yYnN]/[yYnN]\\]|\\([yYnN]/[yYnN]\\)|approve .+ for the rest of the running session|No, and tell Copilot"
+  heuristic_fallback: true
   require_idle: true
   idle_timeout: 0.5            # 500ms no output after pattern
   waiting_expiry: 10           # Auto-clear WAITING after 10s

--- a/synapse/profiles/dummy.yaml
+++ b/synapse/profiles/dummy.yaml
@@ -11,3 +11,6 @@ idle_detection:
   strategy: "pattern"
   pattern: "> $"
   timeout: 1.5                # Fallback if pattern fails
+
+waiting_detection:
+  heuristic_fallback: false

--- a/synapse/profiles/gemini.yaml
+++ b/synapse/profiles/gemini.yaml
@@ -26,6 +26,7 @@ input_ready_pattern: ">"                       # Gemini shows > in input box whe
 # Header: "Action Required"
 waiting_detection:
   regex: "●\\s+\\d+\\.|Action Required|Allow (?:once|for this session|for this file)|No, suggest changes|Apply this change|Do you want to proceed"
+  heuristic_fallback: true
   require_idle: true
   idle_timeout: 0.5
   waiting_expiry: 10                           # Auto-clear WAITING after 10s

--- a/synapse/profiles/opencode.yaml
+++ b/synapse/profiles/opencode.yaml
@@ -24,6 +24,7 @@ idle_detection:
 # Dialog title: "Permission Required"
 waiting_detection:
   regex: "Permission Required|Allow \\(a\\)|Allow for session \\(s\\)|Deny \\(d\\)"
+  heuristic_fallback: true
   require_idle: true
   idle_timeout: 0.5          # 500ms no output after pattern
   waiting_expiry: 10         # Auto-clear WAITING after 10s

--- a/tests/test_a2a_compat.py
+++ b/tests/test_a2a_compat.py
@@ -353,6 +353,36 @@ class TestA2ARouterEndpoints:
         assert data["task"]["status"] in ["submitted", "working"]
         mock_controller.write.assert_called_once()
 
+    def test_permission_metadata_includes_confidence(self, mock_controller):
+        """WAITING permission metadata should expose detector confidence/source."""
+        from synapse.a2a_compat import task_store
+        from synapse.a2a_models import Message, TextPart
+
+        with task_store._lock:
+            task_store._tasks.clear()
+
+        mock_controller.status = "PROCESSING"
+        mock_controller.get_context.return_value = "Allow Bash command?"
+        mock_controller.last_waiting_confidence = 0.6
+        mock_controller.last_waiting_source = "heuristic"
+
+        create_a2a_router(mock_controller, "test-agent", 8000, "\n")
+        on_status_change = mock_controller.on_status_change.call_args.args[0]
+
+        task = task_store.create(
+            Message(parts=[TextPart(text="Run command")]),
+            metadata={"sender": {"sender_id": "synapse-claude-8100"}},
+        )
+        task_store.update_status(task.id, "working")
+
+        on_status_change("PROCESSING", "WAITING")
+
+        updated = task_store.get(task.id)
+        assert updated is not None
+        permission = updated.metadata["permission"]
+        assert permission["waiting_confidence"] == 0.6
+        assert permission["waiting_source"] == "heuristic"
+
     def test_tasks_send_outputs_plain_message(self, client, mock_controller):
         """/tasks/send should output message with A2A prefix and sender for agent identification."""
         payload = {

--- a/tests/test_compound_signal.py
+++ b/tests/test_compound_signal.py
@@ -435,7 +435,12 @@ def _load_profile_regex(agent: str) -> str:
 
 def _check_pattern(regex: str, text: str) -> bool:
     ctrl = _make_controller(
-        waiting_detection={"regex": regex, "require_idle": False, "waiting_expiry": 60}
+        waiting_detection={
+            "regex": regex,
+            "heuristic_fallback": False,
+            "require_idle": False,
+            "waiting_expiry": 60,
+        }
     )
     return ctrl._check_waiting_state(text.encode("utf-8"))
 

--- a/tests/test_idle_detector.py
+++ b/tests/test_idle_detector.py
@@ -57,7 +57,7 @@ def test_waiting_detection_refreshes_visible_prompt_after_expiry():
     )
 
     waiting_pattern_time = time.time() - 0.2
-    is_waiting, refreshed_time = detector.check_waiting_state(
+    is_waiting, refreshed_time, _, _ = detector.check_waiting_state(
         new_data=b"",
         output_buffer=b"\x1b[31mProceed?\x1b[0m",
         last_output_time=time.time() - 1.0,
@@ -67,6 +67,142 @@ def test_waiting_detection_refreshes_visible_prompt_after_expiry():
     assert is_waiting is True
     assert refreshed_time is not None
     assert refreshed_time > waiting_pattern_time
+
+
+def test_waiting_heuristic_catches_unknown_numbered_prompt():
+    detector = IdleDetector(
+        waiting_detection={
+            "regex": "NEVER_MATCHES_THIS",
+            "idle_timeout": 0.5,
+        }
+    )
+    prompt = b"\n\n\xe2\x80\xba 1. Yes, proceed\n\xe2\x80\xba 2. No\n"
+
+    is_waiting, refreshed, confidence, source = detector.check_waiting_state(
+        new_data=prompt,
+        output_buffer=prompt,
+        last_output_time=time.time() - 1.0,
+        waiting_pattern_time=None,
+    )
+
+    assert is_waiting is True
+    assert refreshed is not None
+    assert confidence == 0.6
+    assert source == "heuristic"
+
+
+def test_waiting_confidence_high_for_primary_regex():
+    detector = IdleDetector(
+        waiting_detection={
+            "regex": r"Proceed\?",
+            "idle_timeout": 0.5,
+        }
+    )
+
+    is_waiting, refreshed, confidence, source = detector.check_waiting_state(
+        new_data=b"Proceed?",
+        output_buffer=b"Proceed?",
+        last_output_time=time.time() - 1.0,
+        waiting_pattern_time=None,
+    )
+
+    assert is_waiting is True
+    assert refreshed is not None
+    assert confidence == 1.0
+    assert source == "regex"
+
+
+def test_waiting_heuristic_disabled_by_profile_flag():
+    detector = IdleDetector(
+        waiting_detection={
+            "regex": "NEVER_MATCHES_THIS",
+            "heuristic_fallback": False,
+            "idle_timeout": 0.5,
+        }
+    )
+    prompt = b"\n\n\xe2\x80\xba 1. Yes, proceed\n\xe2\x80\xba 2. No\n"
+
+    is_waiting, refreshed, confidence, source = detector.check_waiting_state(
+        new_data=prompt,
+        output_buffer=prompt,
+        last_output_time=time.time() - 1.0,
+        waiting_pattern_time=None,
+    )
+
+    assert is_waiting is False
+    assert refreshed is None
+    assert confidence == 0.0
+    assert source == "none"
+
+
+def test_waiting_heuristic_respects_idle_timeout():
+    detector = IdleDetector(
+        waiting_detection={
+            "regex": "NEVER_MATCHES_THIS",
+            "idle_timeout": 0.5,
+        }
+    )
+    prompt = b"\n\n\xe2\x80\xba 1. Yes, proceed\n\xe2\x80\xba 2. No\n"
+
+    is_waiting, refreshed, confidence, source = detector.check_waiting_state(
+        new_data=prompt,
+        output_buffer=prompt,
+        last_output_time=time.time(),
+        waiting_pattern_time=None,
+    )
+
+    assert is_waiting is False
+    assert refreshed is not None
+    assert confidence == 0.0
+    assert source == "none"
+
+
+def test_waiting_heuristic_respects_waiting_expiry():
+    detector = IdleDetector(
+        waiting_detection={
+            "regex": "NEVER_MATCHES_THIS",
+            "require_idle": False,
+            "waiting_expiry": 30,
+        }
+    )
+
+    is_waiting, refreshed, confidence, source = detector.check_waiting_state(
+        new_data=b"",
+        output_buffer=b"regular output",
+        last_output_time=time.time() - 1.0,
+        waiting_pattern_time=time.time() - 31.0,
+    )
+
+    assert is_waiting is False
+    assert refreshed is None
+    assert confidence == 0.0
+    assert source == "none"
+
+
+def test_idle_state_evaluation_includes_waiting_confidence_and_source():
+    detector = IdleDetector(
+        waiting_detection={
+            "regex": "NEVER_MATCHES_THIS",
+            "idle_timeout": 0.5,
+        }
+    )
+    prompt = b"\n\n\xe2\x80\xba 1. Yes, proceed\n\xe2\x80\xba 2. No\n"
+
+    evaluation = detector.check_idle_state(
+        new_data=prompt,
+        output_buffer=prompt,
+        last_output_time=time.time() - 1.0,
+        pattern_detected=False,
+        waiting_pattern_time=None,
+        current_status="PROCESSING",
+        done_time=None,
+        task_protection_active=False,
+        has_file_locks=False,
+    )
+
+    assert evaluation.is_waiting is True
+    assert evaluation.waiting_confidence == 0.6
+    assert evaluation.waiting_source == "heuristic"
 
 
 def test_waiting_detection_with_renderer_resolves_cursor_motion():
@@ -89,7 +225,7 @@ def test_waiting_detection_with_renderer_resolves_cursor_motion():
     # prompt. strip_ansi would leave "WorkingWorkingProceed?" or worse
     # after SGR mangling; pyte resolves the overwrites.
     raw = b"\x1b[H" + b"Working" + b"\x1b[H" + b"Working" + b"\r\nProceed?"
-    is_waiting, refreshed = detector.check_waiting_state(
+    is_waiting, refreshed, _, _ = detector.check_waiting_state(
         new_data=raw,
         output_buffer=raw,
         last_output_time=time.time() - 1.0,
@@ -117,7 +253,7 @@ def test_waiting_detection_renderer_path_expiry_refresh():
     )
 
     waiting_pattern_time = time.time() - 0.2
-    is_waiting, refreshed = detector.check_waiting_state(
+    is_waiting, refreshed, _, _ = detector.check_waiting_state(
         new_data=b"",
         output_buffer=raw,
         last_output_time=time.time() - 1.0,
@@ -144,7 +280,7 @@ def test_waiting_detection_renderer_path_clears_when_screen_gone():
     )
 
     waiting_pattern_time = time.time() - 0.2
-    is_waiting, refreshed = detector.check_waiting_state(
+    is_waiting, refreshed, _, _ = detector.check_waiting_state(
         new_data=b"",
         output_buffer=b"idle prompt >",
         last_output_time=time.time() - 1.0,
@@ -181,7 +317,7 @@ def test_waiting_detection_renderer_path_survives_garbled_raw_tail():
     # last 512 bytes after strip_ansi — only the renderer can see it.
     big_raw = b"X" * 2048 + garbled_raw
     waiting_pattern_time = time.time() - 0.2
-    is_waiting, refreshed = detector.check_waiting_state(
+    is_waiting, refreshed, _, _ = detector.check_waiting_state(
         new_data=b"",
         output_buffer=big_raw,
         last_output_time=time.time() - 1.0,
@@ -210,7 +346,7 @@ def test_waiting_detection_without_renderer_uses_strip_ansi():
         strip_ansi_fn=strip_ansi,
     )
 
-    is_waiting, refreshed = detector.check_waiting_state(
+    is_waiting, refreshed, _, _ = detector.check_waiting_state(
         new_data=b"\x1b[31mProceed?\x1b[0m",
         output_buffer=b"\x1b[31mProceed?\x1b[0m",
         last_output_time=time.time() - 1.0,


### PR DESCRIPTION
## Summary

Closes #572.

Adds a secondary heuristic prompt detector to `IdleDetector` so WAITING is detected when the per-profile regex misses an unknown prompt, and attaches `waiting_confidence` + `waiting_source` to permission notifications so parent agents can weigh primary-regex (1.0) vs heuristic (0.6) detections.

## Issue #572 Acceptance Criteria

| AC | Status |
|----|--------|
| 1. `/debug/pty` endpoint | ✅ already done in PR #575 (`678df09`) — out of scope |
| 2. Alt-screen buffer in waiting_detection | ✅ already done in PR #575 — out of scope |
| 3. Generic heuristic safety net | ✅ this PR |
| 4. Confidence on unknown prompts | ✅ this PR |

## Hypothesis A–D verification

- **B (ANSI/cursor lossy)** & **C (alt-screen DECSET 1049)** — already solved in PR #575 (pyte virtual terminal).
- **A (require_idle 0.5s sliminess)** — heuristic reuses existing `require_idle` / `waiting_idle_timeout` / `waiting_expiry` so any "true idle" benefit applies equally.
- **D (large streaming pushes overlay out of window)** — pyte renderer keeps the visible screen in scope; heuristic adds a backstop.

The remaining real gap was: profile regex doesn't list this novel prompt. That's what this PR fixes.

## Changes

- **`synapse/idle_detector.py`** (+124): module-level `_GENERIC_PROMPT_PATTERNS` (numbered selectors, [Y/N], "Press Enter", "Do you want to", "Allow ... ?", numbered Yes/No choices), `IdleStateEvaluation.waiting_confidence` + `.waiting_source`, `heuristic_fallback` config flag (default true), `check_waiting_state()` returns `(is_waiting, waiting_pattern_time, confidence, source)`.
- **`synapse/controller.py`** (+31): `TerminalController.last_waiting_confidence` / `.last_waiting_source` updated when WAITING enters.
- **`synapse/a2a_compat.py`** (+28): `_build_permission_metadata` adds `waiting_confidence` / `waiting_source` to the notification dict.
- **`synapse/profiles/*.yaml`** (+5 lines): claude/codex/gemini/copilot/opencode `heuristic_fallback: true`; dummy `heuristic_fallback: false`.
- **`tests/test_idle_detector.py`** (+148): 6 new tests covering heuristic detection, confidence values, opt-out, idle timeout respect, expiry clear, propagation.
- **`tests/test_a2a_compat.py`** (+30): permission metadata includes confidence / source.
- **`tests/test_compound_signal.py`** (7 lines): existing per-profile tests pass `heuristic_fallback: false` so they exercise the regex path in isolation.

## Verification

- `uv run pytest tests/test_idle_detector.py tests/test_a2a_compat.py tests/test_a2a_compat_extended.py tests/test_pty_renderer.py -q` → **128 passed**

## Approach note

Implementation was completed by a Codex agent (`heur-fixer`) across 4 commits (`8cb6abe`, `4e93a01`, `6304c26`, `3031d52`) but the agent hit a Codex rate limit before opening the PR. Push and this PR body are by the manager Claude on behalf of the codex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ヒューリスティックベースの待機プロンプト検出により、待機状態の検出精度を向上させました
  * 待機状態の信頼度スコアと検出方法（正規表現またはヒューリスティック）の追跡機能を実装しました
  * 複数のAIプロファイルでヒューリスティック検出フォールバック機能を有効化しました

* **テスト**
  * 新しい待機検出ロジックの包括的なテストカバレッジを追加しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->