### PR TITLE
docs(skills): prefer subagent over synapse spawn for same-model delegation

### DIFF
--- a/.agents/skills/synapse-a2a/SKILL.md
+++ b/.agents/skills/synapse-a2a/SKILL.md
@@ -110,6 +110,19 @@ Use raw `synapse canvas post <format>` for single blocks; templates for multi-se
 
 ## Spawning Decision Table
 
+> **⚠️ Same-model rule — try subagents first.** When a Claude Code agent needs
+> another claude (or a codex agent needs another codex), use the in-process
+> subagent (`Agent` / `Task` tool for Claude, subprocess for Codex) **before**
+> reaching for `synapse spawn`. Spawning the same model on the same account
+> shares the rate-limit window — it doubles consumption against the same quota
+> instead of distributing it. Reserve same-model `synapse spawn` for cases
+> where the helper must outlive the parent session, needs file isolation that
+> subagents can't provide, or holds a distinct long-running role.
+>
+> `synapse spawn` is the right tool for **cross-model** delegation
+> (Claude → codex / gemini), agents that lack subagent support
+> (Gemini / OpenCode / Copilot), or persistent multi-task helpers.
+
 **Default spawn policy:** When using `synapse spawn`, pass the underlying CLI's
 tool-specific automation args after `--` so spawned agents can run unattended.
 For most CLIs this is an approval-skip / auto-approve flag; for OpenCode use
@@ -135,11 +148,12 @@ Common defaults:
 | Condition | Action |
 |-----------|--------|
 | Existing READY agent can handle it | `synapse send` — reuse is faster (avoids startup overhead) |
-| Need parallel execution | `synapse spawn` with `--worktree -- <tool-specific-automation-args>` for file isolation |
-| Task needs a different model's strengths | Spawn a different type (Claude spawns Gemini, etc.) |
+| **Same-model helper needed (Claude → claude, Codex → codex)** | **Use the in-process subagent first** (`Agent`/`Task` tool for Claude, subprocess for Codex). `synapse spawn` same-model shares the rate-limit window. |
+| Need parallel execution | `synapse spawn` with `--worktree -- <tool-specific-automation-args>` for file isolation (cross-model preferred) |
+| Task needs a different model's strengths | `synapse spawn` a different type (Claude spawns Gemini / Codex, etc.) |
 | User specified agent count | Follow exactly |
-| Single focused subtask | Spawn 1 agent |
-| N independent subtasks | Spawn N agents |
+| Single focused subtask | Subagent (same model) or `synapse spawn` (cross model) |
+| N independent subtasks | Subagents for same-model fan-out, `synapse spawn` for cross-model |
 
 **Spawn lifecycle (preferred, one-command)**: `synapse spawn --task-file ... --task-timeout 600 --notify` → wait for A2A completion notification → evaluate result → `synapse kill <name> -f` → confirm in `synapse list --json`
 

--- a/.claude/skills/synapse-a2a/SKILL.md
+++ b/.claude/skills/synapse-a2a/SKILL.md
@@ -110,6 +110,19 @@ Use raw `synapse canvas post <format>` for single blocks; templates for multi-se
 
 ## Spawning Decision Table
 
+> **⚠️ Same-model rule — try subagents first.** When a Claude Code agent needs
+> another claude (or a codex agent needs another codex), use the in-process
+> subagent (`Agent` / `Task` tool for Claude, subprocess for Codex) **before**
+> reaching for `synapse spawn`. Spawning the same model on the same account
+> shares the rate-limit window — it doubles consumption against the same quota
+> instead of distributing it. Reserve same-model `synapse spawn` for cases
+> where the helper must outlive the parent session, needs file isolation that
+> subagents can't provide, or holds a distinct long-running role.
+>
+> `synapse spawn` is the right tool for **cross-model** delegation
+> (Claude → codex / gemini), agents that lack subagent support
+> (Gemini / OpenCode / Copilot), or persistent multi-task helpers.
+
 **Default spawn policy:** When using `synapse spawn`, pass the underlying CLI's
 tool-specific automation args after `--` so spawned agents can run unattended.
 For most CLIs this is an approval-skip / auto-approve flag; for OpenCode use
@@ -135,11 +148,12 @@ Common defaults:
 | Condition | Action |
 |-----------|--------|
 | Existing READY agent can handle it | `synapse send` — reuse is faster (avoids startup overhead) |
-| Need parallel execution | `synapse spawn` with `--worktree -- <tool-specific-automation-args>` for file isolation |
-| Task needs a different model's strengths | Spawn a different type (Claude spawns Gemini, etc.) |
+| **Same-model helper needed (Claude → claude, Codex → codex)** | **Use the in-process subagent first** (`Agent`/`Task` tool for Claude, subprocess for Codex). `synapse spawn` same-model shares the rate-limit window. |
+| Need parallel execution | `synapse spawn` with `--worktree -- <tool-specific-automation-args>` for file isolation (cross-model preferred) |
+| Task needs a different model's strengths | `synapse spawn` a different type (Claude spawns Gemini / Codex, etc.) |
 | User specified agent count | Follow exactly |
-| Single focused subtask | Spawn 1 agent |
-| N independent subtasks | Spawn N agents |
+| Single focused subtask | Subagent (same model) or `synapse spawn` (cross model) |
+| N independent subtasks | Subagents for same-model fan-out, `synapse spawn` for cross-model |
 
 **Spawn lifecycle (preferred, one-command)**: `synapse spawn --task-file ... --task-timeout 600 --notify` → wait for A2A completion notification → evaluate result → `synapse kill <name> -f` → confirm in `synapse list --json`
 

--- a/plugins/synapse-a2a/skills/synapse-a2a/SKILL.md
+++ b/plugins/synapse-a2a/skills/synapse-a2a/SKILL.md
@@ -110,6 +110,19 @@ Use raw `synapse canvas post <format>` for single blocks; templates for multi-se
 
 ## Spawning Decision Table
 
+> **⚠️ Same-model rule — try subagents first.** When a Claude Code agent needs
+> another claude (or a codex agent needs another codex), use the in-process
+> subagent (`Agent` / `Task` tool for Claude, subprocess for Codex) **before**
+> reaching for `synapse spawn`. Spawning the same model on the same account
+> shares the rate-limit window — it doubles consumption against the same quota
+> instead of distributing it. Reserve same-model `synapse spawn` for cases
+> where the helper must outlive the parent session, needs file isolation that
+> subagents can't provide, or holds a distinct long-running role.
+>
+> `synapse spawn` is the right tool for **cross-model** delegation
+> (Claude → codex / gemini), agents that lack subagent support
+> (Gemini / OpenCode / Copilot), or persistent multi-task helpers.
+
 **Default spawn policy:** When using `synapse spawn`, pass the underlying CLI's
 tool-specific automation args after `--` so spawned agents can run unattended.
 For most CLIs this is an approval-skip / auto-approve flag; for OpenCode use
@@ -135,11 +148,12 @@ Common defaults:
 | Condition | Action |
 |-----------|--------|
 | Existing READY agent can handle it | `synapse send` — reuse is faster (avoids startup overhead) |
-| Need parallel execution | `synapse spawn` with `--worktree -- <tool-specific-automation-args>` for file isolation |
-| Task needs a different model's strengths | Spawn a different type (Claude spawns Gemini, etc.) |
+| **Same-model helper needed (Claude → claude, Codex → codex)** | **Use the in-process subagent first** (`Agent`/`Task` tool for Claude, subprocess for Codex). `synapse spawn` same-model shares the rate-limit window. |
+| Need parallel execution | `synapse spawn` with `--worktree -- <tool-specific-automation-args>` for file isolation (cross-model preferred) |
+| Task needs a different model's strengths | `synapse spawn` a different type (Claude spawns Gemini / Codex, etc.) |
 | User specified agent count | Follow exactly |
-| Single focused subtask | Spawn 1 agent |
-| N independent subtasks | Spawn N agents |
+| Single focused subtask | Subagent (same model) or `synapse spawn` (cross model) |
+| N independent subtasks | Subagents for same-model fan-out, `synapse spawn` for cross-model |
 
 **Spawn lifecycle (preferred, one-command)**: `synapse spawn --task-file ... --task-timeout 600 --notify` → wait for A2A completion notification → evaluate result → `synapse kill <name> -f` → confirm in `synapse list --json`
 

--- a/synapse/templates/.synapse/default.md
+++ b/synapse/templates/.synapse/default.md
@@ -43,6 +43,14 @@ STEP 2: Collaboration Decision Framework
   - Immediate result needed (no startup cost)
   - Only available for: Claude Code, Codex (not Gemini, OpenCode, Copilot)
   - `analyze_task` returned delegation_strategy == "subagent"
+  - **SAME-MODEL PREFERENCE — Claude → claude / Codex → codex**: When a Claude
+    Code agent needs another claude (or a codex agent needs another codex),
+    ALWAYS try the in-process subagent (Agent / Task tool for Claude;
+    subprocess for Codex) BEFORE `synapse spawn`. Spawning the same model on
+    the same account does not distribute rate limits — it just doubles the
+    consumption against the same quota. Reserve `synapse spawn` for
+    cross-model work (Claude → codex/gemini), file isolation that subagents
+    cannot provide, or roles that require a long-running independent agent.
 
   [DELEGATE TO EXISTING AGENT] synapse send <target> "..." --notify or --silent
   - Outside your role (check ROLE column in synapse list)
@@ -52,13 +60,20 @@ STEP 2: Collaboration Decision Framework
   [USE SYNAPSE SPAWN] synapse spawn / synapse team start
   - 9+ files OR 3+ directories
   - Different model's perspective needed (review, verification, second opinion)
-  - Rate-limit distribution needed (use a different model type)
+  - Rate-limit distribution needed (use a different model type — NOT same model)
   - File isolation needed (--worktree for concurrent edits)
   - Agent types without subagent capability (Gemini, OpenCode, Copilot)
   - `analyze_task` returned delegation_strategy == "spawn"
   - CROSS-MODEL PREFERENCE: When spawning, prefer a DIFFERENT model type.
     Reasons: (1) diverse models bring diverse strengths, (2) distributes token usage across
     providers to avoid rate limits. If one model is rate-limited, delegate to another type.
+  - **SAME-MODEL ANTI-PATTERN**: Spawning claude from claude (or codex from
+    codex) shares the same provider rate limit window. If you need a same-model
+    helper, prefer the in-process subagent (`Agent`/`Task` tool for Claude,
+    subprocess for Codex) — see `[USE SUBAGENT]` above. Use `synapse spawn`
+    same-model only when the helper must outlive the parent session, needs
+    file isolation that subagents cannot provide, or holds a distinct
+    long-running role.
   - Auto-approve: `spawn` and `team start` automatically inject CLI permission bypass
     flags. Use `--no-auto-approve` to disable.
 


### PR DESCRIPTION
## Summary

Adds explicit guidance to the synapse-a2a skill and MCP bootstrap instructions: **when a Claude Code agent needs another claude (or codex needs another codex), prefer the in-process subagent over \`synapse spawn\`**.

## Why

Spawning the same model on the same account does not distribute rate limits — it **doubles consumption against the same quota**. This was observed today when 4 codex spawn agents and 4 claude spawn agents all hit their respective rate limits within minutes.

Subagents (Agent / Task tool for Claude, subprocess for Codex) run in-process and consume the parent's existing API session, which is the same quota — but the model already considered that as part of its own rate budget when accepting the parent task. Spawning a separate same-model agent re-enters the queue from zero against the same throttle.

## Changes

- **\`synapse/templates/.synapse/default.md\`** (MCP bootstrap instructions sent on \`bootstrap_agent()\`):
  - \`[USE SUBAGENT]\` section: new \`SAME-MODEL PREFERENCE\` rule with explicit Claude → claude / Codex → codex guidance
  - \`[USE SYNAPSE SPAWN]\` section: \`SAME-MODEL ANTI-PATTERN\` warning pointing back to \`[USE SUBAGENT]\`
- **\`plugins/synapse-a2a/skills/synapse-a2a/SKILL.md\`** (canonical skill):
  - Spawning Decision Table: prominent admonition above the table
  - Decision matrix: new row \"Same-model helper needed → subagent first\"
- **\`.agents/skills/synapse-a2a/SKILL.md\`** + **\`.claude/skills/synapse-a2a/SKILL.md\`** (byte-for-byte mirrors)

## When synapse spawn is still right

The PR is careful to preserve \`synapse spawn\` as the right tool for:
- **Cross-model** delegation (Claude → codex / gemini) — different providers / quotas
- Agents that lack subagent support (Gemini / OpenCode / Copilot)
- Helpers that must outlive the parent session
- Roles that need file isolation only worktrees provide
- Persistent multi-task helpers

## Test plan

- [x] All 3 SKILL.md copies remain byte-for-byte synchronized (\`diff -q\` clean)
- [x] No code changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)