### PR TITLE
fix(worktree): resolve nested worktree path to original repo root (#546)

### DIFF
--- a/synapse/worktree.py
+++ b/synapse/worktree.py
@@ -142,6 +142,12 @@ def generate_worktree_name() -> str:
 def get_git_root() -> Path:
     """Return the root directory of the current git repository.
 
+    Note:
+        Inside a git worktree this returns the *worktree's* toplevel,
+        not the original repo root. For worktree creation use
+        :func:`get_main_repo_root` instead so that nested worktrees do
+        not accumulate (issue #546).
+
     Raises:
         RuntimeError: If not inside a git repository.
     """
@@ -153,6 +159,33 @@ def get_git_root() -> Path:
     if result.returncode != 0:
         raise RuntimeError("Not a git repository")
     return Path(result.stdout.strip())
+
+
+def get_main_repo_root() -> Path:
+    """Return the original repo root, even when called from a worktree.
+
+    Uses ``git rev-parse --git-common-dir`` to locate the *main*
+    ``.git`` directory (which is shared across all worktrees) and
+    returns its parent. This guarantees that worktree creation always
+    targets ``<main-repo>/.synapse/worktrees/<name>`` rather than a
+    nested path under another worktree (issue #546).
+
+    Raises:
+        RuntimeError: If not inside a git repository.
+    """
+    result = subprocess.run(
+        ["git", "rev-parse", "--git-common-dir"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError("Not a git repository")
+    common_dir = Path(result.stdout.strip())
+    if not common_dir.is_absolute():
+        # Git returns ``.git`` relative to the current working directory
+        # for the main checkout. Anchor it before stripping the suffix.
+        common_dir = (Path.cwd() / common_dir).resolve()
+    return common_dir.parent
 
 
 def _ref_exists(ref: str) -> bool:
@@ -239,7 +272,11 @@ def create_worktree(
         RuntimeError: If not in a git repo, directory exists, or git fails.
         ValueError: If the provided name contains unsafe characters.
     """
-    git_root = get_git_root()
+    # Always anchor new worktrees to the *main* repo root. When the
+    # caller is itself running inside a worktree, ``get_git_root``
+    # would return the worktree's toplevel and cause nested
+    # ``.synapse/worktrees/...`` paths to accumulate (issue #546).
+    git_root = get_main_repo_root()
     if base_branch is not None:
         base_branch = base_branch.strip()
         if not base_branch:

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -16,6 +16,7 @@ from synapse.worktree import (
     generate_worktree_name,
     get_default_remote_branch,
     get_git_root,
+    get_main_repo_root,
     has_new_commits,
     has_uncommitted_changes,
     has_worktree_changes,
@@ -47,6 +48,66 @@ class TestGetGitRoot:
             )
             with pytest.raises(RuntimeError, match="Not a git repository"):
                 get_git_root()
+
+
+# ============================================================
+# get_main_repo_root  (issue #546)
+# ============================================================
+
+
+class TestGetMainRepoRoot:
+    """`get_main_repo_root` must always return the original repo root.
+
+    Even when called from inside a git worktree, the function should
+    resolve to the directory that owns ``.git/`` (the main checkout),
+    not the current worktree's toplevel. This prevents nested worktrees
+    being created at ``<wt>/.synapse/worktrees/<wt2>``.
+    """
+
+    def test_main_repo_detection_uses_git_common_dir(self) -> None:
+        """Function must invoke ``git rev-parse --git-common-dir``."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout="/repo/.git\n", stderr=""
+            )
+            result = get_main_repo_root()
+            assert result == Path("/repo")
+            mock_run.assert_called_once()
+            cmd = mock_run.call_args[0][0]
+            assert cmd == ["git", "rev-parse", "--git-common-dir"]
+
+    def test_resolves_relative_common_dir(self, tmp_path: Path) -> None:
+        """When git returns ``.git`` (relative), resolve it via ``cwd``."""
+        repo = tmp_path / "repo"
+        (repo / ".git").mkdir(parents=True)
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout=".git\n", stderr="")
+            with patch("pathlib.Path.cwd", return_value=repo):
+                result = get_main_repo_root()
+            assert result == repo
+
+    def test_strips_worktrees_subpath(self) -> None:
+        """When invoked inside a worktree, ``--git-common-dir`` returns
+        the main ``.git`` directory regardless. Its parent is the main
+        repo root."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout="/repo/.git\n",
+                stderr="",
+            )
+            result = get_main_repo_root()
+            # Parent of /repo/.git is /repo (the main checkout), NOT
+            # /repo/.synapse/worktrees/rich-elk (the current worktree).
+            assert result == Path("/repo")
+
+    def test_raises_when_not_git_repo(self) -> None:
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=128, stdout="", stderr="fatal: not a git repository"
+            )
+            with pytest.raises(RuntimeError, match="Not a git repository"):
+                get_main_repo_root()
 
 
 # ============================================================
@@ -293,6 +354,69 @@ class TestCreateWorktree:
         with patch("pathlib.Path.exists", return_value=False):
             with pytest.raises(RuntimeError, match="Failed to create worktree"):
                 create_worktree(name="bad-wt")
+
+    # --- Issue #546: nested worktree path resolution -------------------
+
+    @patch("synapse.worktree.get_default_remote_branch", return_value="origin/main")
+    @patch("synapse.worktree.get_main_repo_root", return_value=Path("/repo"))
+    @patch("subprocess.run")
+    @patch("pathlib.Path.mkdir")
+    def test_nested_worktree_resolves_to_main_repo_root(
+        self,
+        mock_mkdir: MagicMock,
+        mock_run: MagicMock,
+        mock_main_root: MagicMock,
+        mock_remote: MagicMock,
+    ) -> None:
+        """When invoked from inside a worktree, the new worktree must
+        be created under the main repo root, not under the parent
+        worktree (issue #546).
+
+        The test mocks ``get_main_repo_root`` to return ``/repo`` (i.e.
+        what would be returned even if cwd is
+        ``/repo/.synapse/worktrees/rich-elk``). The created worktree
+        path must be ``/repo/.synapse/worktrees/<name>`` — *not* nested.
+        """
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("synapse.worktree.generate_worktree_name", return_value="live-swan"):
+            with patch("pathlib.Path.exists", return_value=False):
+                info = create_worktree()
+
+        assert info.path == Path("/repo/.synapse/worktrees/live-swan")
+        # Must NOT be nested under a parent worktree
+        assert ".synapse/worktrees/rich-elk" not in str(info.path)
+        # Verify git worktree add was called with the un-nested path
+        cmd = mock_run.call_args[0][0]
+        assert str(Path("/repo/.synapse/worktrees/live-swan")) in cmd
+
+    @patch("synapse.worktree.get_default_remote_branch", return_value="origin/main")
+    @patch("synapse.worktree.get_main_repo_root", return_value=Path("/repo"))
+    @patch("subprocess.run")
+    @patch("pathlib.Path.mkdir")
+    def test_worktree_creation_from_repo_root_is_unchanged(
+        self,
+        mock_mkdir: MagicMock,
+        mock_run: MagicMock,
+        mock_main_root: MagicMock,
+        mock_remote: MagicMock,
+    ) -> None:
+        """Creating a worktree from the main repo root must continue to
+        place it under ``<repo>/.synapse/worktrees/<name>`` exactly as
+        before. This guards against regressions from the issue #546
+        fix (no double-resolution, no path drift)."""
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch(
+            "synapse.worktree.generate_worktree_name", return_value="bright-falcon"
+        ):
+            with patch("pathlib.Path.exists", return_value=False):
+                info = create_worktree()
+
+        assert info.name == "bright-falcon"
+        assert info.branch == "worktree-bright-falcon"
+        assert info.path == Path("/repo/.synapse/worktrees/bright-falcon")
+        assert info.base_branch == "origin/main"
 
 
 # ============================================================

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -212,14 +212,14 @@ class TestGenerateWorktreeName:
 
 class TestCreateWorktree:
     @patch("synapse.worktree.get_default_remote_branch", return_value="origin/main")
-    @patch("synapse.worktree.get_git_root", return_value=Path("/repo"))
+    @patch("synapse.worktree.get_main_repo_root", return_value=Path("/repo"))
     @patch("subprocess.run")
     @patch("pathlib.Path.mkdir")
     def test_create_worktree_auto_name(
         self,
         mock_mkdir: MagicMock,
         mock_run: MagicMock,
-        mock_git_root: MagicMock,
+        mock_main_root: MagicMock,
         mock_remote: MagicMock,
     ) -> None:
         mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
@@ -241,14 +241,14 @@ class TestCreateWorktree:
         assert len(add_call) >= 1
 
     @patch("synapse.worktree.get_default_remote_branch", return_value="origin/main")
-    @patch("synapse.worktree.get_git_root", return_value=Path("/repo"))
+    @patch("synapse.worktree.get_main_repo_root", return_value=Path("/repo"))
     @patch("subprocess.run")
     @patch("pathlib.Path.mkdir")
     def test_create_worktree_with_name(
         self,
         mock_mkdir: MagicMock,
         mock_run: MagicMock,
-        mock_git_root: MagicMock,
+        mock_main_root: MagicMock,
         mock_remote: MagicMock,
     ) -> None:
         mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
@@ -260,14 +260,14 @@ class TestCreateWorktree:
         assert info.branch == "worktree-feature-auth"
         assert info.path == Path("/repo/.synapse/worktrees/feature-auth")
 
-    @patch("synapse.worktree.get_git_root", return_value=Path("/repo"))
+    @patch("synapse.worktree.get_main_repo_root", return_value=Path("/repo"))
     @patch("subprocess.run")
     @patch("pathlib.Path.mkdir")
     def test_create_worktree_with_custom_base_branch(
         self,
         mock_mkdir: MagicMock,
         mock_run: MagicMock,
-        mock_git_root: MagicMock,
+        mock_main_root: MagicMock,
     ) -> None:
         """When base_branch is provided, it should be used instead of get_default_remote_branch."""
         mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
@@ -285,14 +285,14 @@ class TestCreateWorktree:
         assert cmd[-1] == "renovate/major-eslint-monorepo"
 
     @patch("synapse.worktree.get_default_remote_branch", return_value="origin/main")
-    @patch("synapse.worktree.get_git_root", return_value=Path("/repo"))
+    @patch("synapse.worktree.get_main_repo_root", return_value=Path("/repo"))
     @patch("subprocess.run")
     @patch("pathlib.Path.mkdir")
     def test_create_worktree_base_branch_none_uses_default(
         self,
         mock_mkdir: MagicMock,
         mock_run: MagicMock,
-        mock_git_root: MagicMock,
+        mock_main_root: MagicMock,
         mock_remote: MagicMock,
     ) -> None:
         """When base_branch is None, get_default_remote_branch is used."""
@@ -306,31 +306,31 @@ class TestCreateWorktree:
         cmd = mock_run.call_args[0][0]
         assert cmd[-1] == "origin/main"
 
-    @patch("synapse.worktree.get_git_root", return_value=Path("/repo"))
+    @patch("synapse.worktree.get_main_repo_root", return_value=Path("/repo"))
     def test_create_worktree_empty_base_branch_raises(
-        self, mock_git_root: MagicMock
+        self, mock_main_root: MagicMock
     ) -> None:
         with pytest.raises(ValueError, match="must not be empty"):
             create_worktree(base_branch="")
 
-    @patch("synapse.worktree.get_git_root", return_value=Path("/repo"))
+    @patch("synapse.worktree.get_main_repo_root", return_value=Path("/repo"))
     def test_create_worktree_dash_base_branch_raises(
-        self, mock_git_root: MagicMock
+        self, mock_main_root: MagicMock
     ) -> None:
         with pytest.raises(ValueError, match="must not start with"):
             create_worktree(base_branch="--malicious")
 
-    @patch("synapse.worktree.get_git_root")
-    def test_create_worktree_not_in_git_repo(self, mock_git_root: MagicMock) -> None:
-        mock_git_root.side_effect = RuntimeError("Not a git repository")
+    @patch("synapse.worktree.get_main_repo_root")
+    def test_create_worktree_not_in_git_repo(self, mock_main_root: MagicMock) -> None:
+        mock_main_root.side_effect = RuntimeError("Not a git repository")
         with pytest.raises(RuntimeError, match="Not a git repository"):
             create_worktree()
 
     @patch("synapse.worktree.get_default_remote_branch", return_value="origin/main")
-    @patch("synapse.worktree.get_git_root", return_value=Path("/repo"))
+    @patch("synapse.worktree.get_main_repo_root", return_value=Path("/repo"))
     def test_create_worktree_duplicate_name(
         self,
-        mock_git_root: MagicMock,
+        mock_main_root: MagicMock,
         mock_remote: MagicMock,
     ) -> None:
         with patch("pathlib.Path.exists", return_value=True):
@@ -338,14 +338,14 @@ class TestCreateWorktree:
                 create_worktree(name="existing-wt")
 
     @patch("synapse.worktree.get_default_remote_branch", return_value="origin/main")
-    @patch("synapse.worktree.get_git_root", return_value=Path("/repo"))
+    @patch("synapse.worktree.get_main_repo_root", return_value=Path("/repo"))
     @patch("subprocess.run")
     @patch("pathlib.Path.mkdir")
     def test_create_worktree_git_command_fails(
         self,
         mock_mkdir: MagicMock,
         mock_run: MagicMock,
-        mock_git_root: MagicMock,
+        mock_main_root: MagicMock,
         mock_remote: MagicMock,
     ) -> None:
         mock_run.return_value = MagicMock(


### PR DESCRIPTION
## Summary

When a worktree-spawned agent itself spawned another worktree agent, the new worktree was created relative to the *parent* worktree's cwd, producing a nested path:

```
/repo/.synapse/worktrees/rich-elk/.synapse/worktrees/live-swan
```

`synapse list --json` then surfaced the nested `working_dir`, which broke downstream tooling and made cleanup confusing.

## Root cause

`create_worktree` used `get_git_root`, which inside a worktree resolves to the *worktree's* toplevel rather than the main checkout.

## Fix

- New helper `get_main_repo_root` calls `git rev-parse --git-common-dir`. The shared `.git/` directory is owned by the main checkout regardless of where you invoke git from, so its parent is always the original repo root.
- `create_worktree` now anchors to `get_main_repo_root` so new worktrees always land at `<main-repo>/.synapse/worktrees/<name>`.
- `get_git_root` is unchanged (still used for in-worktree merge/prune work) but docstring now points readers at the new helper for creation paths.

## Test plan

- [x] `tests/test_worktree.py::TestGetMainRepoRoot` (4 tests) — common-dir invocation, relative-path resolution, worktree-context behaviour, error handling
- [x] `tests/test_worktree.py::TestCreateWorktree::test_nested_worktree_resolves_to_main_repo_root` — explicit regression for #546
- [x] `tests/test_worktree.py::TestCreateWorktree::test_worktree_creation_from_repo_root_is_unchanged` — guards against drift in the unchanged path
- [x] Existing `TestCreateWorktree` suite repointed at the new helper; all 68 worktree tests pass
- [x] `tests/test_spawn*.py` (106 tests) — no regressions

## Caveats

`prune_worktrees` still uses `get_git_root` to compute its `synapse_wt_prefix`. If invoked from inside a worktree it would build the prefix relative to that worktree's toplevel and could miss orphans. Out of scope for this PR (no observed bug report); flagging for a follow-up.

Closes #546

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>