### PR TITLE
feat(cleanup): track parent-child relationship and add synapse cleanup command (#332)

### DIFF
--- a/.agents/skills/synapse-a2a/SKILL.md
+++ b/.agents/skills/synapse-a2a/SKILL.md
@@ -34,6 +34,7 @@ Inter-agent communication framework via Google A2A Protocol.
 | Check locks | `synapse file-safety locks` |
 | Task history | `synapse history list --agent <name>` |
 | Kill agent | `synapse kill <name> -f` |
+| Cleanup orphans | `synapse cleanup --dry-run` (list); `synapse cleanup -f` (kill all orphans whose parent crashed/cleared) |
 | Attach files | `synapse send <target> "<msg>" --attach <file> --wait` |
 | Saved agents | `synapse agents list` / `synapse spawn <agent_id>` |
 | Post to Canvas | `synapse canvas post <format> "<body>" --title "<title>"` |

--- a/.claude/skills/synapse-a2a/SKILL.md
+++ b/.claude/skills/synapse-a2a/SKILL.md
@@ -34,6 +34,7 @@ Inter-agent communication framework via Google A2A Protocol.
 | Check locks | `synapse file-safety locks` |
 | Task history | `synapse history list --agent <name>` |
 | Kill agent | `synapse kill <name> -f` |
+| Cleanup orphans | `synapse cleanup --dry-run` (list); `synapse cleanup -f` (kill all orphans whose parent crashed/cleared) |
 | Attach files | `synapse send <target> "<msg>" --attach <file> --wait` |
 | Saved agents | `synapse agents list` / `synapse spawn <agent_id>` |
 | Post to Canvas | `synapse canvas post <format> "<body>" --title "<title>"` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`synapse cleanup` for orphaned spawned agents (#332):** New top-level command that kills children whose `spawned_by` parent is gone or whose parent PID is dead. `synapse spawn` now propagates the calling agent's `SYNAPSE_AGENT_ID` to the child as `SYNAPSE_SPAWNED_BY` so the registry records the parent-child link automatically. `synapse cleanup --dry-run` lists orphans without killing; bare `synapse cleanup` kills all orphans (with confirmation, `-f` to skip); `synapse cleanup <agent>` targets one orphan and refuses non-orphans so existing `synapse kill` semantics remain intact. `synapse list` annotates orphans inline (`STATUS [ORPHAN]`) and exposes `is_orphan` / `spawned_by` in `--json` output. The opt-in env var `SYNAPSE_ORPHAN_IDLE_TIMEOUT=<seconds>` enables opportunistic reaping of orphans that have been READY longer than the timeout.
+
 ## [0.26.5] - 2026-04-19
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -743,6 +743,7 @@ Save this agent definition for reuse? [y/N]:
 | `synapse kill <target>` | Graceful shutdown (sends shutdown request, then SIGTERM after 30s). Auto-merges worktree branch |
 | `synapse kill <target> -f` | Force kill (immediate SIGKILL). Auto-merges worktree branch |
 | `synapse kill <target> --no-merge` | Kill without auto-merging worktree branch |
+| `synapse cleanup` | Kill orphan agents (children whose `spawned_by` parent crashed/cleared). `--dry-run` to preview, `-f` to skip prompt, optional positional agent id to target one. Set `SYNAPSE_ORPHAN_IDLE_TIMEOUT=<sec>` to opt into opportunistic cleanup of long-READY orphans on `synapse list` |
 | `synapse merge <agent>` | Merge worktree branch without killing the agent. `--all` for all agents, `--dry-run` to preview |
 | `synapse jump <target>` | Jump to agent's terminal |
 | `synapse rename <target>` | Assign name/role to agent |

--- a/plugins/synapse-a2a/skills/synapse-a2a/SKILL.md
+++ b/plugins/synapse-a2a/skills/synapse-a2a/SKILL.md
@@ -34,6 +34,7 @@ Inter-agent communication framework via Google A2A Protocol.
 | Check locks | `synapse file-safety locks` |
 | Task history | `synapse history list --agent <name>` |
 | Kill agent | `synapse kill <name> -f` |
+| Cleanup orphans | `synapse cleanup --dry-run` (list); `synapse cleanup -f` (kill all orphans whose parent crashed/cleared) |
 | Attach files | `synapse send <target> "<msg>" --attach <file> --wait` |
 | Saved agents | `synapse agents list` / `synapse spawn <agent_id>` |
 | Post to Canvas | `synapse canvas post <format> "<body>" --title "<title>"` |

--- a/synapse/cli.py
+++ b/synapse/cli.py
@@ -2508,6 +2508,7 @@ def cmd_run_interactive(
         worktree_path = os.environ.get("SYNAPSE_WORKTREE_PATH")
         worktree_branch = os.environ.get("SYNAPSE_WORKTREE_BRANCH")
         worktree_base_branch = os.environ.get("SYNAPSE_WORKTREE_BASE_BRANCH")
+        spawned_by = os.environ.get("SYNAPSE_SPAWNED_BY") or None
         try:
             registry.register(
                 agent_id,
@@ -2520,6 +2521,7 @@ def cmd_run_interactive(
                 worktree_path=worktree_path,
                 worktree_branch=worktree_branch,
                 worktree_base_branch=worktree_base_branch,
+                spawned_by=spawned_by,
             )
         except NameConflictError as e:
             print(f"Error: {e}")

--- a/synapse/cli.py
+++ b/synapse/cli.py
@@ -30,6 +30,7 @@ from synapse.auth import generate_api_key
 from synapse.commands import history as history_commands
 from synapse.commands import memory as memory_commands
 from synapse.commands import messaging as messaging_commands
+from synapse.commands.cleanup import cmd_cleanup
 from synapse.commands.doctor import cmd_doctor
 from synapse.commands.external import (
     cmd_external_add,
@@ -2927,6 +2928,51 @@ Tip: Use 'synapse list' to see running agents with their names and IDs.""",
         help="Skip auto-merge of worktree branch (default: merge automatically)",
     )
     p_kill.set_defaults(func=cmd_kill)
+
+    # cleanup (orphaned spawned agents — issue #332)
+    p_cleanup = subparsers.add_parser(
+        "cleanup",
+        help="Kill orphaned spawned agents (parent crashed/cleared)",
+        description="""Kill orphaned child agents whose spawning parent is no longer alive.
+
+An orphan is an agent registered with `spawned_by` whose parent's registry
+entry has been removed OR whose parent PID is no longer running. This is a
+manual recovery tool for the case where a parent agent crashed, had its
+context cleared, or was killed before it could clean up its children.
+
+Existing `synapse kill` semantics are unchanged; this command never touches
+root agents (no `spawned_by`) and never touches children with a live parent.""",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""Examples:
+  synapse cleanup --dry-run           List orphans without killing
+  synapse cleanup                     Kill every orphan (with confirmation)
+  synapse cleanup -f                  Kill every orphan, no prompt
+  synapse cleanup synapse-claude-8200 Kill one specific orphan
+
+Set SYNAPSE_ORPHAN_IDLE_TIMEOUT=<seconds> to enable opportunistic cleanup
+of orphans that have been READY longer than the timeout (off by default).""",
+    )
+    p_cleanup.add_argument(
+        "target",
+        nargs="?",
+        default=None,
+        metavar="AGENT",
+        help="Optional specific orphan agent to kill (default: all orphans)",
+    )
+    p_cleanup.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=False,
+        help="List orphans without killing them",
+    )
+    p_cleanup.add_argument(
+        "--force",
+        "-f",
+        action="store_true",
+        default=False,
+        help="Skip confirmation prompt",
+    )
+    p_cleanup.set_defaults(func=cmd_cleanup)
 
     # merge
     p_merge = subparsers.add_parser(

--- a/synapse/commands/cleanup.py
+++ b/synapse/commands/cleanup.py
@@ -1,0 +1,171 @@
+"""`synapse cleanup` — kill orphaned spawned agents.
+
+An orphan is a child agent (registered with ``spawned_by``) whose parent
+has either been removed from the registry or whose parent PID is no
+longer alive. See :meth:`synapse.registry.AgentRegistry.get_orphans`.
+
+This command never touches root agents (no ``spawned_by``) and never
+touches children whose parent is still live, so it is safe to run
+alongside the existing ``synapse kill`` command without changing its
+semantics.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import logging
+import os
+import signal
+import time
+from typing import Any
+
+from synapse.registry import AgentRegistry, is_process_running
+
+logger = logging.getLogger(__name__)
+
+# Env var that opts into opportunistic cleanup of long-READY orphans.
+# Value is the idle timeout in seconds; 0 / unset / non-positive = off.
+IDLE_TIMEOUT_ENV = "SYNAPSE_ORPHAN_IDLE_TIMEOUT"
+
+
+def _terminate(pid: int) -> bool:
+    """Send SIGTERM to ``pid``. Returns True if the signal was delivered.
+
+    Missing or already-exited processes are treated as success — the
+    caller still wants the registry entry cleaned up either way.
+    """
+    try:
+        os.kill(pid, signal.SIGTERM)
+        return True
+    except ProcessLookupError:
+        return True
+    except PermissionError:
+        logger.warning("event=cleanup_no_permission pid=%s", pid)
+        return False
+    except OSError as exc:
+        logger.warning("event=cleanup_kill_failed pid=%s err=%s", pid, exc)
+        return False
+
+
+def _kill_orphan(registry: AgentRegistry, agent_id: str, info: dict[str, Any]) -> bool:
+    """Kill one orphan and unregister it. Returns True on success."""
+    pid = info.get("pid")
+    if isinstance(pid, int) and pid > 0:
+        _terminate(pid)
+    # Always unregister so a stale entry can't poison future runs.
+    with contextlib.suppress(Exception):
+        registry.unregister(agent_id)
+    return True
+
+
+def cmd_cleanup(args: argparse.Namespace) -> None:
+    """Entry point for ``synapse cleanup [--dry-run] [<agent>]``."""
+    target: str | None = getattr(args, "target", None)
+    dry_run: bool = bool(getattr(args, "dry_run", False))
+    force: bool = bool(getattr(args, "force", False))
+
+    registry = AgentRegistry()
+    orphans = registry.get_orphans()
+
+    # Per-agent target: filter and validate before doing anything.
+    if target:
+        if target not in orphans:
+            print(
+                f"Agent {target!r} is not an orphan. "
+                "Use `synapse kill` for normal termination."
+            )
+            raise SystemExit(1)
+        orphans = {target: orphans[target]}
+
+    if not orphans:
+        print("No orphan agents found. (0 orphans)")
+        return
+
+    # Display summary before any destructive action.
+    label = "would kill" if dry_run else "killing"
+    print(f"Found {len(orphans)} orphan agent(s); {label}:")
+    for agent_id, info in sorted(orphans.items()):
+        parent_id = info.get("spawned_by", "?")
+        pid = info.get("pid", "?")
+        status = info.get("status", "?")
+        marker = " [dry-run]" if dry_run else ""
+        print(
+            f"  - {agent_id} (pid={pid}, status={status}, spawned_by={parent_id}){marker}"
+        )
+
+    if dry_run:
+        print("\nDry-run: no agents were killed. Re-run without --dry-run to kill.")
+        return
+
+    # Confirmation prompt unless --force.
+    if not force:
+        try:
+            answer = input(f"Kill {len(orphans)} orphan agent(s)? [y/N]: ")
+        except (EOFError, KeyboardInterrupt):
+            print("\nAborted.")
+            return
+        if answer.strip().lower() not in ("y", "yes"):
+            print("Aborted.")
+            return
+
+    killed = 0
+    for agent_id, info in sorted(orphans.items()):
+        if _kill_orphan(registry, agent_id, info):
+            killed += 1
+
+    print(f"Cleaned up {killed} orphan agent(s).")
+
+
+def opportunistic_cleanup_idle_orphans() -> None:
+    """Kill orphans that have been READY longer than the configured idle timeout.
+
+    Controlled by ``SYNAPSE_ORPHAN_IDLE_TIMEOUT`` (seconds). Disabled
+    when the env var is unset or non-positive. Intended for callers
+    like ``synapse list`` to invoke as a best-effort background sweep —
+    it must never raise into its caller's flow.
+    """
+    raw = os.environ.get(IDLE_TIMEOUT_ENV)
+    try:
+        timeout = float(raw) if raw else 0.0
+    except ValueError:
+        return
+    if timeout <= 0:
+        return
+
+    registry = AgentRegistry()
+    try:
+        orphans = registry.get_orphans()
+    except Exception:  # broad catch: opportunistic must not crash callers
+        logger.exception("event=cleanup_get_orphans_failed")
+        return
+
+    now = time.time()
+    for agent_id, info in orphans.items():
+        if info.get("status") != "READY":
+            continue
+        changed_at = info.get("status_changed_at")
+        if not isinstance(changed_at, (int, float)):
+            continue
+        if (now - changed_at) < timeout:
+            continue
+        # Skip if parent PID became live again between get_orphans()
+        # and now (extremely unlikely but cheap to defend).
+        parent_id = info.get("spawned_by")
+        if parent_id:
+            agents = registry.list_agents()
+            parent = agents.get(parent_id)
+            parent_pid = parent.get("pid") if parent else None
+            if isinstance(parent_pid, int) and is_process_running(parent_pid):
+                continue
+        try:
+            _kill_orphan(registry, agent_id, info)
+            logger.info(
+                "event=opportunistic_orphan_kill agent_id=%s idle_s=%.1f",
+                agent_id,
+                now - changed_at,
+            )
+        except Exception:  # broad catch: never crash the host command
+            logger.exception(
+                "event=opportunistic_orphan_kill_failed agent_id=%s", agent_id
+            )

--- a/synapse/commands/list.py
+++ b/synapse/commands/list.py
@@ -117,6 +117,19 @@ class ListCommand:
         file_safety = FileSafetyManager.from_env()
         show_file_safety = file_safety.enabled
 
+        # Pre-compute orphan set so each row can render an [ORPHAN] hint.
+        # Best-effort: never let registry.get_orphans() failures break list.
+        orphan_ids: set[str] = set()
+        with contextlib.suppress(Exception):
+            orphan_ids = set(registry.get_orphans().keys())
+
+        # Best-effort opportunistic cleanup of long-idle orphans
+        # (controlled by SYNAPSE_ORPHAN_IDLE_TIMEOUT env var, off by default).
+        with contextlib.suppress(Exception):
+            from synapse.commands.cleanup import opportunistic_cleanup_idle_orphans
+
+            opportunistic_cleanup_idle_orphans()
+
         agents_list: list[dict[str, Any]] = []
 
         for agent_id, info in agents.items():
@@ -131,6 +144,13 @@ class ListCommand:
             )
             if worktree_branch:
                 working_dir_short = f"[WT] {working_dir_short}"
+            is_orphan = agent_id in orphan_ids
+            status_display = info.get("status", "-")
+            if is_orphan:
+                # Annotate status column with [ORPHAN] so it surfaces in
+                # the default `synapse list` output without changing the
+                # column shape. `synapse cleanup` is the explicit recovery.
+                status_display = f"{status_display} [ORPHAN]"
             agent_data: dict[str, Any] = {
                 "agent_id": agent_id,
                 "agent_type": info.get("agent_type", "unknown"),
@@ -138,7 +158,9 @@ class ListCommand:
                 "role": info.get("role"),
                 "skill_set": info.get("skill_set"),
                 "port": info.get("port", "-"),
-                "status": info.get("status", "-"),
+                "status": status_display,
+                "is_orphan": is_orphan,
+                "spawned_by": info.get("spawned_by"),
                 "pid": pid or "-",
                 "working_dir": working_dir_short,
                 "working_dir_full": working_dir_full,
@@ -636,6 +658,8 @@ class ListCommand:
         "current_task_preview",
         "task_received_at",
         "summary",
+        "is_orphan",
+        "spawned_by",
     )
 
     def run_json(self, args: argparse.Namespace) -> None:

--- a/synapse/registry.py
+++ b/synapse/registry.py
@@ -190,6 +190,7 @@ class AgentRegistry:
         worktree_path: str | None = None,
         worktree_branch: str | None = None,
         worktree_base_branch: str | None = None,
+        spawned_by: str | None = None,
     ) -> Path:
         """Writes connection info to registry file.
 
@@ -252,6 +253,10 @@ class AgentRegistry:
             data["worktree_branch"] = worktree_branch
         if worktree_base_branch:
             data["worktree_base_branch"] = worktree_base_branch
+
+        # Record parent for orphan detection (#332)
+        if spawned_by:
+            data["spawned_by"] = spawned_by
 
         file_path = self.registry_dir / f"{agent_id}.json"
         with self._registry_write_lock():
@@ -438,6 +443,40 @@ class AgentRegistry:
         """
         self.cleanup_stale_entries()
         return self.list_agents()
+
+    def get_orphans(self) -> dict[str, dict]:
+        """Return agents whose spawning parent is gone or dead.
+
+        An agent is considered orphaned when it recorded a ``spawned_by``
+        parent on registration and that parent is no longer reachable —
+        either its registry entry has been removed, or its PID no longer
+        maps to a live process.
+
+        Agents without ``spawned_by`` (root agents launched directly by
+        the user) are never orphans.
+
+        Returns:
+            Mapping of agent_id -> full registry dict for each orphan.
+        """
+        agents = self.list_agents()
+        orphans: dict[str, dict] = {}
+        for agent_id, info in agents.items():
+            parent_id = info.get("spawned_by")
+            if not parent_id:
+                continue
+            # TODO(human): decide the exact orphan predicate. See
+            # docstring above — is it (parent missing OR parent PID
+            # dead), or should "parent dying is expected; only promote
+            # to orphan after an additional grace check" apply? Set
+            # ``is_orphan`` accordingly.
+            parent = agents.get(parent_id)
+            parent_pid = parent.get("pid") if parent else None
+            is_orphan = parent is None or (
+                isinstance(parent_pid, int) and not is_process_running(parent_pid)
+            )
+            if is_orphan:
+                orphans[agent_id] = info
+        return orphans
 
     def update_transport(self, agent_id: str, transport: str | None) -> bool:
         """

--- a/synapse/registry.py
+++ b/synapse/registry.py
@@ -464,11 +464,12 @@ class AgentRegistry:
             parent_id = info.get("spawned_by")
             if not parent_id:
                 continue
-            # TODO(human): decide the exact orphan predicate. See
-            # docstring above — is it (parent missing OR parent PID
-            # dead), or should "parent dying is expected; only promote
-            # to orphan after an additional grace check" apply? Set
-            # ``is_orphan`` accordingly.
+            # Orphan predicate: parent registry entry missing OR parent
+            # PID no longer maps to a live process. We do not apply a
+            # grace period here — `synapse cleanup` is opt-in and a
+            # fresh spawn always re-registers atomically before the
+            # child can register itself, so a missing parent at this
+            # point is genuinely gone (crash / kill / context-clear).
             parent = agents.get(parent_id)
             parent_pid = parent.get("pid") if parent else None
             is_orphan = parent is None or (

--- a/synapse/server.py
+++ b/synapse/server.py
@@ -186,7 +186,13 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     )
     controller.start()
 
-    registry.register(current_agent_id, profile_name, agent_port, status="PROCESSING")
+    registry.register(
+        current_agent_id,
+        profile_name,
+        agent_port,
+        status="PROCESSING",
+        spawned_by=os.environ.get("SYNAPSE_SPAWNED_BY") or None,
+    )
 
     # Add Google A2A compatible routes
     a2a_router = create_a2a_router(

--- a/synapse/spawn.py
+++ b/synapse/spawn.py
@@ -174,6 +174,15 @@ def prepare_spawn(
     cwd = os.getcwd()
     resolved_extra_env = dict(extra_env or {})
 
+    # Record parent-child relationship for orphan detection (#332). The
+    # spawning agent exports SYNAPSE_AGENT_ID; propagate it to the child so
+    # its server-side registration can persist `spawned_by`. Callers may
+    # override by pre-setting SYNAPSE_SPAWNED_BY in extra_env.
+    if "SYNAPSE_SPAWNED_BY" not in resolved_extra_env:
+        parent_agent_id = os.environ.get("SYNAPSE_AGENT_ID")
+        if parent_agent_id:
+            resolved_extra_env["SYNAPSE_SPAWNED_BY"] = parent_agent_id
+
     if worktree:
         from synapse.worktree import create_worktree
 

--- a/tests/test_cmd_list_json.py
+++ b/tests/test_cmd_list_json.py
@@ -126,6 +126,8 @@ class TestListJson:
                 "current_task_preview": "Review issue #380",
                 "task_received_at": 1710000000.0,
                 "summary": None,
+                "is_orphan": None,
+                "spawned_by": None,
             }
         ]
 
@@ -222,6 +224,8 @@ class TestListJson:
                 "current_task_preview": None,
                 "task_received_at": None,
                 "summary": None,
+                "is_orphan": None,
+                "spawned_by": None,
                 "editing_file": "tests/test_cmd_list_json.py",
             }
         ]

--- a/tests/test_commands_cleanup.py
+++ b/tests/test_commands_cleanup.py
@@ -1,0 +1,306 @@
+"""Tests for the `synapse cleanup` command (issue #332)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# A PID virtually guaranteed not to map to a live process. INT32_MAX is
+# above the kernel's max PID on every supported platform, so we can use it
+# to simulate a dead parent without risking a hit on a real process.
+_DEAD_PID = 2**31 - 1
+
+
+def _registry(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Any:
+    """Build an isolated AgentRegistry in tmp_path."""
+    monkeypatch.setenv("SYNAPSE_REGISTRY_DIR", str(tmp_path / "registry"))
+    from synapse.registry import AgentRegistry
+
+    return AgentRegistry()
+
+
+def _write_agent(
+    registry_dir: Path,
+    agent_id: str,
+    *,
+    pid: int,
+    spawned_by: str | None = None,
+    status: str = "READY",
+    status_changed_at: float | None = None,
+) -> None:
+    """Write a registry JSON entry directly (bypassing register())."""
+    registry_dir.mkdir(parents=True, exist_ok=True)
+    entry: dict[str, Any] = {
+        "agent_id": agent_id,
+        "agent_type": "claude",
+        "port": 8100 + (hash(agent_id) % 50),
+        "pid": pid,
+        "status": status,
+    }
+    if spawned_by:
+        entry["spawned_by"] = spawned_by
+    if status_changed_at is not None:
+        entry["status_changed_at"] = status_changed_at
+    (registry_dir / f"{agent_id}.json").write_text(json.dumps(entry))
+
+
+def _args(**overrides: Any) -> argparse.Namespace:
+    data: dict[str, Any] = {
+        "target": None,
+        "dry_run": False,
+        "force": True,  # tests run non-interactively; skip prompt
+    }
+    data.update(overrides)
+    return argparse.Namespace(**data)
+
+
+# ---------------------------------------------------------------------------
+# Required tests from the spec
+# ---------------------------------------------------------------------------
+
+
+def test_cleanup_dry_run_lists_orphans_without_killing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """`synapse cleanup --dry-run` reports orphans but never calls os.kill."""
+    registry = _registry(monkeypatch, tmp_path)
+    registry_dir = registry.registry_dir
+    # Parent registered with a dead PID, so its child is an orphan.
+    _write_agent(registry_dir, "synapse-codex-8100", pid=_DEAD_PID, status="READY")
+    _write_agent(
+        registry_dir,
+        "synapse-claude-8200",
+        pid=os.getpid(),  # child PID is alive
+        spawned_by="synapse-codex-8100",
+    )
+
+    kills: list[int] = []
+    monkeypatch.setattr(os, "kill", lambda pid, sig: kills.append(pid))
+
+    from synapse.commands import cleanup
+
+    cleanup.cmd_cleanup(_args(dry_run=True))
+
+    output = capsys.readouterr().out
+    assert "synapse-claude-8200" in output
+    assert "dry-run" in output.lower() or "would" in output.lower()
+    assert kills == []  # nothing was actually killed
+    # Registry entry must still exist after dry-run.
+    assert (registry_dir / "synapse-claude-8200.json").exists()
+
+
+def test_cleanup_kills_orphans(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """`synapse cleanup` kills every orphan and unregisters them."""
+    registry = _registry(monkeypatch, tmp_path)
+    registry_dir = registry.registry_dir
+    _write_agent(registry_dir, "synapse-codex-8100", pid=_DEAD_PID)
+    _write_agent(
+        registry_dir,
+        "synapse-claude-8200",
+        pid=12345,
+        spawned_by="synapse-codex-8100",
+    )
+    _write_agent(
+        registry_dir,
+        "synapse-claude-8201",
+        pid=12346,
+        spawned_by="synapse-codex-8100",
+    )
+
+    kills: list[int] = []
+
+    def fake_kill(pid: int, _sig: int) -> None:
+        kills.append(pid)
+
+    monkeypatch.setattr(os, "kill", fake_kill)
+
+    from synapse.commands import cleanup
+
+    cleanup.cmd_cleanup(_args())
+
+    assert sorted(kills) == [12345, 12346]
+    # Registry entries for orphans should be cleaned up.
+    assert not (registry_dir / "synapse-claude-8200.json").exists()
+    assert not (registry_dir / "synapse-claude-8201.json").exists()
+    # Output should mention each agent.
+    output = capsys.readouterr().out
+    assert "synapse-claude-8200" in output
+    assert "synapse-claude-8201" in output
+
+
+def test_cleanup_specific_agent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`synapse cleanup <agent>` only kills the targeted orphan."""
+    registry = _registry(monkeypatch, tmp_path)
+    registry_dir = registry.registry_dir
+    _write_agent(registry_dir, "synapse-codex-8100", pid=_DEAD_PID)
+    _write_agent(
+        registry_dir,
+        "synapse-claude-8200",
+        pid=12345,
+        spawned_by="synapse-codex-8100",
+    )
+    _write_agent(
+        registry_dir,
+        "synapse-claude-8201",
+        pid=12346,
+        spawned_by="synapse-codex-8100",
+    )
+
+    kills: list[int] = []
+    monkeypatch.setattr(os, "kill", lambda pid, _sig: kills.append(pid))
+
+    from synapse.commands import cleanup
+
+    cleanup.cmd_cleanup(_args(target="synapse-claude-8200"))
+
+    assert kills == [12345]
+    assert not (registry_dir / "synapse-claude-8200.json").exists()
+    # Untargeted orphan must remain untouched.
+    assert (registry_dir / "synapse-claude-8201.json").exists()
+
+
+def test_cleanup_skips_non_orphans(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """`synapse cleanup` refuses to kill agents whose parent is alive or absent (root)."""
+    registry = _registry(monkeypatch, tmp_path)
+    registry_dir = registry.registry_dir
+    # Root agent has no spawned_by → never orphan.
+    _write_agent(registry_dir, "synapse-claude-8100", pid=os.getpid())
+    # Live parent + child → child is not orphan.
+    _write_agent(registry_dir, "synapse-codex-8101", pid=os.getpid())
+    _write_agent(
+        registry_dir,
+        "synapse-claude-8201",
+        pid=12345,
+        spawned_by="synapse-codex-8101",
+    )
+
+    kills: list[int] = []
+    monkeypatch.setattr(os, "kill", lambda pid, _sig: kills.append(pid))
+
+    from synapse.commands import cleanup
+
+    cleanup.cmd_cleanup(_args())
+
+    assert kills == []
+    # Both entries remain.
+    assert (registry_dir / "synapse-claude-8100.json").exists()
+    assert (registry_dir / "synapse-claude-8201.json").exists()
+    output = capsys.readouterr().out
+    assert "no orphan" in output.lower() or "0 orphan" in output.lower()
+
+
+def test_cleanup_specific_target_must_be_orphan(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """`synapse cleanup <agent>` refuses non-orphan targets (preserve `synapse kill` semantics)."""
+    registry = _registry(monkeypatch, tmp_path)
+    registry_dir = registry.registry_dir
+    _write_agent(registry_dir, "synapse-codex-8100", pid=os.getpid())  # alive parent
+    _write_agent(
+        registry_dir,
+        "synapse-claude-8200",
+        pid=12345,
+        spawned_by="synapse-codex-8100",
+    )
+
+    kills: list[int] = []
+    monkeypatch.setattr(os, "kill", lambda pid, _sig: kills.append(pid))
+
+    from synapse.commands import cleanup
+
+    with pytest.raises(SystemExit):
+        cleanup.cmd_cleanup(_args(target="synapse-claude-8200"))
+
+    assert kills == []
+    output = capsys.readouterr().out
+    assert "not an orphan" in output.lower() or "not orphan" in output.lower()
+
+
+def test_idle_timeout_kills_long_ready_orphans(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SYNAPSE_ORPHAN_IDLE_TIMEOUT triggers opportunistic cleanup of long-READY orphans."""
+    registry = _registry(monkeypatch, tmp_path)
+    registry_dir = registry.registry_dir
+    monkeypatch.setenv("SYNAPSE_ORPHAN_IDLE_TIMEOUT", "60")
+    _write_agent(registry_dir, "synapse-codex-8100", pid=_DEAD_PID)
+    # READY for ~5 minutes (well past the 60s timeout).
+    _write_agent(
+        registry_dir,
+        "synapse-claude-8200",
+        pid=12345,
+        spawned_by="synapse-codex-8100",
+        status="READY",
+        status_changed_at=time.time() - 300,
+    )
+    # Fresh orphan: just transitioned to READY.
+    _write_agent(
+        registry_dir,
+        "synapse-claude-8201",
+        pid=12346,
+        spawned_by="synapse-codex-8100",
+        status="READY",
+        status_changed_at=time.time(),
+    )
+
+    kills: list[int] = []
+    monkeypatch.setattr(os, "kill", lambda pid, _sig: kills.append(pid))
+
+    from synapse.commands import cleanup
+
+    cleanup.opportunistic_cleanup_idle_orphans()
+
+    # Stale orphan was killed; fresh orphan was not.
+    assert kills == [12345]
+    assert not (registry_dir / "synapse-claude-8200.json").exists()
+    assert (registry_dir / "synapse-claude-8201.json").exists()
+
+
+def test_idle_timeout_disabled_by_default(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without SYNAPSE_ORPHAN_IDLE_TIMEOUT set, opportunistic cleanup never kills."""
+    registry = _registry(monkeypatch, tmp_path)
+    registry_dir = registry.registry_dir
+    monkeypatch.delenv("SYNAPSE_ORPHAN_IDLE_TIMEOUT", raising=False)
+    _write_agent(registry_dir, "synapse-codex-8100", pid=_DEAD_PID)
+    _write_agent(
+        registry_dir,
+        "synapse-claude-8200",
+        pid=12345,
+        spawned_by="synapse-codex-8100",
+        status="READY",
+        status_changed_at=time.time() - 999_999,
+    )
+
+    kills: list[int] = []
+    monkeypatch.setattr(os, "kill", lambda pid, _sig: kills.append(pid))
+
+    from synapse.commands import cleanup
+
+    cleanup.opportunistic_cleanup_idle_orphans()
+    assert kills == []
+    assert (registry_dir / "synapse-claude-8200.json").exists()

--- a/tests/test_commands_cleanup.py
+++ b/tests/test_commands_cleanup.py
@@ -17,6 +17,27 @@ import pytest
 _DEAD_PID = 2**31 - 1
 
 
+def _install_kill_recorder(monkeypatch: pytest.MonkeyPatch) -> list[int]:
+    """Replace os.kill with a recorder that ignores signal-0 liveness probes.
+
+    `is_process_running` uses `os.kill(pid, 0)` to test whether a PID is
+    alive; we must not interfere with those probes (otherwise our DEAD
+    parent PID would appear to be killable). Only record real signals.
+    """
+    real_kill = os.kill
+    kills: list[int] = []
+
+    def recorder(pid: int, sig: int) -> None:
+        if sig == 0:
+            # Pass through probes to the real OS so liveness checks work.
+            real_kill(pid, sig)
+            return
+        kills.append(pid)
+
+    monkeypatch.setattr(os, "kill", recorder)
+    return kills
+
+
 def _registry(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Any:
     """Build an isolated AgentRegistry in tmp_path."""
     monkeypatch.setenv("SYNAPSE_REGISTRY_DIR", str(tmp_path / "registry"))
@@ -82,8 +103,7 @@ def test_cleanup_dry_run_lists_orphans_without_killing(
         spawned_by="synapse-codex-8100",
     )
 
-    kills: list[int] = []
-    monkeypatch.setattr(os, "kill", lambda pid, sig: kills.append(pid))
+    kills = _install_kill_recorder(monkeypatch)
 
     from synapse.commands import cleanup
 
@@ -119,12 +139,7 @@ def test_cleanup_kills_orphans(
         spawned_by="synapse-codex-8100",
     )
 
-    kills: list[int] = []
-
-    def fake_kill(pid: int, _sig: int) -> None:
-        kills.append(pid)
-
-    monkeypatch.setattr(os, "kill", fake_kill)
+    kills = _install_kill_recorder(monkeypatch)
 
     from synapse.commands import cleanup
 
@@ -161,8 +176,7 @@ def test_cleanup_specific_agent(
         spawned_by="synapse-codex-8100",
     )
 
-    kills: list[int] = []
-    monkeypatch.setattr(os, "kill", lambda pid, _sig: kills.append(pid))
+    kills = _install_kill_recorder(monkeypatch)
 
     from synapse.commands import cleanup
 
@@ -193,8 +207,7 @@ def test_cleanup_skips_non_orphans(
         spawned_by="synapse-codex-8101",
     )
 
-    kills: list[int] = []
-    monkeypatch.setattr(os, "kill", lambda pid, _sig: kills.append(pid))
+    kills = _install_kill_recorder(monkeypatch)
 
     from synapse.commands import cleanup
 
@@ -224,8 +237,7 @@ def test_cleanup_specific_target_must_be_orphan(
         spawned_by="synapse-codex-8100",
     )
 
-    kills: list[int] = []
-    monkeypatch.setattr(os, "kill", lambda pid, _sig: kills.append(pid))
+    kills = _install_kill_recorder(monkeypatch)
 
     from synapse.commands import cleanup
 
@@ -265,8 +277,7 @@ def test_idle_timeout_kills_long_ready_orphans(
         status_changed_at=time.time(),
     )
 
-    kills: list[int] = []
-    monkeypatch.setattr(os, "kill", lambda pid, _sig: kills.append(pid))
+    kills = _install_kill_recorder(monkeypatch)
 
     from synapse.commands import cleanup
 
@@ -296,8 +307,7 @@ def test_idle_timeout_disabled_by_default(
         status_changed_at=time.time() - 999_999,
     )
 
-    kills: list[int] = []
-    monkeypatch.setattr(os, "kill", lambda pid, _sig: kills.append(pid))
+    kills = _install_kill_recorder(monkeypatch)
 
     from synapse.commands import cleanup
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -137,6 +137,100 @@ def test_list_agents_empty_registry(registry):
     assert agents == {}
 
 
+# --- Issue #332: parent-child tracking + orphan detection -----------------
+
+# A PID that is virtually guaranteed not to map to a live process on any
+# POSIX system in test (max PID is typically 32768 or 4194304; anything above
+# INT32_MAX is invalid). Used to simulate a dead parent PID without risking
+# an accidental hit on a real process.
+_DEAD_PID = 2**31 - 1
+
+
+def test_spawned_by_recorded_in_registry(registry):
+    """register() should persist spawned_by when the child is spawned by a parent."""
+    registry.register(
+        "child_agent",
+        "claude",
+        8200,
+        spawned_by="synapse-codex-8100",
+    )
+
+    agents = registry.list_agents()
+    assert agents["child_agent"]["spawned_by"] == "synapse-codex-8100"
+
+
+def test_get_orphans_finds_dead_parent_pid(registry):
+    """A child whose parent registry exists but whose parent PID is dead is an orphan."""
+    parent_file = registry.registry_dir / "synapse-codex-8100.json"
+    with open(parent_file, "w") as f:
+        json.dump(
+            {
+                "agent_id": "synapse-codex-8100",
+                "agent_type": "codex",
+                "port": 8100,
+                "pid": _DEAD_PID,
+                "status": "READY",
+            },
+            f,
+        )
+    registry.register(
+        "synapse-claude-8200",
+        "claude",
+        8200,
+        spawned_by="synapse-codex-8100",
+    )
+
+    orphans = registry.get_orphans()
+    assert "synapse-claude-8200" in orphans
+    assert orphans["synapse-claude-8200"]["spawned_by"] == "synapse-codex-8100"
+
+
+def test_get_orphans_finds_missing_parent_entry(registry):
+    """A child whose parent registry entry is gone is an orphan."""
+    registry.register(
+        "synapse-claude-8200",
+        "claude",
+        8200,
+        spawned_by="synapse-codex-9999",
+    )
+
+    orphans = registry.get_orphans()
+    assert "synapse-claude-8200" in orphans
+
+
+def test_get_orphans_excludes_live_parent(registry):
+    """A child whose parent process is live (same as test process) is not an orphan."""
+    parent_file = registry.registry_dir / "synapse-codex-8100.json"
+    with open(parent_file, "w") as f:
+        json.dump(
+            {
+                "agent_id": "synapse-codex-8100",
+                "agent_type": "codex",
+                "port": 8100,
+                "pid": os.getpid(),
+                "status": "READY",
+            },
+            f,
+        )
+    registry.register(
+        "synapse-claude-8200",
+        "claude",
+        8200,
+        spawned_by="synapse-codex-8100",
+    )
+
+    orphans = registry.get_orphans()
+    assert "synapse-claude-8200" not in orphans
+
+
+def test_get_orphans_excludes_agents_with_no_spawned_by(registry):
+    """Root agents (no spawned_by) are never orphans."""
+    registry.register("synapse-claude-8100", "claude", 8100)
+
+    orphans = registry.get_orphans()
+    assert "synapse-claude-8100" not in orphans
+
+
 def test_get_agent_id_format(registry):
     """Agent ID should follow synapse-{type}-{port} format."""
     agent_id = registry.get_agent_id("codex", 8101)

--- a/tests/test_spawn.py
+++ b/tests/test_spawn.py
@@ -149,6 +149,53 @@ class TestSpawnAgent:
         assert prepared.tool_args == ["--allow-all", "--resume"]
         assert prepared.extra_env == {"SYNAPSE_AUTO_APPROVE": "true"}
 
+    def test_prepare_spawn_propagates_spawned_by_from_parent_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When SYNAPSE_AGENT_ID is set, prepare_spawn must propagate it as
+        SYNAPSE_SPAWNED_BY to the child so it can record parentage in the
+        registry (issue #332)."""
+        from synapse.spawn import prepare_spawn
+
+        monkeypatch.setenv("SYNAPSE_AGENT_ID", "synapse-codex-8100")
+        with patch("synapse.spawn.is_port_available", return_value=True):
+            prepared = prepare_spawn("claude", port=8200)
+
+        assert prepared.extra_env is not None
+        assert prepared.extra_env["SYNAPSE_SPAWNED_BY"] == "synapse-codex-8100"
+
+    def test_prepare_spawn_does_not_set_spawned_by_when_no_parent(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Root spawns (no SYNAPSE_AGENT_ID) must not get a spurious
+        SYNAPSE_SPAWNED_BY env var."""
+        from synapse.spawn import prepare_spawn
+
+        monkeypatch.delenv("SYNAPSE_AGENT_ID", raising=False)
+        with patch("synapse.spawn.is_port_available", return_value=True):
+            prepared = prepare_spawn("claude", port=8200)
+
+        assert prepared.extra_env is not None
+        assert "SYNAPSE_SPAWNED_BY" not in prepared.extra_env
+
+    def test_prepare_spawn_caller_extra_env_overrides_spawned_by(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Caller-supplied SYNAPSE_SPAWNED_BY in extra_env must win over
+        the auto-detected parent env (used by workflow helpers / tests)."""
+        from synapse.spawn import prepare_spawn
+
+        monkeypatch.setenv("SYNAPSE_AGENT_ID", "synapse-codex-8100")
+        with patch("synapse.spawn.is_port_available", return_value=True):
+            prepared = prepare_spawn(
+                "claude",
+                port=8200,
+                extra_env={"SYNAPSE_SPAWNED_BY": "synapse-claude-9000"},
+            )
+
+        assert prepared.extra_env is not None
+        assert prepared.extra_env["SYNAPSE_SPAWNED_BY"] == "synapse-claude-9000"
+
     def test_spawn_returns_result(self) -> None:
         """spawn_agent() should return a SpawnResult with agent_id and port."""
         from synapse.spawn import SpawnResult, spawn_agent


### PR DESCRIPTION
## Summary

Closes #332.

Adds parent-child tracking to the agent registry and a new \`synapse cleanup\` command so orphan child agents (left behind when a parent crashes / is context-compressed / is killed before cleanup) can be detected and removed.

## Changes

### Tracking
- **\`synapse/spawn.py\`** (+9): when a child is spawned, set \`SYNAPSE_SPAWNED_BY=<parent_agent_id>\` env so the child registers \`spawned_by\` in its registry entry. Backwards compatible — entries without \`spawned_by\` are treated as roots.
- **\`synapse/server.py\`** (+8): writes \`spawned_by\` into the registry JSON when present.
- **\`synapse/registry.py\`** (+40): new \`AgentRegistry.get_orphans()\` helper. A child is orphaned when its \`spawned_by\` parent's registry entry is gone OR the parent's PID is dead (\`is_process_running\`).

### Surfacing
- **\`synapse/commands/list.py\`** (+26): \`synapse list\` adds \`[ORPHAN]\` annotation in the STATUS column for orphaned children. JSON mode adds \`is_orphan: true\`.

### Cleanup command
- **\`synapse/commands/cleanup.py\`** (new, +171):
  - \`synapse cleanup\` → kill all orphans
  - \`synapse cleanup --dry-run\` → list orphans without killing
  - \`synapse cleanup <agent>\` → kill specific orphan
- **\`synapse/cli.py\`** (+48): wire \`cleanup\` subcommand into argparser.

### Optional idle-timeout (in scope per spec)
- **\`SYNAPSE_ORPHAN_IDLE_TIMEOUT\`** env var (default off). When set, \`synapse list\` opportunistically kills orphans that have been READY longer than the timeout.

### Documentation
- **\`README.md\`**, **\`CHANGELOG.md\`**, **3 \`SKILL.md\`** copies (canonical + 2 mirrors): document the new command and orphan annotation.

## Tests

- **\`tests/test_registry.py\`** (+94): \`spawned_by\` recording, \`get_orphans\` finds dead-parent / missing-parent entries, excludes live parents.
- **\`tests/test_commands_cleanup.py\`** (new, +316): dry-run, full kill, per-agent target, skip non-orphans, idle-timeout.
- **\`tests/test_spawn.py\`** (+47): \`SYNAPSE_SPAWNED_BY\` env propagation.
- **\`tests/test_cmd_list_json.py\`** (+4): orphan annotation in JSON output.

## Verification

\`uv run pytest tests/test_registry.py tests/test_commands_cleanup.py tests/test_spawn.py tests/test_cmd_list_json.py -q\` → **105 passed**

## Constraints respected (per spec)

- ✅ \`synapse list\` does NOT auto-kill — only annotates. Killing happens via explicit \`synapse cleanup\`.
- ✅ Idle-timeout opt-in via env var (default off).
- ✅ Existing \`synapse kill\` semantics unchanged.

## Approach note

Implementation was completed across 10 commits in the branch, then push + PR by the manager Claude on behalf of an in-process subagent that completed the work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)