### PR TITLE
feat(worktree): persist saved agent profiles across cleanup + release 0.27.0 (#410)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.0] - 2026-04-19
+
 ### Added
 
 - **`synapse cleanup` for orphaned spawned agents (#332):** New top-level command that kills children whose `spawned_by` parent is gone or whose parent PID is dead. `synapse spawn` now propagates the calling agent's `SYNAPSE_AGENT_ID` to the child as `SYNAPSE_SPAWNED_BY` so the registry records the parent-child link automatically. `synapse cleanup --dry-run` lists orphans without killing; bare `synapse cleanup` kills all orphans (with confirmation, `-f` to skip); `synapse cleanup <agent>` targets one orphan and refuses non-orphans so existing `synapse kill` semantics remain intact. `synapse list` annotates orphans inline (`STATUS [ORPHAN]`) and exposes `is_orphan` / `spawned_by` in `--json` output. The opt-in env var `SYNAPSE_ORPHAN_IDLE_TIMEOUT=<seconds>` enables opportunistic reaping of orphans that have been READY longer than the timeout.
+- **Worktree-aware agent-profile save defaults (#410):** When the interactive save-prompt fires inside a worktree session, the default scope flips from `project` to `user` and the prompt explains why ("project scope in a worktree is deleted on cleanup"). On worktree cleanup, any saved `*.agent` files under `<worktree>/.synapse/agents/` are also copied back to the main repo's `.synapse/agents/` as a safety net — main-repo files win on collision and identical files are skipped silently. Detection is now pure-Python (`worktree.is_path_in_worktree`) instead of shelling out to `git rev-parse`, so the per-prompt cost on the common non-worktree path is negligible.
+
+### Fixed
+
+- **Idle-detection prompt heuristic safety net (#572, #594):** The `idle_detector` generic-prompt heuristic now has an explicit safety net so accidental loop-confidence promotions cannot misclassify a still-PROCESSING agent as WAITING. Also tightens the WAITING-confidence threshold so transient single-prompt frames no longer flip status alone.
+- **Nested-worktree path resolution (#546, #598):** `synapse spawn --worktree` invoked from inside an existing worktree now anchors the new worktree at the *main* repo root (`git rev-parse --git-common-dir` parent) instead of the calling worktree's toplevel. Prevents nested `<wt-A>/.synapse/worktrees/<wt-B>/` paths from accumulating across recursive spawns.
+
+### Documentation
+
+- **Subagent-vs-spawn guidance (#595):** The `synapse-a2a` skill now recommends Claude Code's Agent tool / Codex subprocess for same-model delegation rather than always spawning a fresh `synapse` agent. Captures the lower startup cost and shared context advantage when both calls would land on the same model.
+- **No-cd-into-worktree warning (#547, #599):** The `synapse-a2a` skill's new "Worktree Discipline" section tells subagents never to `cd` into `.synapse/worktrees/` (the parent's persistent shell inherits the cwd change), and points them at absolute paths and `git -C /abs/path …` instead. Mirrored byte-for-byte into `.agents/skills/` and `.claude/skills/`.
+
+### Tests
+
+- **Post-impl workflow e2e (#531, #600):** New opt-in pytest test (`@pytest.mark.e2e`) exercises the full `run_workflow` + `_WorkflowHelper` lifecycle for the real `post-impl.yaml` without spawning live Claude/Codex agents. A `FakeHelperController` mocks the helper contract while production code paths run unmodified — asserts the #531 acceptance criteria (5 steps reach `completed`, helper spawned/killed exactly once, no 409 `Agent busy`, `synapse workflow status` reports per-step progression). Default `pytest -q` is unaffected; opt in with `pytest -m e2e` or `SYNAPSE_E2E_POSTIMPL=1`.
 
 ## [0.26.5] - 2026-04-19
 
@@ -3443,7 +3460,8 @@ See v0.3.14 for reply PTY injection, CURRENT column, and history default changes
 - External agent connectivity vision document
 - PyPI publishing instructions
 
-[Unreleased]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.26.5...HEAD
+[Unreleased]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.27.0...HEAD
+[0.27.0]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.26.5...v0.27.0
 [0.26.5]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.26.4...v0.26.5
 [0.26.4]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.26.3...v0.26.4
 [0.26.3]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.26.2...v0.26.3

--- a/README.md
+++ b/README.md
@@ -731,6 +731,7 @@ Save this agent definition for reuse? [y/N]:
 - Triggered only for interactive `synapse <profile>` sessions with a configured name.
 - Not shown in `--headless` mode or non-TTY environments.
 - Not shown for `synapse stop ...` or `synapse kill ...` (those commands only stop running processes).
+- Default scope is `project`, but switches to `user` when the session is running inside a worktree (issue #410). The prompt makes this explicit (`default: user - project scope in a worktree is deleted on cleanup`). When a worktree is cleaned up, any `*.agent` files saved under `<worktree>/.synapse/agents/` are also copied back to the main repo's `.synapse/agents/` as a safety net (main repo files win on collision).
 - Disable with `SYNAPSE_AGENT_SAVE_PROMPT_ENABLED=false`.
 
 ### Command List

--- a/docs/worktree.md
+++ b/docs/worktree.md
@@ -34,6 +34,7 @@ Unlike Claude Code's built-in `--worktree` (which only works for Claude Code and
    - **No changes AND no new commits** → auto-delete worktree and branch
    - **Changes or commits exist (interactive)** → prompt to keep or remove
    - **Changes or commits exist (non-interactive/headless)** → keep worktree, print path and branch
+   - **Saved agent sync (issue #410)**: any time the worktree is about to be removed (auto-delete, post-merge, or interactive `y` confirmation), `*.agent` files under `<worktree>/.synapse/agents/` are copied back to the main repo's `.synapse/agents/` directory via `sync_worktree_agents_to_main`. Main-repo files win on collisions (identical files are skipped silently; differing files are left in place with a `worktree_agent_sync_collision` warning). Pruning truly orphaned worktrees (`synapse worktree prune`) cannot sync agents because the directory is already missing.
 5. **Auto-merge** (default on `synapse kill`):
    - Uncommitted changes are auto-committed as WIP
    - `git merge worktree-<name> --no-edit` is attempted on the parent branch
@@ -305,7 +306,7 @@ Synapse:
 
 ## Module Reference
 
-- `synapse/worktree.py` — Core worktree operations (`create_worktree`, `cleanup_worktree`, `merge_worktree`, `has_worktree_changes`, `has_new_commits`, `has_uncommitted_changes`, `get_default_remote_branch`, `prune_worktrees`, `_parse_prunable_worktrees`)
+- `synapse/worktree.py` — Core worktree operations (`create_worktree`, `cleanup_worktree`, `merge_worktree`, `has_worktree_changes`, `has_new_commits`, `has_uncommitted_changes`, `get_default_remote_branch`, `get_main_repo_root`, `sync_worktree_agents_to_main`, `prune_worktrees`, `_parse_prunable_worktrees`)
 - `synapse/spawn.py` — `spawn_agent(worktree=...)` parameter
 - `synapse/cli.py` — `--worktree` / `-w` flag, `--no-merge` flag on kill, `synapse merge` command, `synapse worktree prune` subcommand (`cmd_worktree_prune`)
 - `synapse/commands/merge.py` — `merge_single`, `merge_all` implementations

--- a/guides/usage.md
+++ b/guides/usage.md
@@ -531,6 +531,8 @@ Save this agent definition for reuse? [y/N]:
 - `synapse <profile>` の対話起動終了時のみ表示されます（名前が設定されている場合）。
 - `--headless` または非TTY環境では表示されません。
 - `synapse stop ...` / `synapse kill ...` で停止した場合は表示されません。
+- スコープのデフォルトは通常 `project` ですが、**worktree 内で起動された場合は `user` に切り替わります**（issue #410）。worktree 内の `project` スコープ（`<worktree>/.synapse/agents/`）はクリーンアップ時に worktree ごと削除されるため、データ損失を避けるためのデフォルト変更です。プロンプトには `(default: user - project scope in a worktree is deleted on cleanup)` と明示されます。
+- worktree のクリーンアップ時には、`<worktree>/.synapse/agents/*.agent` がメインリポジトリの `.synapse/agents/` に自動コピーされます（メインリポジトリ側のファイルが優先、衝突は警告ログ）。プロンプトで `project` を選んだ場合のセーフティネットです。
 - 無効化: `SYNAPSE_AGENT_SAVE_PROMPT_ENABLED=false`
 
 ---
@@ -771,6 +773,13 @@ synapse team start sharp-checker steady-builder  # team start で使用
 
 IDが重複する場合、Project スコープが User スコープより優先されます。
 
+**worktree 内での挙動（issue #410）**:
+
+worktree 内で `project` スコープを選ぶと、保存先は `<worktree>/.synapse/agents/` となり、worktree 削除時に消えます。これを防ぐため、
+
+- 終了時の保存プロンプトは worktree 内では `user` をデフォルトとして提示します（プロンプト末尾に `default: user - project scope in a worktree is deleted on cleanup` と表示）。
+- `synapse kill` 等で worktree がクリーンアップされる直前に、`<worktree>/.synapse/agents/*.agent` を main リポジトリの `.synapse/agents/` にコピーバックします（メインリポジトリ側のファイルが優先）。
+
 #### Worktree の注意事項
 
 **Synapse ネイティブ worktree（推奨）**:
@@ -801,6 +810,7 @@ synapse gemini --worktree review --name Reviewer --role "code reviewer"
 
 - `.gitignore` に記載されたファイル（`.env`、`.venv/`、`node_modules/`）は worktree にコピーされません。必要に応じて `uv sync`、`npm install`、`.env` のコピーを実行してください。
 - 終了時: 未コミットの変更 **およびベースブランチ以降の新規コミット** がない worktree は自動削除されます。変更またはコミットがある場合、対話モードでは保持/削除の確認プロンプトが表示され、非対話モード（headless）では worktree を保持してパスとブランチを出力します。
+- 削除直前に `<worktree>/.synapse/agents/*.agent` はメインリポジトリの `.synapse/agents/` に自動コピーされます（issue #410）。worktree 内で保存した project スコープのエージェント定義が消えないようにするためのセーフティネットです（メインリポジトリ側のファイルが優先、衝突は警告ログのみ）。
 - ブランチの自動マージ: `synapse kill` 実行時、worktree ブランチはデフォルトで親ブランチに自動マージされます（未コミットの変更は WIP コミットされます）。コンフリクト発生時はブランチが保持され警告が表示されます。`--no-merge` で自動マージをスキップできます:
   ```bash
   synapse kill my-claude               # 自動マージ（デフォルト）

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ site_url: https://s-hiraoku.github.io/synapse-a2a/
 site_description: Multi-agent collaboration framework using Google A2A Protocol
 site_author: s-hiraoku
 repo_url: https://github.com/s-hiraoku/synapse-a2a
-repo_name: s-hiraoku/synapse-a2a v0.26.5
+repo_name: s-hiraoku/synapse-a2a v0.27.0
 docs_dir: site-docs
 
 theme:

--- a/plugins/synapse-a2a/.claude-plugin/plugin.json
+++ b/plugins/synapse-a2a/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synapse-a2a",
-  "version": "0.26.5",
+  "version": "0.27.0",
   "description": "Complete plugin for Synapse A2A multi-agent framework including inter-agent communication, file safety, and history management",
   "author": {
     "name": "s-hiraoku",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synapse-a2a"
-version = "0.26.5"
+version = "0.27.0"
 description = "Agent-to-Agent communication protocol for CLI agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/site-docs/changelog.md
+++ b/site-docs/changelog.md
@@ -4,6 +4,15 @@ For the complete changelog, see [CHANGELOG.md on GitHub](https://github.com/s-hi
 
 ## Recent Highlights
 
+### v0.27.0
+
+- **Added**: `synapse cleanup` for orphaned spawned agents — kills children whose `spawned_by` parent is gone or whose parent PID is dead. `synapse spawn` propagates `SYNAPSE_AGENT_ID` to the child as `SYNAPSE_SPAWNED_BY` so the registry records the parent-child link automatically. Supports `--dry-run`, per-agent target, opt-in `SYNAPSE_ORPHAN_IDLE_TIMEOUT` reaping, and `[ORPHAN]` annotations + JSON fields in `synapse list` (#332)
+- **Added**: Worktree-aware agent-profile save defaults — the save-prompt default flips from `project` to `user` when running in a worktree (project scope is deleted on cleanup), and worktree cleanup copies any saved `*.agent` files back to the main repo as a safety net (main wins on collision). Detection is pure-Python — no per-prompt `git` subprocess (#410)
+- **Fixed**: Nested-worktree path resolution — `synapse spawn --worktree` from inside a worktree now anchors the new worktree at the main repo root instead of accumulating nested `<wt-A>/.synapse/worktrees/<wt-B>/` paths (#546, #598)
+- **Fixed**: `idle_detector` generic-prompt heuristic safety net + tighter WAITING-confidence threshold so transient single-prompt frames no longer flip status alone (#572, #594)
+- **Documentation**: `synapse-a2a` skill now recommends Agent-tool / subprocess subagents over `synapse spawn` for same-model delegation (#595), and adds a "Worktree Discipline" section warning subagents never to `cd` into `.synapse/worktrees/` (the parent shell inherits the cwd change) (#547, #599)
+- **Tests**: Opt-in pytest e2e for the `post-impl` workflow exercises `run_workflow` + `_WorkflowHelper` against the real `post-impl.yaml` without spawning live agents — asserts the #531 acceptance criteria (5 steps complete, helper spawned/killed exactly once, no 409 `Agent busy`) (#531, #600)
+
 ### v0.26.5
 
 - **Changed**: Permission-notification dedupe path simplified — `_build_permission_metadata` is now pure and `_on_status_change` reads prior dedupe state directly from `task.metadata`. The per-suppression `task_store.update_metadata` call is also dropped, so the lock is only acquired when an actual notification is emitted. Behaviour unchanged (#588 follow-up)

--- a/site-docs/concepts/a2a-protocol.md
+++ b/site-docs/concepts/a2a-protocol.md
@@ -17,7 +17,7 @@ Every A2A agent publishes a discovery document at `/.well-known/agent.json`:
   "name": "synapse-claude-8100",
   "description": "Claude Code agent managed by Synapse A2A",
   "url": "http://localhost:8100",
-  "version": "0.26.5",
+  "version": "0.27.0",
   "capabilities": {
     "streaming": false,
     "pushNotifications": false

--- a/site-docs/getting-started/installation.md
+++ b/site-docs/getting-started/installation.md
@@ -58,7 +58,7 @@
 synapse --version
 ```
 
-You should see the version number (e.g., `0.26.5`).
+You should see the version number (e.g., `0.27.0`).
 
 ## Initialize Configuration
 
@@ -88,7 +88,7 @@ gh skill install s-hiraoku/synapse-a2a synapse-manager
 gh skill install s-hiraoku/synapse-a2a synapse-reinst
 
 # Optional: pin to a release tag so updates are explicit
-gh skill install s-hiraoku/synapse-a2a synapse-a2a --pin v0.26.5
+gh skill install s-hiraoku/synapse-a2a synapse-a2a --pin v0.27.0
 
 # Optional: target a specific agent runtime
 gh skill install s-hiraoku/synapse-a2a synapse-a2a --agent claude-code

--- a/site-docs/guide/skills-management.md
+++ b/site-docs/guide/skills-management.md
@@ -51,7 +51,7 @@ gh skill install s-hiraoku/synapse-a2a synapse-manager
 gh skill install s-hiraoku/synapse-a2a synapse-reinst
 
 # Pin to a release
-gh skill install s-hiraoku/synapse-a2a synapse-a2a --pin v0.26.3
+gh skill install s-hiraoku/synapse-a2a synapse-a2a --pin v0.26.4
 
 # Install for a specific agent
 gh skill install s-hiraoku/synapse-a2a synapse-a2a --agent claude-code
@@ -117,7 +117,7 @@ git tag v0.26.2 && git push --tags
 `gh skill publish` is idempotent per tree SHA — re-running on an
 unchanged skill is a no-op. Publishing a new commit registers a new
 tree SHA so that `gh skill update` clients see drift and can pull the
-update. Pinned installs (`--pin v0.26.3`) continue to resolve against
+update. Pinned installs (`--pin v0.26.4`) continue to resolve against
 the tagged ref you recorded at install time.
 
 ### CI automation (recommended)

--- a/site-docs/reference/permission-detection-spec.md
+++ b/site-docs/reference/permission-detection-spec.md
@@ -126,7 +126,7 @@ Response: {"status": "denied", "task_id": "task-123"}
     "sender": { "sender_id": "synapse-claude-8101" },
     "response_mode": "silent",
     "in_reply_to": "sender-task-id",
-    "reply_status": "input_required",
+    "_reply_status": "input_required",
     "permission_escalation": {
       "task_id": "task-123",
       "child_endpoint": "http://localhost:8101",
@@ -172,6 +172,28 @@ PERMISSION HANDLING - When Spawned Agents Need Approval:
 
 - `auto-approve` 有効時: controller が直接 PTY に承認を送信。`_on_status_change` は発火するが、WAITING 状態が短時間で解消されるため `input_required` 通知は実質的に送られない（WAITING → PROCESSING が高速に遷移）
 - `auto-approve` 無効時（`--no-auto-approve`）: WAITING が持続し、`_on_status_change` が `input_required` 通知を呼び出し元に送信する。親は Approval Gate で自動応答するか、人手で approve/deny API を叩く。`synapse send --wait` はこの介入を待ってから完了/失敗を返す
+
+## 通知の sanitisation と dedupe (#582 / #586, v0.26.4)
+
+`_build_permission_metadata` は `pty_context` を以下の手順で組み立てる:
+
+1. **sanitisation** — `synapse/_pty_sanitize.py` の `strip_control_bytes` で ANSI / CSI / OSC / C0 / C1 制御バイト（8-bit CSI `\x9b...` / OSC `\x9d...` および末尾の途中切れ含む）を除去。TAB/LF は保持、CR は除去。
+2. **fallback chain** — レンダリング後の virtual terminal → 生 `controller.get_context()` → `current_task_preview` → `_sent_message[:200]` → `[permission context unavailable]` プレースホルダ。各候補も sanitise した上で `_PERMISSION_CONTEXT_MIN_PRINTABLE` 閾値で「実質的に空」を判定する。
+3. **dedupe** — `_on_status_change` の WAITING 分岐は `(task_id + pty_context)` を sha256 16桁 でハッシュし、`task.metadata.permission` に `hash + send timestamp + count` を保持する。`_PERMISSION_NOTIFICATION_MIN_INTERVAL_SECONDS` (5 秒) 以内の再送信は抑止し、ハッシュが変化していてもこの最小間隔は維持される。ウィンドウ満了後に同じハッシュが再観測されれば 1 度だけ再送信する。
+
+これにより、controller が WAITING/READY を高頻度に振動した場合でも親は同一通知の連投を受けず、PTY が壊れたバッファを長文ファイルとしてディスクに書き出すこともない。
+
+## 検出される approval overlay (Codex, #529, v0.26.4)
+
+`synapse/profiles/codex.yaml` の `waiting_detection.regex` は以下の Codex CLI 系 overlay 系統をカバーする:
+
+- 旧来の inline approval プロンプト
+- permissions overlay
+- host allow/block overlay
+- patch-files overlay
+- `No, continue without running it` exec オプション
+
+これらが `openai/codex` の `approval_overlay.rs` でラベル変更された場合、READY のまま PTY だけがブロックされる症状が発生していた。検出ラベルは `tests/test_codex_profile.py` で固定し、Codex CLI のリリースに追随する。
 
 ## 変更ファイル
 

--- a/synapse/cli.py
+++ b/synapse/cli.py
@@ -907,9 +907,12 @@ def _maybe_prompt_save_agent_profile(
 
     # Skip if an identical profile already exists in the store.
     resolved_store = store or AgentProfileStore()
-    from synapse.worktree import is_path_in_worktree
+    try:
+        from synapse.worktree import is_path_in_worktree
 
-    is_worktree = is_path_in_worktree(resolved_store.project_root)
+        is_worktree = is_path_in_worktree(resolved_store.project_root)
+    except (OSError, AttributeError):
+        is_worktree = False
     default_scope: Literal["project", "user"] = "user" if is_worktree else "project"
 
     for existing in resolved_store.list_all():

--- a/synapse/cli.py
+++ b/synapse/cli.py
@@ -907,6 +907,11 @@ def _maybe_prompt_save_agent_profile(
 
     # Skip if an identical profile already exists in the store.
     resolved_store = store or AgentProfileStore()
+    from synapse.worktree import is_path_in_worktree
+
+    is_worktree = is_path_in_worktree(resolved_store.project_root)
+    default_scope: Literal["project", "user"] = "user" if is_worktree else "project"
+
     for existing in resolved_store.list_all():
         if (
             existing.profile == profile
@@ -939,9 +944,16 @@ def _maybe_prompt_save_agent_profile(
             continue
         break
 
-    raw_scope = input_func("Scope [project/user] (default: project): ").strip().lower()
+    if is_worktree:
+        scope_prompt = (
+            "Scope [project/user] "
+            "(default: user - project scope in a worktree is deleted on cleanup): "
+        )
+    else:
+        scope_prompt = "Scope [project/user] (default: project): "
+    raw_scope = input_func(scope_prompt).strip().lower()
     if not raw_scope:
-        scope: Literal["project", "user"] = "project"
+        scope = default_scope
     elif raw_scope in {"project", "user"}:
         scope = cast(Literal["project", "user"], raw_scope)
     else:

--- a/synapse/worktree.py
+++ b/synapse/worktree.py
@@ -10,9 +10,11 @@ branch named ``worktree-<name>``.
 
 from __future__ import annotations
 
+import filecmp
 import logging
 import random
 import re
+import shutil
 import subprocess
 import time
 from dataclasses import dataclass
@@ -186,6 +188,60 @@ def get_main_repo_root() -> Path:
         # for the main checkout. Anchor it before stripping the suffix.
         common_dir = (Path.cwd() / common_dir).resolve()
     return common_dir.parent
+
+
+def is_path_in_worktree(path: Path) -> bool:
+    """Return True if ``path`` is inside a git worktree (not the main checkout).
+
+    Uses the canonical git convention: a worktree's ``.git`` is a text
+    file (``gitdir: ...``); the main repo's ``.git`` is a directory.
+    Pure-Python — no subprocess.
+    """
+    git_marker = path / ".git"
+    return git_marker.is_file()
+
+
+def sync_worktree_agents_to_main(worktree_path: Path, main_root: Path) -> list[Path]:
+    """Copy saved worktree agent definitions back to the main repo.
+
+    Main-repo files win on collisions. Identical collisions are ignored;
+    differing collisions are logged so users can reconcile manually.
+    """
+    agents_dir = worktree_path / ".synapse" / "agents"
+    if not agents_dir.is_dir():
+        return []
+
+    sources = sorted(agents_dir.glob("*.agent"))
+    if not sources:
+        return []
+
+    target_dir = main_root / ".synapse" / "agents"
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    copied: list[Path] = []
+    for source in sources:
+        destination = target_dir / source.name
+        try:
+            if destination.exists():
+                if filecmp.cmp(source, destination, shallow=False):
+                    continue
+                logger.warning(
+                    "event=worktree_agent_sync_collision source=%s destination=%s",
+                    source,
+                    destination,
+                )
+                continue
+            shutil.copy2(source, destination)
+        except OSError:
+            logger.warning(
+                "event=worktree_agent_sync_failed source=%s destination=%s",
+                source,
+                destination,
+                exc_info=True,
+            )
+            continue
+        copied.append(destination)
+    return copied
 
 
 def _ref_exists(ref: str) -> bool:
@@ -573,14 +629,24 @@ def cleanup_worktree(
     Returns:
         True if worktree was removed, False if kept.
     """
+    try:
+        main_root: Path | None = get_main_repo_root()
+    except (RuntimeError, FileNotFoundError):
+        logger.debug("Skipping worktree agent sync: main repo root unavailable")
+        main_root = None
+
     uncommitted = has_uncommitted_changes(info.path)
     commits = has_new_commits(info.path, info.base_branch)
 
     if not uncommitted and not commits:
+        if main_root is not None:
+            sync_worktree_agents_to_main(info.path, main_root)
         return remove_worktree(info.path, info.branch, force=False)
 
     if merge:
         if merge_worktree(info, _has_uncommitted=uncommitted, _has_commits=commits):
+            if main_root is not None:
+                sync_worktree_agents_to_main(info.path, main_root)
             return remove_worktree(info.path, info.branch, force=False)
         return False
 
@@ -611,6 +677,8 @@ def cleanup_worktree(
             .lower()
         )
         if answer == "y":
+            if main_root is not None:
+                sync_worktree_agents_to_main(info.path, main_root)
             return remove_worktree(info.path, info.branch, force=True)
     except (EOFError, KeyboardInterrupt):
         pass
@@ -678,7 +746,8 @@ def prune_worktrees() -> list[str]:
     if not prunable:
         return []
 
-    # Remove stale git worktree references
+    # Prunable worktrees are already gone from disk, so saved-agent sync
+    # is impossible here.
     prune_result = subprocess.run(
         ["git", "worktree", "prune"],
         capture_output=True,

--- a/tests/test_agent_profile_scope.py
+++ b/tests/test_agent_profile_scope.py
@@ -73,3 +73,89 @@ def test_maybe_prompt_save_without_store_uses_cwd(
     )
 
     assert (tmp_path / ".synapse" / "agents" / "wise-strategist.agent").exists()
+
+
+def test_prompt_default_scope_is_user_in_worktree(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Accepting the scope default in a worktree saves to user scope."""
+    from synapse.agent_profiles import AgentProfileStore
+
+    main_root = tmp_path / "repo"
+    worktree_root = main_root / ".synapse" / "worktrees" / "test-wt"
+    home = tmp_path / "home"
+    worktree_root.mkdir(parents=True)
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setattr("synapse.worktree.is_path_in_worktree", lambda _path: True)
+
+    store = AgentProfileStore(project_root=worktree_root, home_dir=home)
+
+    from synapse.cli import _maybe_prompt_save_agent_profile
+
+    prompts: list[str] = []
+    responses = iter(["y", "wise-strategist", ""])
+
+    def input_func(prompt: str) -> str:
+        prompts.append(prompt)
+        return next(responses)
+
+    _maybe_prompt_save_agent_profile(
+        profile="claude",
+        name="Frank",
+        role="task manager",
+        skill_set="manager",
+        headless=False,
+        is_tty=True,
+        input_func=input_func,
+        print_func=lambda _msg: None,
+        store=store,
+    )
+
+    assert "default: user" in prompts[-1]
+    assert "worktree is deleted on cleanup" in prompts[-1]
+    assert (home / ".synapse" / "agents" / "wise-strategist.agent").exists()
+    assert not (
+        worktree_root / ".synapse" / "agents" / "wise-strategist.agent"
+    ).exists()
+
+
+def test_prompt_default_scope_is_project_outside_worktree(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Outside a worktree, accepting the scope default still saves to project scope."""
+    from synapse.agent_profiles import AgentProfileStore
+
+    project_root = tmp_path / "repo"
+    home = tmp_path / "home"
+    project_root.mkdir()
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setattr("synapse.worktree.is_path_in_worktree", lambda _path: False)
+
+    store = AgentProfileStore(project_root=project_root, home_dir=home)
+
+    from synapse.cli import _maybe_prompt_save_agent_profile
+
+    prompts: list[str] = []
+    responses = iter(["y", "wise-strategist", ""])
+
+    def input_func(prompt: str) -> str:
+        prompts.append(prompt)
+        return next(responses)
+
+    _maybe_prompt_save_agent_profile(
+        profile="claude",
+        name="Frank",
+        role="task manager",
+        skill_set="manager",
+        headless=False,
+        is_tty=True,
+        input_func=input_func,
+        print_func=lambda _msg: None,
+        store=store,
+    )
+
+    assert "default: project" in prompts[-1]
+    assert (project_root / ".synapse" / "agents" / "wise-strategist.agent").exists()
+    assert not (home / ".synapse" / "agents" / "wise-strategist.agent").exists()

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -645,6 +645,116 @@ class TestCleanupWorktree:
         assert result is True
         mock_remove.assert_called_once_with(info.path, info.branch, force=False)
 
+    @patch("synapse.worktree.remove_worktree", return_value=True)
+    @patch("synapse.worktree.has_new_commits", return_value=False)
+    @patch("synapse.worktree.has_uncommitted_changes", return_value=False)
+    def test_cleanup_worktree_syncs_agents_to_main_repo(
+        self,
+        mock_uncommitted: MagicMock,
+        mock_commits: MagicMock,
+        mock_remove: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        main_root = tmp_path / "repo"
+        worktree_path = main_root / ".synapse" / "worktrees" / "test-wt"
+        agents_dir = worktree_path / ".synapse" / "agents"
+        agents_dir.mkdir(parents=True)
+        agent_content = "id=wise-strategist\nname=Frank\nprofile=claude\n"
+        (agents_dir / "wise-strategist.agent").write_text(
+            agent_content, encoding="utf-8"
+        )
+        monkeypatch.setattr("synapse.worktree.get_main_repo_root", lambda: main_root)
+
+        info = WorktreeInfo(
+            name="test-wt",
+            path=worktree_path,
+            branch="worktree-test-wt",
+            base_branch="origin/main",
+            created_at=1000.0,
+        )
+
+        result = cleanup_worktree(info, interactive=False)
+
+        assert result is True
+        assert (main_root / ".synapse" / "agents" / "wise-strategist.agent").read_text(
+            encoding="utf-8"
+        ) == agent_content
+        mock_remove.assert_called_once_with(info.path, info.branch, force=False)
+
+    @patch("synapse.worktree.remove_worktree", return_value=True)
+    @patch("synapse.worktree.has_new_commits", return_value=False)
+    @patch("synapse.worktree.has_uncommitted_changes", return_value=False)
+    def test_cleanup_worktree_sync_skips_on_main_collision(
+        self,
+        mock_uncommitted: MagicMock,
+        mock_commits: MagicMock,
+        mock_remove: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        main_root = tmp_path / "repo"
+        worktree_path = main_root / ".synapse" / "worktrees" / "test-wt"
+        worktree_agents = worktree_path / ".synapse" / "agents"
+        main_agents = main_root / ".synapse" / "agents"
+        worktree_agents.mkdir(parents=True)
+        main_agents.mkdir(parents=True)
+        main_content = "id=wise-strategist\nname=Main Frank\nprofile=claude\n"
+        worktree_content = "id=wise-strategist\nname=Worktree Frank\nprofile=claude\n"
+        (main_agents / "wise-strategist.agent").write_text(
+            main_content, encoding="utf-8"
+        )
+        (worktree_agents / "wise-strategist.agent").write_text(
+            worktree_content, encoding="utf-8"
+        )
+        monkeypatch.setattr("synapse.worktree.get_main_repo_root", lambda: main_root)
+        info = WorktreeInfo(
+            name="test-wt",
+            path=worktree_path,
+            branch="worktree-test-wt",
+            base_branch="origin/main",
+            created_at=1000.0,
+        )
+
+        result = cleanup_worktree(info, interactive=False)
+
+        assert result is True
+        assert (main_agents / "wise-strategist.agent").read_text(
+            encoding="utf-8"
+        ) == main_content
+        assert "wise-strategist.agent" in caplog.text
+        mock_remove.assert_called_once_with(info.path, info.branch, force=False)
+
+    @patch("synapse.worktree.remove_worktree", return_value=True)
+    @patch("synapse.worktree.has_new_commits", return_value=False)
+    @patch("synapse.worktree.has_uncommitted_changes", return_value=False)
+    def test_cleanup_worktree_sync_handles_empty_agents_dir(
+        self,
+        mock_uncommitted: MagicMock,
+        mock_commits: MagicMock,
+        mock_remove: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        main_root = tmp_path / "repo"
+        worktree_path = main_root / ".synapse" / "worktrees" / "test-wt"
+        (worktree_path / ".synapse" / "agents").mkdir(parents=True)
+        monkeypatch.setattr("synapse.worktree.get_main_repo_root", lambda: main_root)
+        info = WorktreeInfo(
+            name="test-wt",
+            path=worktree_path,
+            branch="worktree-test-wt",
+            base_branch="origin/main",
+            created_at=1000.0,
+        )
+
+        result = cleanup_worktree(info, interactive=False)
+
+        assert result is True
+        assert not (main_root / ".synapse" / "agents").exists()
+        mock_remove.assert_called_once_with(info.path, info.branch, force=False)
+
     @patch("synapse.worktree.remove_worktree")
     @patch("synapse.worktree.has_new_commits", return_value=True)
     @patch("synapse.worktree.has_uncommitted_changes", return_value=False)
@@ -711,6 +821,47 @@ class TestCleanupWorktree:
         )
         mock_remove.assert_called_once_with(info.path, info.branch, force=False)
 
+    @patch("synapse.worktree.remove_worktree", return_value=True)
+    @patch("synapse.worktree.merge_worktree", return_value=True)
+    @patch("synapse.worktree.has_new_commits", return_value=True)
+    @patch("synapse.worktree.has_uncommitted_changes", return_value=False)
+    def test_cleanup_worktree_with_merge_also_syncs(
+        self,
+        mock_uncommitted: MagicMock,
+        mock_commits: MagicMock,
+        mock_merge: MagicMock,
+        mock_remove: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        main_root = tmp_path / "repo"
+        worktree_path = main_root / ".synapse" / "worktrees" / "test-wt"
+        agents_dir = worktree_path / ".synapse" / "agents"
+        agents_dir.mkdir(parents=True)
+        agent_content = "id=wise-strategist\nname=Frank\nprofile=claude\n"
+        (agents_dir / "wise-strategist.agent").write_text(
+            agent_content, encoding="utf-8"
+        )
+        monkeypatch.setattr("synapse.worktree.get_main_repo_root", lambda: main_root)
+        info = WorktreeInfo(
+            name="test-wt",
+            path=worktree_path,
+            branch="worktree-test-wt",
+            base_branch="origin/main",
+            created_at=1000.0,
+        )
+
+        result = cleanup_worktree(info, merge=True)
+
+        assert result is True
+        assert (main_root / ".synapse" / "agents" / "wise-strategist.agent").read_text(
+            encoding="utf-8"
+        ) == agent_content
+        mock_merge.assert_called_once_with(
+            info, _has_uncommitted=False, _has_commits=True
+        )
+        mock_remove.assert_called_once_with(info.path, info.branch, force=False)
+
     @patch("synapse.worktree.remove_worktree")
     @patch("synapse.worktree.merge_worktree")
     @patch("synapse.worktree.has_new_commits", return_value=True)
@@ -746,6 +897,78 @@ class TestCleanupWorktree:
         result = cleanup_worktree(info, merge=False)
         assert result is False
         mock_merge.assert_not_called()
+
+    @patch("synapse.worktree.remove_worktree", return_value=True)
+    @patch("synapse.worktree.has_new_commits", return_value=True)
+    @patch("synapse.worktree.has_uncommitted_changes", return_value=False)
+    @patch("builtins.input", return_value="y")
+    def test_cleanup_worktree_interactive_force_also_syncs(
+        self,
+        mock_input: MagicMock,
+        mock_uncommitted: MagicMock,
+        mock_commits: MagicMock,
+        mock_remove: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        main_root = tmp_path / "repo"
+        worktree_path = main_root / ".synapse" / "worktrees" / "test-wt"
+        agents_dir = worktree_path / ".synapse" / "agents"
+        agents_dir.mkdir(parents=True)
+        agent_content = "id=wise-strategist\nname=Frank\nprofile=claude\n"
+        (agents_dir / "wise-strategist.agent").write_text(
+            agent_content, encoding="utf-8"
+        )
+        monkeypatch.setattr("synapse.worktree.get_main_repo_root", lambda: main_root)
+        info = WorktreeInfo(
+            name="test-wt",
+            path=worktree_path,
+            branch="worktree-test-wt",
+            base_branch="origin/main",
+            created_at=1000.0,
+        )
+
+        result = cleanup_worktree(info, interactive=True)
+
+        assert result is True
+        assert (main_root / ".synapse" / "agents" / "wise-strategist.agent").read_text(
+            encoding="utf-8"
+        ) == agent_content
+        mock_remove.assert_called_once_with(info.path, info.branch, force=True)
+
+    @patch("synapse.worktree.remove_worktree", return_value=True)
+    @patch("synapse.worktree.has_new_commits", return_value=False)
+    @patch("synapse.worktree.has_uncommitted_changes", return_value=False)
+    def test_sync_when_main_root_unresolvable_skips_cleanly(
+        self,
+        mock_uncommitted: MagicMock,
+        mock_commits: MagicMock,
+        mock_remove: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        main_root = tmp_path / "repo"
+        worktree_path = main_root / ".synapse" / "worktrees" / "test-wt"
+        (worktree_path / ".synapse" / "agents").mkdir(parents=True)
+        monkeypatch.setattr(
+            "synapse.worktree.get_main_repo_root",
+            MagicMock(side_effect=RuntimeError("Not a git repository")),
+        )
+        info = WorktreeInfo(
+            name="test-wt",
+            path=worktree_path,
+            branch="worktree-test-wt",
+            base_branch="origin/main",
+            created_at=1000.0,
+        )
+
+        result = cleanup_worktree(info, interactive=False)
+
+        assert result is True
+        assert not (
+            main_root / ".synapse" / "agents" / "wise-strategist.agent"
+        ).exists()
+        mock_remove.assert_called_once_with(info.path, info.branch, force=False)
 
 
 # ============================================================

--- a/uv.lock
+++ b/uv.lock
@@ -1439,7 +1439,7 @@ wheels = [
 
 [[package]]
 name = "synapse-a2a"
-version = "0.26.5"
+version = "0.27.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

- **`feat(worktree)` (#410):** When the interactive `synapse <profile>` save-prompt fires inside a worktree session, the default scope flips from `project` to `user` and the prompt explains why ("project scope in a worktree is deleted on cleanup"). On worktree cleanup, any saved `*.agent` files under `<worktree>/.synapse/agents/` are also copied back to the main repo's `.synapse/agents/` as a safety net — main wins on collision, identical files are skipped via `filecmp.cmp`. Worktree detection is pure-Python (`is_path_in_worktree` reads `.git` as file vs directory) — no per-prompt `git rev-parse` subprocess on the common path.
- **`docs(site)`:** Independent site-docs drift fix caught by the parallel github-pages-sync workflow — `permission-detection-spec.md` brought back in line with the canonical `docs/` copy (#582 / #586 / #529 sections), and `skills-management.md` `--pin` examples bumped to `v0.26.4`.
- **`chore(release): 0.27.0`:** Auto-detected as a minor bump from Conventional Commits since v0.26.5 (1 feat / 2 fix / 2 docs / 1 test, no breaking changes). All 7 version surfaces updated in lockstep: `pyproject.toml`, `plugin.json`, `mkdocs.yml`, `site-docs/getting-started/installation.md`, `site-docs/concepts/a2a-protocol.md`, `CHANGELOG.md` (incl. footer reference link), `site-docs/changelog.md`, and `uv.lock`.

## Implementation notes

- **Refactor done in the same `feat` commit** (driven by `/simplify` review): extracted `is_path_in_worktree(path) -> bool` so `cli.py` no longer imports `get_main_repo_root` just to compare paths; narrowed `OSError` to `(RuntimeError, FileNotFoundError)` in `cleanup_worktree` so real bugs propagate; replaced `read_bytes() == read_bytes()` with `filecmp.cmp(..., shallow=False)` to short-circuit on size mismatch; dropped the `sync_agents` inner closure in favour of three explicit `if main_root is not None:` guards; hoisted `target_dir.mkdir` out of the per-file copy loop while still suppressing it on empty source dirs.
- The `filecmp.cmp` switch and the closure removal each had a behavior-preserving subtlety — the empty-`agents/` dir test (`test_cleanup_worktree_sync_handles_empty_agents_dir`) caught an early version that always created `target_dir`; the final code peeks the sorted glob list and early-returns before mkdir.
- Tests under `tests/test_agent_profile_scope.py` previously monkey-patched `synapse.worktree.get_main_repo_root` for the worktree-vs-main detection; updated to monkey-patch the new `is_path_in_worktree` helper instead.

## Test plan

- [x] `uv run pytest tests/test_agent_profile_scope.py tests/test_worktree.py tests/test_extract_changelog.py` → **89 / 89 passing**.
- [x] `pre-commit` hooks (ruff, ruff format, mypy) pass on all 3 commits.
- [x] `mkdocs build --strict` confirmed passing earlier in the parallel sync workflow (no broken nav, all 43 entries resolve).
- [x] Verified by stash-and-rerun that the unrelated full-suite failures (`test_settings`, `test_file_safety`, `test_server_extended`, `test_learning_mode`) reproduce against pre-edit `HEAD` — pre-existing, not introduced by this PR.

## Commits

```
5976adb  chore(release): 0.27.0
4a6b5d8  docs(site): sync permission-detection spec and skills-management pin
fe439ae  feat(worktree): persist saved agent profiles across worktree cleanup (#410)
```

Closes #410

🤖 Generated with [Claude Code](https://claude.com/claude-code)