### PR TITLE
test: fix test_lifespan assertion for spawned_by kwarg (unblock CI)

### DIFF
--- a/tests/test_server_extended.py
+++ b/tests/test_server_extended.py
@@ -73,7 +73,7 @@ class TestServerExtended:
                 # Check Registry usage
                 mock_registry_inst.get_agent_id.assert_called()
                 mock_registry_inst.register.assert_called_with(
-                    "agent-123", "claude", 9000, status="PROCESSING"
+                    "agent-123", "claude", 9000, status="PROCESSING", spawned_by=None
                 )
 
                 # Check Controller usage


### PR DESCRIPTION
## Summary

- `tests/test_server_extended.py::TestServerExtended::test_lifespan` fails on **every open PR against `main`** ([#602](https://github.com/s-hiraoku/synapse-a2a/pull/602), [#613](https://github.com/s-hiraoku/synapse-a2a/pull/613), [#615](https://github.com/s-hiraoku/synapse-a2a/pull/615), and any docs PR once it starts running). The failures are unrelated to those PRs' contents — they just inherit the broken test from `main`.
- Root cause: [#601](https://github.com/s-hiraoku/synapse-a2a/pull/601) (commit `daaa099`) added a `spawned_by` kwarg to `AgentRegistry.register()` and to the server.py call site ([synapse/server.py:194](synapse/server.py#L194)), but this one test kept its old `assert_called_with(...)` signature. The two sibling tests (`test_lifespan_legacy_profile`, `test_lifespan_missing_command_exits`) already pass because they don't pin the exact kwargs.
- Fix: add `spawned_by=None` to the expected call. One-line test-only change, no production code touched.

```
Expected: register('agent-123', 'claude', 9000, status='PROCESSING')
Actual:   register('agent-123', 'claude', 9000, status='PROCESSING', spawned_by=None)
```

Refs #601

## Test plan

- [x] `uv run pytest tests/test_server_extended.py::TestServerExtended::test_lifespan -v` — passes locally
- [ ] CI `Test` workflow (Python 3.10–3.14) turns green on this PR
- [ ] After merge, re-run CI on [#602](https://github.com/s-hiraoku/synapse-a2a/pull/602), [#613](https://github.com/s-hiraoku/synapse-a2a/pull/613), [#615](https://github.com/s-hiraoku/synapse-a2a/pull/615) to confirm they unblock

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

このプルリクエストは、テストスイートの更新で構成されています。

* **Tests**
  * テスト予想値の更新により、検証ロジックの精度が向上しました。

**ユーザー向けの変更はありません。**

<!-- end of auto-generated comment: release notes by coderabbit.ai -->