### PR TITLE
test: update test_lifespan expectation for spawned_by kwarg (#618)

### DIFF
--- a/tests/test_server_extended.py
+++ b/tests/test_server_extended.py
@@ -73,7 +73,7 @@ class TestServerExtended:
                 # Check Registry usage
                 mock_registry_inst.get_agent_id.assert_called()
                 mock_registry_inst.register.assert_called_with(
-                    "agent-123", "claude", 9000, status="PROCESSING"
+                    "agent-123", "claude", 9000, status="PROCESSING", spawned_by=None
                 )
 
                 # Check Controller usage


### PR DESCRIPTION
## Summary
- Closes #618.
- `Registry.register()` gained a `spawned_by` keyword in #601 (parent-child tracking). `synapse/server.py:189` calls it with `spawned_by=os.environ.get("SYNAPSE_SPAWNED_BY") or None`, so lifespan-time registration now passes `spawned_by=None` when the env var is absent.
- The existing `test_lifespan` assertion still used the pre-#601 shape, causing red CI on main and every downstream PR (#613, #615, #616, #617). One-line fix: add `spawned_by=None` to `assert_called_with`.

## Test plan
- [x] `uv run pytest tests/test_server_extended.py::TestServerExtended::test_lifespan -v` passes locally
- [ ] Merge and verify main CI goes green
- [ ] Rebase/merge main into #613, #615, #616, #617 and confirm their CI recovers

🤖 Generated with [Claude Code](https://claude.com/claude-code)