### PR TITLE
chore(release): 0.27.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3501,7 +3501,8 @@ See v0.3.14 for reply PTY injection, CURRENT column, and history default changes
 - External agent connectivity vision document
 - PyPI publishing instructions
 
-[Unreleased]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.27.0...HEAD
+[Unreleased]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.27.1...HEAD
+[0.27.1]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.27.0...v0.27.1
 [0.27.0]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.26.5...v0.27.0
 [0.26.5]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.26.4...v0.26.5
 [0.26.4]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.26.3...v0.26.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.27.1] - 2026-04-19
+
+### Documentation
+
+- **Golden Path Quick Start in README (#604, #615):** new top-of-README four-command flow that spins up Claude + Codex agents and verifies cross-agent messaging via a `SYNAPSE_GOLDEN_PATH_OK` sentinel. Renames the former install-focused `## Quick Start` to `## Installation` so the new section owns the name that matches reader intent. Adds `examples/golden-path.md` as a copy-paste-ready recipe.
+- **A2A concept overview page (#605, #616):** new `docs/a2a-overview.md` — a one-page explainer (What is A2A? / 3-step mental model / Mermaid diagram / minimum use case / where to go next) so newcomers can grasp the project in under five minutes without wading through the deeper rationale docs.
+- **Terminology glossary (#612, #617):** new `docs/terminology.md` — a shared vocabulary reference covering the 16 core terms (Agent, Task, Message, Skill, Policy, Profile, Agent Card, Registry, Worktree, Workflow, Transport, File Safety, LLM Wiki, Shared Memory, Canvas, Readiness Gate) plus 9 supporting terms. Each entry is anchored to the code path / doc / CLI help where it actually lives, and the "Known Inconsistencies" section calls out the `Skill` dual-use and the `Shared Memory` (CLI-active but README-deprecated) trap.
+
+### Tests
+
+- **`test_lifespan` expectation realigned with `spawned_by` kwarg (#618, #620):** `Registry.register()` gained a `spawned_by` keyword in #601 so `server.py:189` now passes `spawned_by=os.environ.get("SYNAPSE_SPAWNED_BY") or None` at startup. The existing `test_lifespan` used `assert_called_with` (exact-match) and was not updated, which left `main` CI red and cascaded red CI onto every downstream PR. Adding `spawned_by=None` to the expectation restores the invariant and unblocks the whole PR queue.
+
 ## [0.27.0] - 2026-04-19
 
 ### Added

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ site_url: https://s-hiraoku.github.io/synapse-a2a/
 site_description: Multi-agent collaboration framework using Google A2A Protocol
 site_author: s-hiraoku
 repo_url: https://github.com/s-hiraoku/synapse-a2a
-repo_name: s-hiraoku/synapse-a2a v0.27.0
+repo_name: s-hiraoku/synapse-a2a v0.27.1
 docs_dir: site-docs
 
 theme:

--- a/plugins/synapse-a2a/.claude-plugin/plugin.json
+++ b/plugins/synapse-a2a/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synapse-a2a",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "description": "Complete plugin for Synapse A2A multi-agent framework including inter-agent communication, file safety, and history management",
   "author": {
     "name": "s-hiraoku",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synapse-a2a"
-version = "0.27.0"
+version = "0.27.1"
 description = "Agent-to-Agent communication protocol for CLI agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/site-docs/changelog.md
+++ b/site-docs/changelog.md
@@ -4,6 +4,13 @@ For the complete changelog, see [CHANGELOG.md on GitHub](https://github.com/s-hi
 
 ## Recent Highlights
 
+### v0.27.1
+
+- **Documentation**: Golden Path "Quick Start" section at the top of README — four-command flow (`synapse start claude` / `start codex` / `list --plain` / `send ... --wait`) that verifies cross-agent messaging via a `SYNAPSE_GOLDEN_PATH_OK` sentinel; the former install-focused Quick Start is renamed to `Installation`. Adds `examples/golden-path.md` (#604, #615)
+- **Documentation**: `docs/a2a-overview.md` — a one-page A2A concept explainer (What is A2A / 3-step mental model / Mermaid diagram / minimum use case / links to deeper docs) so newcomers can grasp the project in under five minutes (#605, #616)
+- **Documentation**: `docs/terminology.md` — shared vocabulary reference for 16 core terms + 9 supporting terms, each anchored to the code path / doc / CLI help where it actually lives, plus a "Known Inconsistencies" section on the `Skill` and `Shared Memory` dual-use traps (#612, #617)
+- **Tests**: `test_lifespan` expectation realigned with the `spawned_by` kwarg added in #601. `Registry.register()` now receives `spawned_by=os.environ.get("SYNAPSE_SPAWNED_BY") or None` at startup; the pre-existing exact-match `assert_called_with` was left behind and had turned `main` CI red. One-line fix unblocks the whole PR queue (#618, #620)
+
 ### v0.27.0
 
 - **Added**: `synapse cleanup` for orphaned spawned agents — kills children whose `spawned_by` parent is gone or whose parent PID is dead. `synapse spawn` propagates `SYNAPSE_AGENT_ID` to the child as `SYNAPSE_SPAWNED_BY` so the registry records the parent-child link automatically. Supports `--dry-run`, per-agent target, opt-in `SYNAPSE_ORPHAN_IDLE_TIMEOUT` reaping, and `[ORPHAN]` annotations + JSON fields in `synapse list` (#332)

--- a/site-docs/concepts/a2a-protocol.md
+++ b/site-docs/concepts/a2a-protocol.md
@@ -17,7 +17,7 @@ Every A2A agent publishes a discovery document at `/.well-known/agent.json`:
   "name": "synapse-claude-8100",
   "description": "Claude Code agent managed by Synapse A2A",
   "url": "http://localhost:8100",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "capabilities": {
     "streaming": false,
     "pushNotifications": false

--- a/site-docs/getting-started/installation.md
+++ b/site-docs/getting-started/installation.md
@@ -58,7 +58,7 @@
 synapse --version
 ```
 
-You should see the version number (e.g., `0.27.0`).
+You should see the version number (e.g., `0.27.1`).
 
 ## Initialize Configuration
 
@@ -88,7 +88,7 @@ gh skill install s-hiraoku/synapse-a2a synapse-manager
 gh skill install s-hiraoku/synapse-a2a synapse-reinst
 
 # Optional: pin to a release tag so updates are explicit
-gh skill install s-hiraoku/synapse-a2a synapse-a2a --pin v0.27.0
+gh skill install s-hiraoku/synapse-a2a synapse-a2a --pin v0.27.1
 
 # Optional: target a specific agent runtime
 gh skill install s-hiraoku/synapse-a2a synapse-a2a --agent claude-code

--- a/uv.lock
+++ b/uv.lock
@@ -1439,7 +1439,7 @@ wheels = [
 
 [[package]]
 name = "synapse-a2a"
-version = "0.27.0"
+version = "0.27.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

Patch release bundling today's doc additions and the CI-unblocking test fix.

### Documentation
- Golden Path Quick Start in README (#604, #615)
- `docs/a2a-overview.md` — one-page A2A concept explainer (#605, #616)
- `docs/terminology.md` — glossary with 16 core + 9 supporting terms (#612, #617)

### Tests
- `test_lifespan` assertion realigned with the `Registry.register()` `spawned_by` kwarg added in #601 — unblocked the whole PR queue (#618, #620)

### Version bump

Synced across: `pyproject.toml`, `plugins/synapse-a2a/.claude-plugin/plugin.json`, `site-docs/getting-started/installation.md`, `site-docs/concepts/a2a-protocol.md`, `site-docs/changelog.md`, `mkdocs.yml`. New `## [0.27.1]` section added to the top of `CHANGELOG.md`.

## Test plan
- [ ] `uv sync && uv run synapse --version` reports `0.27.1`
- [ ] CI passes on this branch
- [ ] `mkdocs build` (or GitHub Pages preview) shows the new version in the header and the new changelog entry at the top

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * README に Golden Path クイックスタートガイドを追加
  * A2A コンセプト概要ドキュメントを新規追加
  * 用語集ページを新規追加（コード・ドキュメント・CLI リファレンス付き）
  * ドキュメント全体でバージョン 0.27.1 に更新

* **Tests**
  * テストの期待値を新しいパラメータ処理に合わせて更新

* **Chores**
  * バージョンを 0.27.1 に更新

<!-- end of auto-generated comment: release notes by coderabbit.ai -->