### PR TITLE
test: clear logging.disable() state in worktree sync collision test

### DIFF
--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -711,6 +711,9 @@ class TestCleanupWorktree:
         )
         monkeypatch.setattr("synapse.worktree.get_main_repo_root", lambda: main_root)
         monkeypatch.setattr(logging.getLogger("synapse"), "propagate", True)
+        # Clear any logging.disable() state left by earlier tests in the suite
+        # so `synapse.worktree`'s WARNING actually reaches caplog's handler.
+        logging.disable(logging.NOTSET)
         caplog.set_level(logging.WARNING, logger="synapse.worktree")
         info = WorktreeInfo(
             name="test-wt",


### PR DESCRIPTION
## Summary

CI was failing reliably on `tests/test_worktree.py::TestCleanupWorktree::test_cleanup_worktree_sync_skips_on_main_collision` on `main` and every downstream open PR (#622 release, #613 if it rebases, etc.):

\`\`\`
AssertionError: assert 'wise-strategist.agent' in ''
    where '' = <_pytest.logging.LogCaptureFixture object at 0x...>.text
\`\`\`

### Root cause

Classic pytest global state pollution between tests:

- Some earlier test in the full suite calls `logging.disable(<level>)` (very common in tests that want to silence noisy library logs during teardown) and never restores it.
- When this test runs later, `caplog.set_level(logging.WARNING, logger="synapse.worktree")` installs a capture handler, but the **`logging.disable` ceiling still suppresses** the WARNING coming out of `synapse.worktree.sync_worktree_agents_to_main`. Result: `caplog.text` is empty, the assertion fails.
- Reproducible only in full-suite runs — the test passes in isolation because nothing has tripped `logging.disable` yet.

### Fix

One line added before `caplog.set_level`:

\`\`\`python
logging.disable(logging.NOTSET)
\`\`\`

This unconditionally restores the global disable level to "no suppression" for this test. It's test-local (we don't have to hunt down which other test is leaking the state) and is the canonical pytest recipe for caplog-vs-logging.disable conflicts.

## Test plan
- [x] `uv run pytest tests/test_worktree.py -v` → 74 passed
- [ ] Full-suite CI passes on this branch
- [ ] Downstream PRs (#622, #613) stop seeing this failure after they pick up main

🤖 Generated with [Claude Code](https://claude.com/claude-code)