### PR TITLE
fix(controller): tokenize multi-token profile command strings via shlex (#614)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.27.1] - 2026-04-20
+
+### Fixed
+
+- Profile command strings with multiple tokens, such as `python3 -u dummy_agent.py`, are now split with `shlex` before launch so profile-defined arguments are executed correctly.
+
 ## [0.27.0] - 2026-04-19
 
 ### Added
@@ -3489,7 +3495,8 @@ See v0.3.14 for reply PTY injection, CURRENT column, and history default changes
 - External agent connectivity vision document
 - PyPI publishing instructions
 
-[Unreleased]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.27.0...HEAD
+[Unreleased]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.27.1...HEAD
+[0.27.1]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.27.0...v0.27.1
 [0.27.0]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.26.5...v0.27.0
 [0.26.5]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.26.4...v0.26.5
 [0.26.4]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.26.3...v0.26.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [0.27.2] - 2026-04-20
 
 ### Fixed

--- a/docs/skills-management.md
+++ b/docs/skills-management.md
@@ -154,10 +154,10 @@ $EDITOR plugins/synapse-a2a/skills/my-new-skill/SKILL.md
 # 4. Commit + tag
 git add plugins/synapse-a2a/skills/my-new-skill
 git commit -m "feat(skills): add my-new-skill"
-git tag v0.27.0 && git push origin main --tags
+git tag v0.27.1 && git push origin main --tags
 
 # 5. Users can now install
-#   gh skill install s-hiraoku/synapse-a2a my-new-skill --pin v0.27.0
+#   gh skill install s-hiraoku/synapse-a2a my-new-skill --pin v0.27.1
 ```
 
 ## Troubleshooting

--- a/docs/skills-management.md
+++ b/docs/skills-management.md
@@ -51,7 +51,7 @@ gh skill install s-hiraoku/synapse-a2a synapse-manager
 gh skill install s-hiraoku/synapse-a2a synapse-reinst
 
 # Pin to a release
-gh skill install s-hiraoku/synapse-a2a synapse-a2a --pin v0.26.4
+gh skill install s-hiraoku/synapse-a2a synapse-a2a --pin v0.27.2
 
 # Install for a specific agent
 gh skill install s-hiraoku/synapse-a2a synapse-a2a --agent claude-code
@@ -111,13 +111,13 @@ gh skill search synapse-a2a
 gh skill preview s-hiraoku/synapse-a2a synapse-a2a
 
 # 4. Tag the release so `--pin` targets are meaningful
-git tag v0.26.2 && git push --tags
+git tag v0.27.2 && git push --tags
 ```
 
 `gh skill publish` is idempotent per tree SHA — re-running on an
 unchanged skill is a no-op. Publishing a new commit registers a new
 tree SHA so that `gh skill update` clients see drift and can pull the
-update. Pinned installs (`--pin v0.26.4`) continue to resolve against
+update. Pinned installs (`--pin v0.27.2`) continue to resolve against
 the tagged ref you recorded at install time.
 
 ### CI automation (recommended)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ site_url: https://s-hiraoku.github.io/synapse-a2a/
 site_description: Multi-agent collaboration framework using Google A2A Protocol
 site_author: s-hiraoku
 repo_url: https://github.com/s-hiraoku/synapse-a2a
-repo_name: s-hiraoku/synapse-a2a v0.27.0
+repo_name: s-hiraoku/synapse-a2a v0.27.1
 docs_dir: site-docs
 
 theme:

--- a/plugins/synapse-a2a/.claude-plugin/plugin.json
+++ b/plugins/synapse-a2a/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synapse-a2a",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "description": "Complete plugin for Synapse A2A multi-agent framework including inter-agent communication, file safety, and history management",
   "author": {
     "name": "s-hiraoku",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synapse-a2a"
-version = "0.27.0"
+version = "0.27.1"
 description = "Agent-to-Agent communication protocol for CLI agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/site-docs/changelog.md
+++ b/site-docs/changelog.md
@@ -4,6 +4,10 @@ For the complete changelog, see [CHANGELOG.md on GitHub](https://github.com/s-hi
 
 ## Recent Highlights
 
+### v0.27.1
+
+- **Fixed**: Profile command strings with multiple tokens, such as `python3 -u dummy_agent.py`, are now split with `shlex` before launch so profile-defined arguments are executed correctly
+
 ### v0.27.0
 
 - **Added**: `synapse cleanup` for orphaned spawned agents — kills children whose `spawned_by` parent is gone or whose parent PID is dead. `synapse spawn` propagates `SYNAPSE_AGENT_ID` to the child as `SYNAPSE_SPAWNED_BY` so the registry records the parent-child link automatically. Supports `--dry-run`, per-agent target, opt-in `SYNAPSE_ORPHAN_IDLE_TIMEOUT` reaping, and `[ORPHAN]` annotations + JSON fields in `synapse list` (#332)

--- a/site-docs/concepts/a2a-protocol.md
+++ b/site-docs/concepts/a2a-protocol.md
@@ -17,7 +17,7 @@ Every A2A agent publishes a discovery document at `/.well-known/agent.json`:
   "name": "synapse-claude-8100",
   "description": "Claude Code agent managed by Synapse A2A",
   "url": "http://localhost:8100",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "capabilities": {
     "streaming": false,
     "pushNotifications": false

--- a/site-docs/getting-started/installation.md
+++ b/site-docs/getting-started/installation.md
@@ -58,7 +58,7 @@
 synapse --version
 ```
 
-You should see the version number (e.g., `0.27.0`).
+You should see the version number (e.g., `0.27.1`).
 
 ## Initialize Configuration
 
@@ -88,7 +88,7 @@ gh skill install s-hiraoku/synapse-a2a synapse-manager
 gh skill install s-hiraoku/synapse-a2a synapse-reinst
 
 # Optional: pin to a release tag so updates are explicit
-gh skill install s-hiraoku/synapse-a2a synapse-a2a --pin v0.27.0
+gh skill install s-hiraoku/synapse-a2a synapse-a2a --pin v0.27.1
 
 # Optional: target a specific agent runtime
 gh skill install s-hiraoku/synapse-a2a synapse-a2a --agent claude-code

--- a/site-docs/guide/skills-management.md
+++ b/site-docs/guide/skills-management.md
@@ -154,10 +154,10 @@ $EDITOR plugins/synapse-a2a/skills/my-new-skill/SKILL.md
 # 4. Commit + tag
 git add plugins/synapse-a2a/skills/my-new-skill
 git commit -m "feat(skills): add my-new-skill"
-git tag v0.27.0 && git push origin main --tags
+git tag v0.27.1 && git push origin main --tags
 
 # 5. Users can now install
-#   gh skill install s-hiraoku/synapse-a2a my-new-skill --pin v0.27.0
+#   gh skill install s-hiraoku/synapse-a2a my-new-skill --pin v0.27.1
 ```
 
 ## Troubleshooting

--- a/site-docs/guide/skills-management.md
+++ b/site-docs/guide/skills-management.md
@@ -51,7 +51,7 @@ gh skill install s-hiraoku/synapse-a2a synapse-manager
 gh skill install s-hiraoku/synapse-a2a synapse-reinst
 
 # Pin to a release
-gh skill install s-hiraoku/synapse-a2a synapse-a2a --pin v0.26.4
+gh skill install s-hiraoku/synapse-a2a synapse-a2a --pin v0.27.2
 
 # Install for a specific agent
 gh skill install s-hiraoku/synapse-a2a synapse-a2a --agent claude-code
@@ -111,13 +111,13 @@ gh skill search synapse-a2a
 gh skill preview s-hiraoku/synapse-a2a synapse-a2a
 
 # 4. Tag the release so `--pin` targets are meaningful
-git tag v0.26.2 && git push --tags
+git tag v0.27.2 && git push --tags
 ```
 
 `gh skill publish` is idempotent per tree SHA — re-running on an
 unchanged skill is a no-op. Publishing a new commit registers a new
 tree SHA so that `gh skill update` clients see drift and can pull the
-update. Pinned installs (`--pin v0.26.4`) continue to resolve against
+update. Pinned installs (`--pin v0.27.2`) continue to resolve against
 the tagged ref you recorded at install time.
 
 ### CI automation (recommended)

--- a/site-docs/reference/profiles-yaml.md
+++ b/site-docs/reference/profiles-yaml.md
@@ -38,7 +38,7 @@ env:                               # Additional environment variables
 
 ### command
 
-The CLI command to execute.
+The CLI command to execute. Shell-style command strings are split with `shlex`, so a multi-token command like `python3 -u dummy_agent.py` is supported. Values in `args` are appended after the command tokens.
 
 ```yaml
 command: claude          # Claude Code

--- a/synapse/controller.py
+++ b/synapse/controller.py
@@ -9,6 +9,7 @@ import os
 import pty
 import re
 import select
+import shlex
 import shutil
 import signal
 import struct
@@ -137,7 +138,13 @@ class TerminalController(StatusObserverMixin):
         long_submit_confirm_retries: int | None = None,
         auto_approve: dict | None = None,
     ):
-        self.command = command
+        # Support multi-token command strings (e.g. "python3 -u dummy_agent.py").
+        # shlex.split is byte-identical for single-token input: shlex.split("codex") == ["codex"].
+        tokens = shlex.split(command) if isinstance(command, str) else list(command)
+        if not tokens:
+            raise ValueError("command must be a non-empty string or sequence")
+        self._command_tokens = tokens
+        self.command = tokens[0]
         self.args = args or []
         self.delegate_mode = delegate_mode
 
@@ -431,6 +438,10 @@ class TerminalController(StatusObserverMixin):
         if self._auto_approve_enabled:
             self.on_status_change(self._handle_auto_approve)
 
+    def _build_command_list(self) -> list[str]:
+        """Return command tokens followed by controller args."""
+        return list(self._command_tokens) + self.args
+
     def _handle_auto_approve(self, old_status: str, new_status: str) -> None:
         """Auto-approve callback: send approval response on WAITING transitions.
 
@@ -517,8 +528,7 @@ class TerminalController(StatusObserverMixin):
         with contextlib.suppress(termios.error):
             tty.setraw(self.slave_fd)
 
-        # Build command list: command + args
-        cmd_list = [self.command] + self.args
+        cmd_list = self._build_command_list()
 
         self.process = subprocess.Popen(
             cmd_list,
@@ -1477,7 +1487,7 @@ class TerminalController(StatusObserverMixin):
             # Use pty.spawn for robust handling
             signal.signal(signal.SIGWINCH, handle_winch)
 
-            cmd_list = [self.command] + self.args
+            cmd_list = self._build_command_list()
             os.environ.update(self.env)
             os.environ.pop("CLAUDECODE", None)
 

--- a/synapse/utils.py
+++ b/synapse/utils.py
@@ -6,6 +6,7 @@ This module provides common utility functions used across the codebase.
 
 import os
 import re
+import shlex
 import shutil
 from datetime import datetime, timezone
 from pathlib import Path
@@ -263,7 +264,7 @@ def resolve_command_path(command: str) -> str | None:
     if not cmd:
         return None
 
-    cmd_name = cmd.split()[0]
+    cmd_name = shlex.split(cmd)[0]
     if os.path.sep in cmd_name or (os.altsep and os.altsep in cmd_name):
         cmd_path = os.path.expanduser(cmd_name)
         if os.path.isfile(cmd_path) and os.access(cmd_path, os.X_OK):

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -2527,3 +2527,51 @@ class TestKittyKeyboardProtocolDisable:
 
         assert ctrl._kkp_disabled is True
         assert b"\x1b[<u" in writes
+
+
+class TestCommandTokenization:
+    """Tests for TerminalController command tokenization."""
+
+    def test_single_token_command_unchanged(self):
+        """Single-token commands should keep existing public command behavior."""
+        ctrl = TerminalController(command="codex", args=["--foo"], idle_regex=r"\$")
+
+        assert ctrl.command == "codex"
+        assert ctrl._command_tokens == ["codex"]
+
+    def test_multi_token_command_splits_via_shlex(self):
+        """Multi-token command strings should be split into executable tokens."""
+        ctrl = TerminalController(
+            command="python3 -u dummy_agent.py",
+            idle_regex=r"\$",
+        )
+
+        assert ctrl._command_tokens == ["python3", "-u", "dummy_agent.py"]
+        assert ctrl.command == "python3"
+
+    def test_multi_token_command_plus_args_appends(self):
+        """Profile command tokens should precede explicit controller args."""
+        ctrl = TerminalController(
+            command="python3 -u dummy_agent.py",
+            args=["--port", "8198"],
+            idle_regex=r"\$",
+        )
+
+        assert list(ctrl._command_tokens) + ctrl.args == [
+            "python3",
+            "-u",
+            "dummy_agent.py",
+            "--port",
+            "8198",
+        ]
+
+    def test_quoted_argument_preserved(self):
+        """Quoted command segments should stay grouped after tokenization."""
+        ctrl = TerminalController(command='sh -c "echo hi"', idle_regex=r"\$")
+
+        assert ctrl._command_tokens == ["sh", "-c", "echo hi"]
+
+    def test_empty_command_raises(self):
+        """Empty commands should be rejected during initialization."""
+        with pytest.raises(ValueError):
+            TerminalController(command="")

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -2557,7 +2557,7 @@ class TestCommandTokenization:
             idle_regex=r"\$",
         )
 
-        assert list(ctrl._command_tokens) + ctrl.args == [
+        assert ctrl._build_command_list() == [
             "python3",
             "-u",
             "dummy_agent.py",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,9 +2,14 @@
 
 import re
 from datetime import datetime, timezone
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
-from synapse.utils import extract_text_from_parts, format_a2a_message, get_iso_timestamp
+from synapse.utils import (
+    extract_text_from_parts,
+    format_a2a_message,
+    get_iso_timestamp,
+    resolve_command_path,
+)
 
 
 class TestExtractTextFromParts:
@@ -95,6 +100,28 @@ class TestExtractTextFromParts:
         ]
         result = extract_text_from_parts(parts)
         assert result == "日本語テスト\nÉmoji: 🎉"
+
+
+class TestResolveCommandPath:
+    """Tests for command path resolution."""
+
+    def test_resolves_first_shlex_token(self):
+        """Profile command strings should use shlex tokenization."""
+        with patch(
+            "synapse.utils.shutil.which", return_value="/usr/bin/python3"
+        ) as which:
+            result = resolve_command_path("python3 -u dummy_agent.py")
+
+        assert result == "/usr/bin/python3"
+        which.assert_called_once_with("python3")
+
+    def test_preserves_quoted_executable_token(self):
+        """Quoted command tokens should not be split on embedded spaces."""
+        with patch("synapse.utils.shutil.which", return_value=None) as which:
+            result = resolve_command_path('"python 3" -u dummy_agent.py')
+
+        assert result is None
+        which.assert_called_once_with("python 3")
 
 
 class TestFormatA2AMessage:

--- a/uv.lock
+++ b/uv.lock
@@ -1439,7 +1439,7 @@ wheels = [
 
 [[package]]
 name = "synapse-a2a"
-version = "0.27.0"
+version = "0.27.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary
- `TerminalController` now splits `command` through `shlex.split` during init, keeps `self.command` as the executable head, and stores the full argv prefix in `self._command_tokens`.
- Both `cmd_list` construction sites (in `start()` and the secondary `pty.spawn` site) now use `list(self._command_tokens) + self.args`.
- Existing docs already state that profile `command:` strings accept space-separated arguments; this fix makes the implementation match that documented behavior.

## Fix
Closes #614. `uv run synapse start dummy --port <free>` now starts cleanly instead of failing with `FileNotFoundError: 'python3 -u dummy_agent.py'`. Single-token profiles (claude, codex, copilot) are byte-identical — `shlex.split("codex") == ["codex"]`.

## Test plan
- [x] 5 new `TestCommandTokenization` cases in `tests/test_controller.py` (single-token unchanged, multi-token shlex split, command+args append, quoted arg preserved, empty command raises)
- [x] `pytest tests/test_controller.py` → 111 passed
- [x] `pytest -x` (full suite) → 1914 passed, 1 skipped, 1 pre-existing unrelated failure in `test_file_safety` (macOS /var vs /private/var path normalization — present on base commit 7530454)
- [x] `mkdocs build --strict` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート v0.27.1

* **バグ修正**
  * プロファイルコマンド文字列に複数のトークン（例：`python3 -u script.py`）が含まれている場合、正しく解析・実行されるようになりました。

* **ドキュメント**
  * 全ドキュメントおよび設定ファイルのバージョン参照をv0.27.1に更新しました。コマンドフィールドのドキュメントも明確化され、複数トークンコマンドの実行方法が記載されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->