### PR TITLE
feat: add WAITING detection observability layer (#608)

### DIFF
--- a/synapse/a2a_compat.py
+++ b/synapse/a2a_compat.py
@@ -1548,7 +1548,22 @@ def create_a2a_router(
         """
         if controller is None or not hasattr(controller, "pty_snapshot"):
             raise HTTPException(status_code=503, detail="pty renderer not available")
-        snapshot: dict[str, Any] = controller.pty_snapshot()
+        try:
+            snapshot: dict[str, Any] = controller.pty_snapshot()
+        except Exception as exc:
+            raise HTTPException(
+                status_code=503, detail="pty renderer not available"
+            ) from exc
+        return snapshot
+
+    @router.get("/debug/waiting")
+    async def get_debug_waiting(_: Any = Depends(require_auth)) -> dict[str, Any]:
+        """Return recent WAITING-detection attempts."""
+        if controller is None or not hasattr(controller, "waiting_debug_snapshot"):
+            raise HTTPException(
+                status_code=503, detail="waiting debug data not available"
+            )
+        snapshot: dict[str, Any] = controller.waiting_debug_snapshot()
         return snapshot
 
     # --------------------------------------------------------

--- a/synapse/cli.py
+++ b/synapse/cli.py
@@ -2542,6 +2542,7 @@ def cmd_run_interactive(
                 worktree_branch=worktree_branch,
                 worktree_base_branch=worktree_base_branch,
                 spawned_by=spawned_by,
+                renderer_available=controller.renderer_available,
             )
         except NameConflictError as e:
             print(f"Error: {e}")

--- a/synapse/cli.py
+++ b/synapse/cli.py
@@ -679,7 +679,11 @@ def cmd_status(args: argparse.Namespace) -> None:
         file_safety_manager=file_safety,
         output=sys.stdout,
     )
-    cmd.run(args.target, json_output=getattr(args, "json_output", False))
+    cmd.run(
+        args.target,
+        json_output=getattr(args, "json_output", False),
+        debug_waiting=getattr(args, "debug_waiting", False),
+    )
 
 
 def cmd_merge(args: argparse.Namespace) -> None:
@@ -3177,6 +3181,11 @@ Status meanings:
     p_status.add_argument("target", help="Agent name, ID, type-port, or type")
     p_status.add_argument(
         "--json", action="store_true", dest="json_output", help="Output as JSON"
+    )
+    p_status.add_argument(
+        "--debug-waiting",
+        action="store_true",
+        help="Show recent WAITING detection attempts and aggregate diagnostics",
     )
     p_status.set_defaults(func=cmd_status)
 

--- a/synapse/commands/list.py
+++ b/synapse/commands/list.py
@@ -171,6 +171,7 @@ class ListCommand:
                 "task_received_at": info.get("task_received_at"),
                 "summary": info.get("summary"),
                 "transport": registry.get_transport_display(agent_id) or "-",
+                "renderer_available": info.get("renderer_available"),
             }
 
             if show_file_safety:
@@ -662,6 +663,15 @@ class ListCommand:
         "spawned_by",
     )
 
+    def _format_status(self, agent: dict[str, Any]) -> str:
+        status = str(agent.get("status", "-"))
+        renderer_available = agent.get("renderer_available")
+        if renderer_available is False:
+            return f"{status} (renderer: off)"
+        if renderer_available is True:
+            return f"{status} (renderer: on)"
+        return status
+
     def run_json(self, args: argparse.Namespace) -> None:
         """Output agent list as JSON array for programmatic consumption."""
         registry = self._registry_factory()
@@ -670,6 +680,8 @@ class ListCommand:
         result = []
         for agent in agents:
             entry = {k: agent.get(k) for k in self._JSON_FIELDS}
+            if "renderer_available" in agent:
+                entry["renderer_available"] = agent.get("renderer_available")
             # Use full path for working_dir in JSON (short name is for TUI only)
             entry["working_dir"] = agent.get("working_dir_full") or agent.get(
                 "working_dir"
@@ -725,7 +737,7 @@ class ListCommand:
                         (agent.get("skill_set") or "-", 16),
                         (agent.get("agent_id", "-"), 24),
                         (agent["port"], 8),
-                        (agent["status"], 12),
+                        (self._format_status(agent), 12),
                         (str(agent.get("transport") or "-"), 10),
                         (agent.get("working_dir") or "-", 20),
                     ]

--- a/synapse/commands/renderers/rich_renderer.py
+++ b/synapse/commands/renderers/rich_renderer.py
@@ -96,7 +96,7 @@ class RichRenderer:
         "TYPE": ("cyan", 8, 12, None, "agent_type"),
         "ROLE": (None, 10, 20, None, "role"),
         "SKILL_SET": ("blue", 10, 16, None, "skill_set"),
-        "STATUS": (None, 12, None, 24, "status"),
+        "STATUS": (None, 12, None, 30, "status"),
         "CURRENT": (None, 20, 20, 20, "current_task_preview"),
         "TRANSPORT": (None, 10, None, 10, "transport"),
         "WORKING_DIR": (None, 20, 30, None, "working_dir"),

--- a/synapse/commands/renderers/rich_renderer.py
+++ b/synapse/commands/renderers/rich_renderer.py
@@ -50,7 +50,9 @@ class RichRenderer:
         """Get the console instance."""
         return self._console
 
-    def _format_status(self, status: str) -> Text:
+    def _format_status(
+        self, status: str, renderer_available: bool | None = None
+    ) -> Text:
         """Format status with appropriate color.
 
         Args:
@@ -60,7 +62,12 @@ class RichRenderer:
             Rich Text object with styled status.
         """
         style = STATUS_STYLES.get(status, "")
-        return Text(status, style=style)
+        text = Text(status, style=style)
+        if renderer_available is False:
+            text.append(" (renderer: off)", style="dim")
+        elif renderer_available is True:
+            text.append(" (renderer: on)", style="dim")
+        return text
 
     def _build_empty_table(self) -> Table:
         """Build a table showing 'No agents running' with port ranges.
@@ -89,7 +96,7 @@ class RichRenderer:
         "TYPE": ("cyan", 8, 12, None, "agent_type"),
         "ROLE": (None, 10, 20, None, "role"),
         "SKILL_SET": ("blue", 10, 16, None, "skill_set"),
-        "STATUS": (None, 12, None, 13, "status"),
+        "STATUS": (None, 12, None, 24, "status"),
         "CURRENT": (None, 20, 20, 20, "current_task_preview"),
         "TRANSPORT": (None, 10, None, 10, "transport"),
         "WORKING_DIR": (None, 20, 30, None, "working_dir"),
@@ -214,7 +221,12 @@ class RichRenderer:
             for col_name in valid_columns:
                 _, _, _, _, data_key = self.COLUMN_DEFS[col_name]
                 if col_name == "STATUS":
-                    row.append(self._format_status(agent.get(data_key, "-")))
+                    row.append(
+                        self._format_status(
+                            agent.get(data_key, "-"),
+                            agent.get("renderer_available"),
+                        )
+                    )
                 elif col_name == "ROLE":
                     # Show filename only for file references
                     row.append(get_role_display(agent.get(data_key)) or "-")

--- a/synapse/commands/status.py
+++ b/synapse/commands/status.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 import json
 import time
+import urllib.error
+import urllib.request
+from collections import Counter
+from collections.abc import Callable
 from io import StringIO
 from typing import IO, TYPE_CHECKING, Any
 
@@ -24,11 +28,13 @@ class StatusCommand:
         history_manager: HistoryManager | None = None,
         file_safety_manager: FileSafetyManager | None = None,
         output: IO[str] | None = None,
+        debug_waiting_fetcher: Callable[[str], dict[str, Any]] | None = None,
     ) -> None:
         self._registry = registry
         self._history_manager = history_manager
         self._file_safety_manager = file_safety_manager
         self._output = output or StringIO()
+        self._debug_waiting_fetcher = debug_waiting_fetcher or self._http_get_json
 
     def _write(self, text: str) -> None:
         self._output.write(text)
@@ -36,7 +42,9 @@ class StatusCommand:
     def _writeln(self, text: str = "") -> None:
         self._output.write(text + "\n")
 
-    def run(self, target: str, json_output: bool = False) -> None:
+    def run(
+        self, target: str, json_output: bool = False, debug_waiting: bool = False
+    ) -> None:
         """Run the status command.
 
         Args:
@@ -56,6 +64,8 @@ class StatusCommand:
             self._render_json(info)
         else:
             self._render_text(info)
+            if debug_waiting:
+                self._render_waiting_debug(info)
 
     def _render_json(self, info: dict[str, Any]) -> None:
         """Render agent status as JSON."""
@@ -70,6 +80,8 @@ class StatusCommand:
             "working_dir": info.get("working_dir"),
             "endpoint": info.get("endpoint"),
         }
+        if "renderer_available" in info:
+            data["renderer_available"] = info.get("renderer_available")
 
         # Uptime
         registered_at = info.get("registered_at")
@@ -107,7 +119,7 @@ class StatusCommand:
         self._writeln(f"  Name:        {info.get('name') or '-'}")
         self._writeln(f"  Role:        {info.get('role') or '-'}")
         self._writeln(f"  Port:        {info.get('port', '-')}")
-        self._writeln(f"  Status:      {info.get('status', '-')}")
+        self._writeln(f"  Status:      {self._format_status(info)}")
         self._writeln(f"  PID:         {info.get('pid', '-')}")
         self._writeln(f"  Working Dir: {info.get('working_dir', '-')}")
 
@@ -158,6 +170,93 @@ class StatusCommand:
             for lock in locks:
                 self._writeln(f"  {lock.get('file_path', '-')}")
             self._writeln()
+
+    def _format_status(self, info: dict[str, Any]) -> str:
+        status = str(info.get("status", "-"))
+        renderer_available = info.get("renderer_available")
+        if renderer_available is False:
+            return f"{status} (renderer: off)"
+        if renderer_available is True:
+            return f"{status} (renderer: on)"
+        return status
+
+    def _http_get_json(self, url: str) -> dict[str, Any]:
+        with urllib.request.urlopen(url, timeout=3.0) as response:
+            payload = response.read().decode("utf-8")
+        data = json.loads(payload)
+        return data if isinstance(data, dict) else {}
+
+    def _render_waiting_debug(self, info: dict[str, Any]) -> None:
+        endpoint = info.get("endpoint")
+        if not endpoint:
+            self._writeln("--- WAITING Detection Debug ---")
+            self._writeln("  No endpoint registered")
+            return
+
+        self._writeln("--- WAITING Detection Debug ---")
+        try:
+            payload = self._debug_waiting_fetcher(f"{endpoint}/debug/waiting")
+        except (OSError, urllib.error.URLError, json.JSONDecodeError) as exc:
+            self._writeln(f"  Failed to fetch debug data: {exc}")
+            return
+
+        attempts = payload.get("attempts") or []
+        if not isinstance(attempts, list):
+            attempts = []
+
+        total = len(attempts)
+        matched = sum(1 for item in attempts if item.get("pattern_matched") is True)
+        ratio = (matched / total * 100.0) if total else 0.0
+        path_counts = Counter(str(item.get("path_used") or "-") for item in attempts)
+        confidence_counts = Counter(
+            str(item.get("confidence", 0.0)) for item in attempts
+        )
+        idle_gate_drops = sum(
+            1
+            for item in attempts
+            if item.get("pattern_matched") is True
+            and item.get("idle_gate_passed") is not True
+        )
+
+        self._writeln(f"  Renderer: {self._renderer_label(payload)}")
+        self._writeln(f"  Total attempts: {total}")
+        self._writeln(f"  Pattern matched: {matched}/{total} ({ratio:.1f}%)")
+        self._writeln(f"  Path usage: {self._format_counter(path_counts)}")
+        self._writeln(f"  Confidence: {self._format_counter(confidence_counts)}")
+        self._writeln(f"  Idle gate drops: {idle_gate_drops}")
+
+        if not attempts:
+            self._writeln("  No recent attempts")
+            return
+
+        self._writeln()
+        self._writeln("  Recent attempts:")
+        for item in attempts:
+            path = item.get("path_used") or "-"
+            source = item.get("pattern_source") or "-"
+            confidence = item.get("confidence", 0.0)
+            idle = "yes" if item.get("idle_gate_passed") is True else "no"
+            matched_text = "yes" if item.get("pattern_matched") is True else "no"
+            hex_prefix = item.get("new_data_hex_prefix") or "-"
+            tail = str(item.get("rendered_text_tail") or "").replace("\n", "\\n")
+            self._writeln(
+                f"  - {path} {source} {confidence} idle={idle} matched={matched_text}"
+            )
+            self._writeln(f"    hex: {hex_prefix}")
+            self._writeln(f"    tail: {tail}")
+
+    def _renderer_label(self, payload: dict[str, Any]) -> str:
+        renderer_available = payload.get("renderer_available")
+        if renderer_available is True:
+            return "on"
+        if renderer_available is False:
+            return "off"
+        return "unknown"
+
+    def _format_counter(self, counter: Counter[str]) -> str:
+        if not counter:
+            return "-"
+        return ", ".join(f"{key}={counter[key]}" for key in sorted(counter))
 
     def _get_history(self, info: dict[str, Any]) -> list[dict[str, Any]]:
         """Get recent message history for the agent."""

--- a/synapse/controller.py
+++ b/synapse/controller.py
@@ -161,12 +161,17 @@ class TerminalController(StatusObserverMixin):
 
         self.idle_config = idle_detection or {"strategy": "timeout", "timeout": 1.5}
         self._pattern_detected = False
-        self._pty_renderer = PtyRenderer(columns=120, rows=40)
+        try:
+            self._pty_renderer: PtyRenderer | None = PtyRenderer(columns=120, rows=40)
+        except Exception as exc:
+            logger.warning("PtyRenderer init failed: %s", exc)
+            self._pty_renderer = None
         self._idle_detector = IdleDetector(
             idle_detection=self.idle_config,
             waiting_detection=waiting_detection,
             strip_ansi_fn=strip_ansi,
             renderer=self._pty_renderer,
+            profile=agent_type,
         )
         self.idle_strategy = self._idle_detector.idle_strategy
         self.idle_regex = self._idle_detector.idle_regex
@@ -1226,6 +1231,11 @@ class TerminalController(StatusObserverMixin):
             raw = "".join(self._render_buffer)
         return strip_ansi(raw)
 
+    @property
+    def renderer_available(self) -> bool:
+        """Return whether the pyte PTY renderer initialized successfully."""
+        return self._pty_renderer is not None
+
     def pty_snapshot(self) -> dict[str, Any]:
         """Return the rendered virtual terminal state.
 
@@ -1234,7 +1244,17 @@ class TerminalController(StatusObserverMixin):
         evaluates against without reaching into private attributes.
         """
         with self.lock:
+            if self._pty_renderer is None:
+                raise RuntimeError("pty renderer not available")
             return self._pty_renderer.snapshot()
+
+    def waiting_debug_snapshot(self) -> dict[str, Any]:
+        """Return recent WAITING-detection attempts for diagnostics."""
+        with self.lock:
+            return {
+                "renderer_available": self.renderer_available,
+                "attempts": self._idle_detector.waiting_debug_attempts,
+            }
 
     def set_done(self) -> None:
         """Set status to DONE (task completed).

--- a/synapse/idle_detector.py
+++ b/synapse/idle_detector.py
@@ -261,7 +261,8 @@ class IdleDetector:
         if not self.waiting_regex and not self.heuristic_fallback:
             self._waiting_source = "none"
             self._waiting_confidence = 0.0
-            record_attempt()
+            if new_data:
+                record_attempt()
             return False, waiting_pattern_time, 0.0, "none"
 
         # Quiet-tick fast path: no new bytes and nothing previously
@@ -269,7 +270,6 @@ class IdleDetector:
         if not new_data and waiting_pattern_time is None:
             self._waiting_source = "none"
             self._waiting_confidence = 0.0
-            record_attempt()
             return False, None, 0.0, "none"
 
         if new_data:

--- a/synapse/idle_detector.py
+++ b/synapse/idle_detector.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import logging
 import re
 import time
+from collections import deque
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import Any
 
 from synapse.config import WAITING_EXPIRY_SECONDS
 from synapse.pty_renderer import PtyRenderer
@@ -76,6 +78,7 @@ class IdleDetector:
         *,
         strip_ansi_fn: Callable[[str], str] | None = None,
         renderer: PtyRenderer | None = None,
+        profile: str | None = None,
     ) -> None:
         self.idle_config = idle_detection or {"strategy": "timeout", "timeout": 1.5}
         self.idle_strategy = self.idle_config.get("strategy", "pattern")
@@ -100,8 +103,17 @@ class IdleDetector:
         )
         self._strip_ansi = strip_ansi_fn or (lambda text: text)
         self._renderer = renderer
+        self._profile = profile or "unknown"
+        self._waiting_debug_attempts: deque[dict[str, Any]] = deque(
+            maxlen=int(self.waiting_config.get("debug_ring_size", 50))
+        )
         self._waiting_source = "none"
         self._waiting_confidence = 0.0
+
+    @property
+    def waiting_debug_attempts(self) -> list[dict[str, Any]]:
+        """Return recent WAITING-detection attempts."""
+        return list(self._waiting_debug_attempts)
 
     def _compile_idle_regex(self) -> re.Pattern[bytes] | None:
         if self.idle_strategy not in ("pattern", "hybrid"):
@@ -224,9 +236,32 @@ class IdleDetector:
         last_output_time: float | None,
         waiting_pattern_time: float | None,
     ) -> tuple[bool, float | None, float, str]:
+        path_used = "renderer" if self._renderer is not None else "strip_ansi"
+        rendered_text_tail = ""
+        pattern_visible = False
+        confidence = 0.0
+        source = "none"
+        idle_gate_passed = False
+
+        def record_attempt() -> None:
+            try:
+                self._record_waiting_debug_attempt(
+                    new_data=new_data,
+                    path_used=path_used,
+                    renderer_on=self._renderer is not None,
+                    pattern_matched=pattern_visible,
+                    pattern_source=source,
+                    confidence=confidence if pattern_visible else 0.0,
+                    idle_gate_passed=idle_gate_passed,
+                    rendered_text_tail=rendered_text_tail,
+                )
+            except Exception:
+                logger.debug("WAITING debug attempt recording failed", exc_info=True)
+
         if not self.waiting_regex and not self.heuristic_fallback:
             self._waiting_source = "none"
             self._waiting_confidence = 0.0
+            record_attempt()
             return False, waiting_pattern_time, 0.0, "none"
 
         # Quiet-tick fast path: no new bytes and nothing previously
@@ -234,17 +269,21 @@ class IdleDetector:
         if not new_data and waiting_pattern_time is None:
             self._waiting_source = "none"
             self._waiting_confidence = 0.0
+            record_attempt()
             return False, None, 0.0, "none"
 
         if new_data:
             if self._renderer is not None:
                 self._renderer.feed(new_data)
                 # renderer path: match against the full rendered screen
+                rendered_text = self._renderer.render_text()
+                rendered_text_tail = rendered_text.rstrip()[-256:]
                 pattern_visible, confidence, source = self._match_waiting_prompt(
-                    self._renderer.render_text()
+                    rendered_text
                 )
             else:
                 new_text = self._strip_ansi(new_data.decode("utf-8", errors="replace"))
+                rendered_text_tail = new_text[-256:]
                 pattern_visible, confidence, source = self._match_waiting_prompt(
                     new_text
                 )
@@ -252,6 +291,12 @@ class IdleDetector:
             pattern_visible = False
             confidence = self._waiting_confidence
             source = self._waiting_source
+            if self._renderer is not None:
+                rendered_text_tail = self._renderer.render_text().rstrip()[-256:]
+            else:
+                rendered_text_tail = self._strip_ansi(
+                    output_buffer[-512:].decode("utf-8", errors="replace")
+                )[-256:]
 
         if pattern_visible:
             waiting_pattern_time = time.time()
@@ -260,6 +305,7 @@ class IdleDetector:
         elif waiting_pattern_time is None:
             self._waiting_source = "none"
             self._waiting_confidence = 0.0
+            record_attempt()
             return False, None, 0.0, "none"
 
         if waiting_pattern_time is not None:
@@ -291,12 +337,16 @@ class IdleDetector:
                     waiting_pattern_time = time.time()
                     self._waiting_confidence = confidence
                     self._waiting_source = source
+                    pattern_visible = True
                 else:
                     self._waiting_source = "none"
                     self._waiting_confidence = 0.0
+                    record_attempt()
                     return False, None, 0.0, "none"
 
         if not self.waiting_require_idle:
+            idle_gate_passed = True
+            record_attempt()
             return (
                 True,
                 waiting_pattern_time,
@@ -305,17 +355,49 @@ class IdleDetector:
             )
 
         if not (waiting_pattern_time and last_output_time):
+            record_attempt()
             return False, waiting_pattern_time, 0.0, "none"
 
         time_since_output = time.time() - last_output_time
         is_waiting = time_since_output >= self.waiting_idle_timeout
         if not is_waiting:
+            record_attempt()
             return False, waiting_pattern_time, 0.0, "none"
+        idle_gate_passed = True
+        record_attempt()
         return (
             True,
             waiting_pattern_time,
             self._waiting_confidence,
             self._waiting_source,
+        )
+
+    def _record_waiting_debug_attempt(
+        self,
+        *,
+        new_data: bytes,
+        path_used: str,
+        renderer_on: bool,
+        pattern_matched: bool,
+        pattern_source: str,
+        confidence: float,
+        idle_gate_passed: bool,
+        rendered_text_tail: str,
+    ) -> None:
+        source_map = {"regex": "primary", "heuristic": "heuristic"}
+        self._waiting_debug_attempts.append(
+            {
+                "timestamp": time.time(),
+                "profile": self._profile,
+                "path_used": path_used,
+                "renderer_on": renderer_on,
+                "pattern_matched": pattern_matched,
+                "pattern_source": source_map.get(pattern_source),
+                "confidence": confidence,
+                "idle_gate_passed": idle_gate_passed,
+                "new_data_hex_prefix": new_data[:64].hex(),
+                "rendered_text_tail": rendered_text_tail[-256:],
+            }
         )
 
     def _match_waiting_prompt(

--- a/synapse/registry.py
+++ b/synapse/registry.py
@@ -191,6 +191,7 @@ class AgentRegistry:
         worktree_branch: str | None = None,
         worktree_base_branch: str | None = None,
         spawned_by: str | None = None,
+        renderer_available: bool | None = None,
     ) -> Path:
         """Writes connection info to registry file.
 
@@ -256,6 +257,8 @@ class AgentRegistry:
 
         if spawned_by:
             data["spawned_by"] = spawned_by
+        if renderer_available is not None:
+            data["renderer_available"] = renderer_available
 
         file_path = self.registry_dir / f"{agent_id}.json"
         with self._registry_write_lock():

--- a/synapse/server.py
+++ b/synapse/server.py
@@ -186,12 +186,18 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     )
     controller.start()
 
+    register_kwargs: dict[str, Any] = {
+        "status": "PROCESSING",
+        "spawned_by": os.environ.get("SYNAPSE_SPAWNED_BY") or None,
+    }
+    renderer_available = getattr(controller, "renderer_available", None)
+    if isinstance(renderer_available, bool):
+        register_kwargs["renderer_available"] = renderer_available
     registry.register(
         current_agent_id,
         profile_name,
         agent_port,
-        status="PROCESSING",
-        spawned_by=os.environ.get("SYNAPSE_SPAWNED_BY") or None,
+        **register_kwargs,
     )
 
     # Add Google A2A compatible routes

--- a/tests/test_cmd_list_json.py
+++ b/tests/test_cmd_list_json.py
@@ -33,6 +33,7 @@ def make_agent(
     working_dir: str,
     endpoint: str,
     transport: str,
+    renderer_available: bool | None = None,
     current_task_preview: str | None = None,
     task_received_at: float | None = None,
     editing_file: str | None = None,
@@ -57,6 +58,8 @@ def make_agent(
         "summary": None,
         "transport": transport,
     }
+    if renderer_available is not None:
+        agent["renderer_available"] = renderer_available
     if editing_file is not None:
         agent["editing_file"] = editing_file
     return agent
@@ -96,6 +99,7 @@ class TestListJson:
             working_dir="repo-a",
             endpoint="http://localhost:8100",
             transport="UDS→",
+            renderer_available=False,
             current_task_preview="Review issue #380",
             task_received_at=1710000000.0,
         )
@@ -128,8 +132,36 @@ class TestListJson:
                 "summary": None,
                 "is_orphan": None,
                 "spawned_by": None,
+                "renderer_available": False,
             }
         ]
+
+    def test_list_text_appends_renderer_state_to_status(self) -> None:
+        """Plain list output should expose renderer state without a new column."""
+        list_cmd = create_list_command()
+        args = MagicMock()
+        args.plain_output = True
+        agent = make_agent(
+            agent_id="synapse-codex-8120",
+            agent_type="codex",
+            port=8120,
+            status="WAITING",
+            pid=32345,
+            working_dir="repo-c",
+            endpoint="http://localhost:8120",
+            transport="-",
+            renderer_available=False,
+        )
+
+        with patch.object(
+            list_cmd,
+            "_get_agent_data",
+            return_value=([agent], [], False),
+        ):
+            list_cmd.run(args)
+
+        rows = [call.args[0] for call in list_cmd._print.call_args_list]
+        assert any("WAITING (renderer: off)" in row for row in rows)
 
     def test_list_json_multiple_agents(self) -> None:
         """Should output multiple agents as a JSON array."""

--- a/tests/test_cmd_status.py
+++ b/tests/test_cmd_status.py
@@ -106,6 +106,15 @@ class TestStatusMetadata:
         text = output.getvalue()
         assert "2h" in text
 
+    def test_displays_renderer_state_when_registered(self):
+        """Should show renderer availability without changing the status value."""
+        info = _make_agent_info(status="WAITING", renderer_available=False)
+        cmd, output = _make_command(agent_info=info)
+        cmd.run("my-claude")
+
+        text = output.getvalue()
+        assert "Status:      WAITING (renderer: off)" in text
+
 
 class TestStatusCurrentTask:
     """Tests for current task with elapsed time."""
@@ -178,7 +187,7 @@ class TestStatusJsonOutput:
 
     def test_json_output(self):
         """Should output valid JSON when json=True."""
-        info = _make_agent_info()
+        info = _make_agent_info(renderer_available=True)
         cmd, output = _make_command(agent_info=info)
         cmd.run("my-claude", json_output=True)
 
@@ -186,6 +195,7 @@ class TestStatusJsonOutput:
         data = json.loads(text)
         assert data["agent_id"] == "synapse-claude-8100"
         assert data["status"] == "READY"
+        assert data["renderer_available"] is True
 
     def test_json_not_found(self):
         """Should output error JSON when agent not found."""
@@ -210,3 +220,64 @@ class TestStatusErrorHandling:
         cmd.run("my-claude")
         text = output.getvalue()
         assert "synapse-claude-8100" in text
+
+
+class TestStatusDebugWaiting:
+    """Tests for WAITING detection diagnostics."""
+
+    def test_debug_waiting_formats_recent_attempts_and_aggregates(self):
+        info = _make_agent_info(endpoint="http://localhost:8100")
+
+        def fake_http_get(url: str) -> dict[str, Any]:
+            assert url == "http://localhost:8100/debug/waiting"
+            return {
+                "renderer_available": True,
+                "attempts": [
+                    {
+                        "timestamp": 1776814438.0,
+                        "profile": "codex",
+                        "path_used": "renderer",
+                        "renderer_on": True,
+                        "pattern_matched": True,
+                        "pattern_source": "primary",
+                        "confidence": 1.0,
+                        "idle_gate_passed": False,
+                        "new_data_hex_prefix": "50726f636565643f",
+                        "rendered_text_tail": "Proceed?",
+                    },
+                    {
+                        "timestamp": 1776814439.0,
+                        "profile": "codex",
+                        "path_used": "strip_ansi",
+                        "renderer_on": False,
+                        "pattern_matched": False,
+                        "pattern_source": None,
+                        "confidence": 0.0,
+                        "idle_gate_passed": False,
+                        "new_data_hex_prefix": "6f7264696e617279",
+                        "rendered_text_tail": "ordinary",
+                    },
+                ],
+            }
+
+        output = StringIO()
+        mock_registry = MagicMock()
+        mock_registry.resolve_agent.return_value = info
+        cmd = StatusCommand(
+            registry=mock_registry,
+            output=output,
+            debug_waiting_fetcher=fake_http_get,
+        )
+
+        cmd.run("my-claude", debug_waiting=True)
+
+        text = output.getvalue()
+        assert "--- WAITING Detection Debug ---" in text
+        assert "Total attempts: 2" in text
+        assert "Pattern matched: 1/2 (50.0%)" in text
+        assert "Path usage: renderer=1, strip_ansi=1" in text
+        assert "Confidence: 0.0=1, 1.0=1" in text
+        assert "Idle gate drops: 1" in text
+        assert "renderer primary 1.0 idle=no matched=yes" in text
+        assert "50726f636565643f" in text
+        assert "Proceed?" in text

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -121,6 +121,24 @@ class TestIdentityInstruction:
         assert controller.status == "PROCESSING"
         controller._dispatch_status_callbacks.assert_not_called()
 
+    def test_renderer_initialization_failure_disables_renderer(self, mock_registry):
+        """Renderer startup failures should be observable and non-fatal."""
+        with patch("synapse.controller.PtyRenderer", side_effect=RuntimeError("boom")):
+            ctrl = TerminalController(
+                command="echo test",
+                idle_regex=r"\$",
+                registry=mock_registry,
+                agent_id="synapse-claude-8100",
+                agent_type="claude",
+                submit_seq="\r",
+            )
+
+        assert ctrl.renderer_available is False
+        assert ctrl._idle_detector._renderer is None
+
+    def test_renderer_available_true_when_renderer_starts(self, controller):
+        assert controller.renderer_available is True
+
     def test_identity_sent_on_first_idle(self, controller):
         """Identity instruction should be sent on first IDLE detection."""
         controller.running = True

--- a/tests/test_debug_pty_endpoint.py
+++ b/tests/test_debug_pty_endpoint.py
@@ -106,3 +106,47 @@ class TestDebugPtyEndpoint:
         client = TestClient(app)
         response = client.get("/debug/pty")
         assert response.status_code == 503
+
+
+class TestDebugWaitingEndpoint:
+    def test_returns_waiting_detection_snapshot(self) -> None:
+        controller = MagicMock()
+        controller.status = "WAITING"
+        controller.renderer_available = False
+        controller.waiting_debug_snapshot.return_value = {
+            "renderer_available": False,
+            "attempts": [
+                {
+                    "timestamp": 1776814438.0,
+                    "profile": "codex",
+                    "path_used": "strip_ansi",
+                    "renderer_on": False,
+                    "pattern_matched": False,
+                    "pattern_source": None,
+                    "confidence": 0.0,
+                    "idle_gate_passed": False,
+                    "new_data_hex_prefix": "6f7264696e617279",
+                    "rendered_text_tail": "ordinary",
+                }
+            ],
+        }
+        app = FastAPI()
+        app.include_router(create_a2a_router(controller, "codex", 8126, "\n"))
+        client = TestClient(app)
+
+        response = client.get("/debug/waiting")
+
+        assert response.status_code == 200
+        assert response.json()["renderer_available"] is False
+        assert response.json()["attempts"][0]["path_used"] == "strip_ansi"
+
+    def test_handles_controller_without_waiting_debug_snapshot(self) -> None:
+        legacy = MagicMock(spec=["status", "on_status_change"])
+        legacy.status = "PROCESSING"
+        app = FastAPI()
+        app.include_router(create_a2a_router(legacy, "codex", 8126, "\n"))
+        client = TestClient(app)
+
+        response = client.get("/debug/waiting")
+
+        assert response.status_code == 503

--- a/tests/test_idle_detector.py
+++ b/tests/test_idle_detector.py
@@ -383,6 +383,28 @@ def test_waiting_debug_ring_buffer_discards_oldest_entries():
     assert all(entry["profile"] == "codex" for entry in attempts)
 
 
+def test_waiting_debug_skips_quiet_tick_fast_path():
+    detector = IdleDetector(
+        waiting_detection={
+            "regex": r"Proceed\?",
+            "debug_ring_size": 50,
+        }
+    )
+
+    is_waiting, refreshed, confidence, source = detector.check_waiting_state(
+        new_data=b"",
+        output_buffer=b"",
+        last_output_time=None,
+        waiting_pattern_time=None,
+    )
+
+    assert is_waiting is False
+    assert refreshed is None
+    assert confidence == 0.0
+    assert source == "none"
+    assert detector.waiting_debug_attempts == []
+
+
 def test_waiting_debug_records_strip_ansi_path_and_miss():
     detector = IdleDetector(
         waiting_detection={

--- a/tests/test_idle_detector.py
+++ b/tests/test_idle_detector.py
@@ -356,6 +356,121 @@ def test_waiting_detection_without_renderer_uses_strip_ansi():
     assert is_waiting is True
 
 
+def test_waiting_debug_ring_buffer_discards_oldest_entries():
+    detector = IdleDetector(
+        waiting_detection={
+            "regex": r"Proceed\?",
+            "require_idle": False,
+            "debug_ring_size": 2,
+        },
+        profile="codex",
+    )
+
+    for raw in (b"first", b"Proceed?", b"third"):
+        detector.check_waiting_state(
+            new_data=raw,
+            output_buffer=raw,
+            last_output_time=time.time() - 1.0,
+            waiting_pattern_time=None,
+        )
+
+    attempts = detector.waiting_debug_attempts
+    assert len(attempts) == 2
+    assert [entry["new_data_hex_prefix"] for entry in attempts] == [
+        b"Proceed?".hex(),
+        b"third".hex(),
+    ]
+    assert all(entry["profile"] == "codex" for entry in attempts)
+
+
+def test_waiting_debug_records_strip_ansi_path_and_miss():
+    detector = IdleDetector(
+        waiting_detection={
+            "regex": r"Proceed\?",
+            "require_idle": False,
+            "debug_ring_size": 50,
+        },
+        strip_ansi_fn=lambda text: text.replace("\x1b[31m", "").replace("\x1b[0m", ""),
+    )
+
+    is_waiting, _, confidence, source = detector.check_waiting_state(
+        new_data=b"\x1b[31mordinary output\x1b[0m",
+        output_buffer=b"\x1b[31mordinary output\x1b[0m",
+        last_output_time=time.time() - 1.0,
+        waiting_pattern_time=None,
+    )
+
+    attempt = detector.waiting_debug_attempts[-1]
+    assert is_waiting is False
+    assert confidence == 0.0
+    assert source == "none"
+    assert attempt["path_used"] == "strip_ansi"
+    assert attempt["renderer_on"] is False
+    assert attempt["pattern_matched"] is False
+    assert attempt["pattern_source"] is None
+    assert attempt["confidence"] == 0.0
+    assert attempt["idle_gate_passed"] is False
+    assert attempt["rendered_text_tail"].endswith("ordinary output")
+
+
+def test_waiting_debug_records_renderer_path_primary_match_and_idle_gate_drop():
+    renderer = PtyRenderer(columns=80, rows=24)
+    detector = IdleDetector(
+        waiting_detection={
+            "regex": r"Proceed\?",
+            "idle_timeout": 0.5,
+            "debug_ring_size": 50,
+        },
+        renderer=renderer,
+        profile="claude",
+    )
+
+    is_waiting, refreshed, confidence, source = detector.check_waiting_state(
+        new_data=b"Proceed?",
+        output_buffer=b"Proceed?",
+        last_output_time=time.time(),
+        waiting_pattern_time=None,
+    )
+
+    attempt = detector.waiting_debug_attempts[-1]
+    assert is_waiting is False
+    assert refreshed is not None
+    assert confidence == 0.0
+    assert source == "none"
+    assert attempt["profile"] == "claude"
+    assert attempt["path_used"] == "renderer"
+    assert attempt["renderer_on"] is True
+    assert attempt["pattern_matched"] is True
+    assert attempt["pattern_source"] == "primary"
+    assert attempt["confidence"] == 1.0
+    assert attempt["idle_gate_passed"] is False
+    assert attempt["new_data_hex_prefix"] == b"Proceed?".hex()
+    assert attempt["rendered_text_tail"].endswith("Proceed?")
+
+
+def test_waiting_debug_records_heuristic_source():
+    detector = IdleDetector(
+        waiting_detection={
+            "regex": "NEVER_MATCHES_THIS",
+            "require_idle": False,
+            "debug_ring_size": 50,
+        }
+    )
+
+    detector.check_waiting_state(
+        new_data=b"\n> 1. Yes\n> 2. No\n",
+        output_buffer=b"\n> 1. Yes\n> 2. No\n",
+        last_output_time=time.time() - 1.0,
+        waiting_pattern_time=None,
+    )
+
+    attempt = detector.waiting_debug_attempts[-1]
+    assert attempt["pattern_matched"] is True
+    assert attempt["pattern_source"] == "heuristic"
+    assert attempt["confidence"] == 0.6
+    assert attempt["idle_gate_passed"] is True
+
+
 def test_done_state_remains_done_until_timeout_expires():
     detector = IdleDetector()
 

--- a/tests/test_list_columns_config.py
+++ b/tests/test_list_columns_config.py
@@ -107,6 +107,16 @@ class TestRichRendererColumns:
         column_names = [col.header for col in table.columns]
         assert column_names == ["ID", "STATUS"]
 
+    def test_status_column_width_fits_renderer_suffix(
+        self, renderer: RichRenderer
+    ) -> None:
+        """STATUS column should fit the longest renderer state suffix."""
+        _style, _min_width, _max_width, fixed_width, _key = renderer.COLUMN_DEFS[
+            "STATUS"
+        ]
+        assert fixed_width is not None
+        assert fixed_width >= len("SHUTTING_DOWN (renderer: off)")
+
     def test_build_table_with_all_available_columns(
         self, renderer: RichRenderer, sample_agents: list[dict]
     ) -> None:


### PR DESCRIPTION
## Summary
- Add an in-memory WAITING detection attempt ring buffer to `IdleDetector` with path/source/confidence/idle-gate/raw-hex/rendered-tail diagnostics.
- Make `PtyRenderer` initialization observable and non-fatal via `renderer_available`, then expose that state in registry-backed list/status output.
- Add `/debug/waiting` and `synapse status <agent> --debug-waiting` aggregate/detail diagnostics.

## Scope
Phase 1 only. This PR adds observability for WAITING detection misses; it does not change WAITING detection logic, add regexes, change `require_idle`, or dual-run renderer and strip-ANSI paths. Detection logic changes and regex additions are intentionally deferred to Phase 2.

## Tests
- `uv run pytest tests/test_idle_detector.py tests/test_controller.py tests/test_cmd_status.py tests/test_cmd_list_json.py tests/test_debug_pty_endpoint.py -q` -> 161 passed
- `env -u SYNAPSE_FILE_SAFETY_DB_PATH -u SYNAPSE_FILE_SAFETY_ENABLED -u SYNAPSE_AGENT_SAVE_PROMPT_ENABLED -u SYNAPSE_SHARED_MEMORY_ENABLED -u SYNAPSE_LEARNING_MODE_ENABLED -u SYNAPSE_LEARNING_MODE_TRANSLATION HOME=/tmp/synapse-test-home uv run pytest` -> 4197 passed, 29 skipped, 1 warning
- `uv run ruff check synapse/idle_detector.py synapse/controller.py synapse/registry.py synapse/server.py synapse/a2a_compat.py synapse/commands/status.py synapse/commands/list.py synapse/commands/renderers/rich_renderer.py tests/test_idle_detector.py tests/test_controller.py tests/test_cmd_status.py tests/test_cmd_list_json.py tests/test_debug_pty_endpoint.py` -> passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * `/debug/waiting`エンドポイントを追加し、デバッグ情報を提供
  * `status`コマンドに`--debug-waiting`フラグを追加
  * ステータス出力にレンダラーの利用可能性を表示
  * 待機検出に関するデバッグ診断データを表示

* **バグ修正**
  * PTYレンダラーの初期化エラーハンドリングを改善
  * エンドポイント例外処理を強化し、フォールバック機能を実装

<!-- end of auto-generated comment: release notes by coderabbit.ai -->