### PR TITLE
docs(608): document WAITING observability in skills + agent-management guide

### DIFF
--- a/.agents/skills/synapse-a2a/references/api.md
+++ b/.agents/skills/synapse-a2a/references/api.md
@@ -94,8 +94,44 @@ When a spawned agent hits a permission prompt (e.g., tool approval), the control
 | Endpoint | Method | Description |
 |----------|--------|-------------|
 | `/debug/pty` | GET | Return the pyte-rendered virtual terminal state as JSON (`display`, `cursor`, `alt_screen`, `rows`, `columns`) |
+| `/debug/waiting` | GET | Return the recent WAITING-detection attempts ring buffer plus `renderer_available` |
 
 `GET /debug/pty` exposes exactly what `waiting_detection` regexes see: the raw PTY stream is replayed through a pyte-backed virtual terminal (`PtyRenderer`) so cursor-motion CSI sequences, ratatui-style redraws, and alt-screen overlays are resolved against a real screen before matching. Use it when tuning profile `waiting_detection` patterns or diagnosing why a WAITING prompt was (or was not) detected.
+
+`GET /debug/waiting` returns an in-memory ring buffer (default 50 entries) of recent WAITING detection attempts, one per incoming PTY chunk. Response shape:
+
+```json
+{
+  "renderer_available": true,
+  "attempts": [
+    {
+      "timestamp": 1776819000.12,
+      "profile": "codex",
+      "path_used": "renderer",
+      "renderer_on": true,
+      "pattern_matched": true,
+      "pattern_source": "primary",
+      "confidence": 1.0,
+      "idle_gate_passed": false,
+      "new_data_hex_prefix": "50726f636565643f",
+      "rendered_text_tail": "...Proceed?"
+    }
+  ]
+}
+```
+
+Field meanings:
+- `path_used`: `"renderer"` (pyte virtual terminal path) or `"strip_ansi"` (fallback path)
+- `renderer_on`: whether `PtyRenderer` is initialised on this agent (see `renderer_available` below)
+- `pattern_source`: `"primary"` (profile-specific regex), `"heuristic"` (generic fallback), or `null`
+- `confidence`: `1.0` for primary regex, `0.6` for heuristic, `0.0` for no match
+- `idle_gate_passed`: whether `time_since_output >= waiting_idle_timeout` was satisfied
+- `new_data_hex_prefix`: first 64 bytes of the raw PTY chunk as hex (preserves ANSI/binary data)
+- `rendered_text_tail`: last 256 chars of the rendered (or strip-ANSI'd) text
+
+Returns HTTP 503 when the controller predates Phase 1 (#627). Use `synapse status <agent> --debug-waiting` for formatted aggregates; query this endpoint directly when you need the raw attempts for custom analysis or periodic collection.
+
+**`renderer_available`:** reflects whether `PtyRenderer` initialised successfully for this agent. If pyte failed to start, the agent falls back to the strip-ANSI path (lower fidelity for ratatui TUIs). This field appears in `synapse list --json`, `synapse status --json`, and the `/debug/waiting` snapshot. The text output of `synapse list` / `synapse status` annotates the status as `WAITING (renderer: off)` when the renderer is down.
 
 ### Shared Memory Endpoints
 

--- a/.agents/skills/synapse-a2a/references/commands.md
+++ b/.agents/skills/synapse-a2a/references/commands.md
@@ -62,7 +62,9 @@ synapse list --json
 
 **Plain Output:** `synapse list --plain` forces single-shot text output without entering the Rich TUI, even when stdout is a TTY. `SYNAPSE_NONINTERACTIVE=1` provides the same behavior for automation wrappers.
 
-**JSON Output:** `synapse list --json` outputs a JSON array of agent objects (fields: `agent_id`, `agent_type`, `name`, `role`, `skill_set`, `port`, `status`, `pid`, `working_dir`, `endpoint`, `transport`, `current_task_preview`, `task_received_at`, optionally `editing_file`).
+**JSON Output:** `synapse list --json` outputs a JSON array of agent objects (fields: `agent_id`, `agent_type`, `name`, `role`, `skill_set`, `port`, `status`, `pid`, `working_dir`, `endpoint`, `transport`, `current_task_preview`, `task_received_at`, optionally `editing_file`, and `renderer_available` when the controller reports it).
+
+**Renderer state annotation:** when an agent's `PtyRenderer` failed to initialise (for example pyte import failure), the plain-text STATUS column is annotated as `WAITING (renderer: off)` / `READY (renderer: off)` etc. The JSON `status` value itself is unchanged; `renderer_available: false` in the JSON row is the structured equivalent. A missing renderer degrades WAITING detection for ratatui/alt-screen TUIs like Codex — prefer restarting the agent if this persists.
 
 **Name vs ID:** Display shows name if set, internal operations use Runtime ID (`synapse-claude-8100`).
 
@@ -275,15 +277,27 @@ synapse status claude              # Only if single instance
 
 # Machine-readable JSON
 synapse status my-claude --json
+
+# WAITING detection diagnostics (Phase 1 observability)
+synapse status my-claude --debug-waiting
+synapse status my-claude --debug-waiting --json
 ```
 
 **Text output sections:**
-- **Agent Info**: ID, type, name, role, port, status, PID, working directory, uptime
+- **Agent Info**: ID, type, name, role, port, status (with `(renderer: off)` annotation when `PtyRenderer` failed), PID, working directory, uptime
 - **Current Task**: Task preview with elapsed time (e.g., `Review code (2m 15s)`)
 - **Recent Messages**: Last 5 messages from history (task ID, direction, sender, preview)
 - **File Locks**: Files currently locked by this agent (if File Safety is enabled)
 
-**JSON output** includes all the same data in structured format, with `uptime_seconds` and `current_task.elapsed_seconds` as numeric values for programmatic use.
+**JSON output** includes all the same data in structured format, with `uptime_seconds` and `current_task.elapsed_seconds` as numeric values for programmatic use. Adds `renderer_available: bool` when the controller reports it.
+
+**`--debug-waiting`:** prints the last ~50 WAITING-detection attempts recorded in the agent's in-memory ring buffer, plus aggregate counts:
+
+- Total attempts, `pattern_matched` ratio, `path_used` distribution (renderer vs strip_ansi)
+- `confidence` distribution (1.0 primary / 0.6 heuristic / 0.0 miss)
+- `idle_gate_passed=false` count (the "prompt was visible but idle gate dropped it" case — a common Phase 2 investigation target)
+
+Use this when a WAITING prompt did not trip the controller as expected: each attempt carries `new_data_hex_prefix` (raw bytes) and `rendered_text_tail` (what the detector saw) so you can see why the match failed. Data is ephemeral — it disappears on process restart. For long-running collection feed `/debug/waiting` into a JSONL (see Issue #630).
 
 **Use cases:**
 - Checking what an agent is currently working on and how long it has been running

--- a/.claude/skills/synapse-a2a/references/api.md
+++ b/.claude/skills/synapse-a2a/references/api.md
@@ -94,8 +94,44 @@ When a spawned agent hits a permission prompt (e.g., tool approval), the control
 | Endpoint | Method | Description |
 |----------|--------|-------------|
 | `/debug/pty` | GET | Return the pyte-rendered virtual terminal state as JSON (`display`, `cursor`, `alt_screen`, `rows`, `columns`) |
+| `/debug/waiting` | GET | Return the recent WAITING-detection attempts ring buffer plus `renderer_available` |
 
 `GET /debug/pty` exposes exactly what `waiting_detection` regexes see: the raw PTY stream is replayed through a pyte-backed virtual terminal (`PtyRenderer`) so cursor-motion CSI sequences, ratatui-style redraws, and alt-screen overlays are resolved against a real screen before matching. Use it when tuning profile `waiting_detection` patterns or diagnosing why a WAITING prompt was (or was not) detected.
+
+`GET /debug/waiting` returns an in-memory ring buffer (default 50 entries) of recent WAITING detection attempts, one per incoming PTY chunk. Response shape:
+
+```json
+{
+  "renderer_available": true,
+  "attempts": [
+    {
+      "timestamp": 1776819000.12,
+      "profile": "codex",
+      "path_used": "renderer",
+      "renderer_on": true,
+      "pattern_matched": true,
+      "pattern_source": "primary",
+      "confidence": 1.0,
+      "idle_gate_passed": false,
+      "new_data_hex_prefix": "50726f636565643f",
+      "rendered_text_tail": "...Proceed?"
+    }
+  ]
+}
+```
+
+Field meanings:
+- `path_used`: `"renderer"` (pyte virtual terminal path) or `"strip_ansi"` (fallback path)
+- `renderer_on`: whether `PtyRenderer` is initialised on this agent (see `renderer_available` below)
+- `pattern_source`: `"primary"` (profile-specific regex), `"heuristic"` (generic fallback), or `null`
+- `confidence`: `1.0` for primary regex, `0.6` for heuristic, `0.0` for no match
+- `idle_gate_passed`: whether `time_since_output >= waiting_idle_timeout` was satisfied
+- `new_data_hex_prefix`: first 64 bytes of the raw PTY chunk as hex (preserves ANSI/binary data)
+- `rendered_text_tail`: last 256 chars of the rendered (or strip-ANSI'd) text
+
+Returns HTTP 503 when the controller predates Phase 1 (#627). Use `synapse status <agent> --debug-waiting` for formatted aggregates; query this endpoint directly when you need the raw attempts for custom analysis or periodic collection.
+
+**`renderer_available`:** reflects whether `PtyRenderer` initialised successfully for this agent. If pyte failed to start, the agent falls back to the strip-ANSI path (lower fidelity for ratatui TUIs). This field appears in `synapse list --json`, `synapse status --json`, and the `/debug/waiting` snapshot. The text output of `synapse list` / `synapse status` annotates the status as `WAITING (renderer: off)` when the renderer is down.
 
 ### Shared Memory Endpoints
 

--- a/.claude/skills/synapse-a2a/references/commands.md
+++ b/.claude/skills/synapse-a2a/references/commands.md
@@ -62,7 +62,9 @@ synapse list --json
 
 **Plain Output:** `synapse list --plain` forces single-shot text output without entering the Rich TUI, even when stdout is a TTY. `SYNAPSE_NONINTERACTIVE=1` provides the same behavior for automation wrappers.
 
-**JSON Output:** `synapse list --json` outputs a JSON array of agent objects (fields: `agent_id`, `agent_type`, `name`, `role`, `skill_set`, `port`, `status`, `pid`, `working_dir`, `endpoint`, `transport`, `current_task_preview`, `task_received_at`, optionally `editing_file`).
+**JSON Output:** `synapse list --json` outputs a JSON array of agent objects (fields: `agent_id`, `agent_type`, `name`, `role`, `skill_set`, `port`, `status`, `pid`, `working_dir`, `endpoint`, `transport`, `current_task_preview`, `task_received_at`, optionally `editing_file`, and `renderer_available` when the controller reports it).
+
+**Renderer state annotation:** when an agent's `PtyRenderer` failed to initialise (for example pyte import failure), the plain-text STATUS column is annotated as `WAITING (renderer: off)` / `READY (renderer: off)` etc. The JSON `status` value itself is unchanged; `renderer_available: false` in the JSON row is the structured equivalent. A missing renderer degrades WAITING detection for ratatui/alt-screen TUIs like Codex — prefer restarting the agent if this persists.
 
 **Name vs ID:** Display shows name if set, internal operations use Runtime ID (`synapse-claude-8100`).
 
@@ -275,15 +277,27 @@ synapse status claude              # Only if single instance
 
 # Machine-readable JSON
 synapse status my-claude --json
+
+# WAITING detection diagnostics (Phase 1 observability)
+synapse status my-claude --debug-waiting
+synapse status my-claude --debug-waiting --json
 ```
 
 **Text output sections:**
-- **Agent Info**: ID, type, name, role, port, status, PID, working directory, uptime
+- **Agent Info**: ID, type, name, role, port, status (with `(renderer: off)` annotation when `PtyRenderer` failed), PID, working directory, uptime
 - **Current Task**: Task preview with elapsed time (e.g., `Review code (2m 15s)`)
 - **Recent Messages**: Last 5 messages from history (task ID, direction, sender, preview)
 - **File Locks**: Files currently locked by this agent (if File Safety is enabled)
 
-**JSON output** includes all the same data in structured format, with `uptime_seconds` and `current_task.elapsed_seconds` as numeric values for programmatic use.
+**JSON output** includes all the same data in structured format, with `uptime_seconds` and `current_task.elapsed_seconds` as numeric values for programmatic use. Adds `renderer_available: bool` when the controller reports it.
+
+**`--debug-waiting`:** prints the last ~50 WAITING-detection attempts recorded in the agent's in-memory ring buffer, plus aggregate counts:
+
+- Total attempts, `pattern_matched` ratio, `path_used` distribution (renderer vs strip_ansi)
+- `confidence` distribution (1.0 primary / 0.6 heuristic / 0.0 miss)
+- `idle_gate_passed=false` count (the "prompt was visible but idle gate dropped it" case — a common Phase 2 investigation target)
+
+Use this when a WAITING prompt did not trip the controller as expected: each attempt carries `new_data_hex_prefix` (raw bytes) and `rendered_text_tail` (what the detector saw) so you can see why the match failed. Data is ephemeral — it disappears on process restart. For long-running collection feed `/debug/waiting` into a JSONL (see Issue #630).
 
 **Use cases:**
 - Checking what an agent is currently working on and how long it has been running

--- a/plugins/synapse-a2a/skills/synapse-a2a/references/api.md
+++ b/plugins/synapse-a2a/skills/synapse-a2a/references/api.md
@@ -94,8 +94,44 @@ When a spawned agent hits a permission prompt (e.g., tool approval), the control
 | Endpoint | Method | Description |
 |----------|--------|-------------|
 | `/debug/pty` | GET | Return the pyte-rendered virtual terminal state as JSON (`display`, `cursor`, `alt_screen`, `rows`, `columns`) |
+| `/debug/waiting` | GET | Return the recent WAITING-detection attempts ring buffer plus `renderer_available` |
 
 `GET /debug/pty` exposes exactly what `waiting_detection` regexes see: the raw PTY stream is replayed through a pyte-backed virtual terminal (`PtyRenderer`) so cursor-motion CSI sequences, ratatui-style redraws, and alt-screen overlays are resolved against a real screen before matching. Use it when tuning profile `waiting_detection` patterns or diagnosing why a WAITING prompt was (or was not) detected.
+
+`GET /debug/waiting` returns an in-memory ring buffer (default 50 entries) of recent WAITING detection attempts, one per incoming PTY chunk. Response shape:
+
+```json
+{
+  "renderer_available": true,
+  "attempts": [
+    {
+      "timestamp": 1776819000.12,
+      "profile": "codex",
+      "path_used": "renderer",
+      "renderer_on": true,
+      "pattern_matched": true,
+      "pattern_source": "primary",
+      "confidence": 1.0,
+      "idle_gate_passed": false,
+      "new_data_hex_prefix": "50726f636565643f",
+      "rendered_text_tail": "...Proceed?"
+    }
+  ]
+}
+```
+
+Field meanings:
+- `path_used`: `"renderer"` (pyte virtual terminal path) or `"strip_ansi"` (fallback path)
+- `renderer_on`: whether `PtyRenderer` is initialised on this agent (see `renderer_available` below)
+- `pattern_source`: `"primary"` (profile-specific regex), `"heuristic"` (generic fallback), or `null`
+- `confidence`: `1.0` for primary regex, `0.6` for heuristic, `0.0` for no match
+- `idle_gate_passed`: whether `time_since_output >= waiting_idle_timeout` was satisfied
+- `new_data_hex_prefix`: first 64 bytes of the raw PTY chunk as hex (preserves ANSI/binary data)
+- `rendered_text_tail`: last 256 chars of the rendered (or strip-ANSI'd) text
+
+Returns HTTP 503 when the controller predates Phase 1 (#627). Use `synapse status <agent> --debug-waiting` for formatted aggregates; query this endpoint directly when you need the raw attempts for custom analysis or periodic collection.
+
+**`renderer_available`:** reflects whether `PtyRenderer` initialised successfully for this agent. If pyte failed to start, the agent falls back to the strip-ANSI path (lower fidelity for ratatui TUIs). This field appears in `synapse list --json`, `synapse status --json`, and the `/debug/waiting` snapshot. The text output of `synapse list` / `synapse status` annotates the status as `WAITING (renderer: off)` when the renderer is down.
 
 ### Shared Memory Endpoints
 

--- a/plugins/synapse-a2a/skills/synapse-a2a/references/commands.md
+++ b/plugins/synapse-a2a/skills/synapse-a2a/references/commands.md
@@ -62,7 +62,9 @@ synapse list --json
 
 **Plain Output:** `synapse list --plain` forces single-shot text output without entering the Rich TUI, even when stdout is a TTY. `SYNAPSE_NONINTERACTIVE=1` provides the same behavior for automation wrappers.
 
-**JSON Output:** `synapse list --json` outputs a JSON array of agent objects (fields: `agent_id`, `agent_type`, `name`, `role`, `skill_set`, `port`, `status`, `pid`, `working_dir`, `endpoint`, `transport`, `current_task_preview`, `task_received_at`, optionally `editing_file`).
+**JSON Output:** `synapse list --json` outputs a JSON array of agent objects (fields: `agent_id`, `agent_type`, `name`, `role`, `skill_set`, `port`, `status`, `pid`, `working_dir`, `endpoint`, `transport`, `current_task_preview`, `task_received_at`, optionally `editing_file`, and `renderer_available` when the controller reports it).
+
+**Renderer state annotation:** when an agent's `PtyRenderer` failed to initialise (for example pyte import failure), the plain-text STATUS column is annotated as `WAITING (renderer: off)` / `READY (renderer: off)` etc. The JSON `status` value itself is unchanged; `renderer_available: false` in the JSON row is the structured equivalent. A missing renderer degrades WAITING detection for ratatui/alt-screen TUIs like Codex — prefer restarting the agent if this persists.
 
 **Name vs ID:** Display shows name if set, internal operations use Runtime ID (`synapse-claude-8100`).
 
@@ -275,15 +277,27 @@ synapse status claude              # Only if single instance
 
 # Machine-readable JSON
 synapse status my-claude --json
+
+# WAITING detection diagnostics (Phase 1 observability)
+synapse status my-claude --debug-waiting
+synapse status my-claude --debug-waiting --json
 ```
 
 **Text output sections:**
-- **Agent Info**: ID, type, name, role, port, status, PID, working directory, uptime
+- **Agent Info**: ID, type, name, role, port, status (with `(renderer: off)` annotation when `PtyRenderer` failed), PID, working directory, uptime
 - **Current Task**: Task preview with elapsed time (e.g., `Review code (2m 15s)`)
 - **Recent Messages**: Last 5 messages from history (task ID, direction, sender, preview)
 - **File Locks**: Files currently locked by this agent (if File Safety is enabled)
 
-**JSON output** includes all the same data in structured format, with `uptime_seconds` and `current_task.elapsed_seconds` as numeric values for programmatic use.
+**JSON output** includes all the same data in structured format, with `uptime_seconds` and `current_task.elapsed_seconds` as numeric values for programmatic use. Adds `renderer_available: bool` when the controller reports it.
+
+**`--debug-waiting`:** prints the last ~50 WAITING-detection attempts recorded in the agent's in-memory ring buffer, plus aggregate counts:
+
+- Total attempts, `pattern_matched` ratio, `path_used` distribution (renderer vs strip_ansi)
+- `confidence` distribution (1.0 primary / 0.6 heuristic / 0.0 miss)
+- `idle_gate_passed=false` count (the "prompt was visible but idle gate dropped it" case — a common Phase 2 investigation target)
+
+Use this when a WAITING prompt did not trip the controller as expected: each attempt carries `new_data_hex_prefix` (raw bytes) and `rendered_text_tail` (what the detector saw) so you can see why the match failed. Data is ephemeral — it disappears on process restart. For long-running collection feed `/debug/waiting` into a JSONL (see Issue #630).
 
 **Use cases:**
 - Checking what an agent is currently working on and how long it has been running

--- a/site-docs/guide/agent-management.md
+++ b/site-docs/guide/agent-management.md
@@ -325,3 +325,28 @@ Status transitions use **compound signals** to improve accuracy. The PROCESSING-
 This prevents agents from briefly flickering to READY while still processing an injected task or actively editing files. WAITING detection uses **fresh-output-only** matching to avoid false positives from old prompt patterns in the scrollback buffer.
 
 See [Architecture — Compound Signal Detection](../concepts/architecture.md#compound-signal-detection) for technical details.
+
+### Renderer Availability
+
+Each agent wraps its PTY output in a `PtyRenderer` (pyte-backed virtual terminal) so cursor motion, ratatui redraws, and alt-screen overlays are resolved into stable text before `waiting_detection` regexes run. If initialization fails (for example on a pyte import error), the controller falls back to a plain ANSI-stripping path — functional for line-oriented CLIs but less accurate for ratatui-style TUIs like Codex.
+
+Fallback is observable rather than silent:
+
+- `synapse list` / `synapse status` plain-text output annotates the status as `WAITING (renderer: off)` / `READY (renderer: off)` etc. when the renderer is down.
+- `synapse list --json` and `synapse status --json` expose `renderer_available: bool` on each agent.
+- `GET /debug/waiting` returns `renderer_available` at the top level.
+
+If `(renderer: off)` persists on an agent, restart the agent (`synapse kill <id>` then respawn) — renderer failures are per-process and do not recover automatically.
+
+### WAITING Detection Diagnostics (`--debug-waiting`)
+
+`synapse status <agent> --debug-waiting` (added in v0.28.0, see #608/#627) prints the last ~50 WAITING-detection attempts that the agent recorded in-memory, plus aggregate counts:
+
+- Total attempts, `pattern_matched` ratio, `path_used` distribution (renderer vs strip_ansi)
+- `pattern_source` distribution (primary regex / heuristic / none)
+- `confidence` distribution (1.0 primary / 0.6 heuristic / 0.0 miss)
+- `idle_gate_passed=false` count — "prompt was visible but the idle gate dropped it"
+
+Use this when a prompt *should* have flipped the agent to WAITING but did not: each attempt row includes `new_data_hex_prefix` (raw bytes) and `rendered_text_tail` (what the detector saw), so you can diagnose whether the regex missed, the idle gate dropped it, or the renderer garbled it.
+
+The buffer is in-memory only — it empties on process restart. For long-running collection across multiple agents, scrape `GET /debug/waiting` into a JSONL (see [Issue #630](https://github.com/s-hiraoku/synapse-a2a/issues/630), Phase 1.5).


### PR DESCRIPTION
## Summary

Phase 1 WAITING detection observability (#608, #627) shipped five user-visible features that were only mentioned in the CHANGELOG. This PR fills the gap in the skill references and the agent-management guide so agents and humans can actually discover how to use them.

## What's documented

| Feature | File |
|---|---|
| \`GET /debug/waiting\` endpoint — response shape, field meanings, 503 fallback | \`plugins/synapse-a2a/skills/synapse-a2a/references/api.md\` |
| \`synapse status --debug-waiting\` flag + aggregate output | \`plugins/synapse-a2a/skills/synapse-a2a/references/commands.md\` |
| \`renderer_available\` field in \`list\` / \`status\` JSON | \`plugins/synapse-a2a/skills/synapse-a2a/references/commands.md\` |
| \`(renderer: off)\` text annotation | \`plugins/synapse-a2a/skills/synapse-a2a/references/commands.md\` + \`site-docs/guide/agent-management.md\` |
| PtyRenderer fallback behavior + diagnostic workflow | \`site-docs/guide/agent-management.md\` (new \"Renderer Availability\" and \"WAITING Detection Diagnostics\" subsections) |

Canonical skill updates mirrored to \`.agents/skills/\` and \`.claude/skills/\`.

## Scope

Docs only. No code changes.

## Related

- Phase 1 implementation: #627
- Phase 1.5 collection pipeline (persist snapshots across restarts): #630

## Test plan

- [ ] CI green
- [ ] Mirrors match canonical (\`diff -q\` passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)