### PR TITLE
feat: add waiting-debug collection pipeline (#630)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,8 @@ venv/
 .synapse/*.db
 .synapse/*.db-shm
 .synapse/*.db-wal
+.synapse/waiting_debug.jsonl
+.synapse/waiting_debug.*
 
 # OS
 .DS_Store

--- a/docs/phase15-collection.md
+++ b/docs/phase15-collection.md
@@ -1,0 +1,112 @@
+# Phase 1.5 WAITING Debug Collection
+
+Phase 1.5 persists the in-memory WAITING detection debug data exposed by
+`GET /debug/waiting`. It does not change WAITING detection logic; it only
+collects snapshots for later Phase 2 analysis.
+
+## Collect Snapshots
+
+Run a one-shot collection across registered agents:
+
+```bash
+synapse waiting-debug collect
+```
+
+By default, records are appended to `~/.synapse/waiting_debug.jsonl`. The file
+is user-scoped so data can accumulate across projects. Each JSONL row has this
+shape:
+
+```json
+{
+  "agent_id": "synapse-codex-8123",
+  "agent_type": "codex",
+  "port": 8123,
+  "collected_at": "2026-04-23T01:00:00+00:00",
+  "snapshot": {
+    "renderer_available": true,
+    "attempts": []
+  }
+}
+```
+
+Useful options:
+
+```bash
+synapse waiting-debug collect --out /tmp/waiting_debug.jsonl
+synapse waiting-debug collect --agent synapse-codex-8123
+synapse waiting-debug collect --include-empty
+```
+
+The collector warns on stderr when one agent cannot be reached and continues
+collecting the remaining agents.
+
+## Report Aggregates
+
+Print a human-readable report:
+
+```bash
+synapse waiting-debug report
+```
+
+Filter by time or agent:
+
+```bash
+synapse waiting-debug report --since 2026-04-23T00:00:00+00:00
+synapse waiting-debug report --agent synapse-codex-8123
+```
+
+Produce machine-readable JSON for Phase 2 analysis:
+
+```bash
+synapse waiting-debug report --json
+```
+
+The report includes profile, `pattern_source`, `path_used`, and `confidence`
+distributions, plus idle-gate drop counts and the ratio of agents whose
+snapshot reported `renderer_available=false`.
+
+## Run Every Five Minutes
+
+There is no `synapse schedule` CLI in this version. Use cron or launchd to run
+collection every five minutes.
+
+Cron example:
+
+```cron
+*/5 * * * * /usr/bin/env synapse waiting-debug collect >> ~/.synapse/waiting_debug_collect.log 2>&1
+```
+
+Launchd example for macOS, saved as
+`~/Library/LaunchAgents/dev.synapse.waiting-debug.plist`:
+replace `your-user` with the local macOS account name.
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>dev.synapse.waiting-debug</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/bin/env</string>
+    <string>synapse</string>
+    <string>waiting-debug</string>
+    <string>collect</string>
+  </array>
+  <key>StartInterval</key>
+  <integer>300</integer>
+  <key>StandardOutPath</key>
+  <string>/Users/your-user/.synapse/waiting_debug_collect.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Users/your-user/.synapse/waiting_debug_collect.err</string>
+</dict>
+</plist>
+```
+
+Load it with:
+
+```bash
+launchctl load ~/Library/LaunchAgents/dev.synapse.waiting-debug.plist
+```

--- a/synapse/cli.py
+++ b/synapse/cli.py
@@ -98,6 +98,7 @@ from synapse.commands.spawn_cmd import (
     cmd_team_start,
 )
 from synapse.commands.start import StartCommand
+from synapse.commands.waiting_debug import cmd_waiting_debug
 from synapse.commands.workflow import (
     cmd_workflow_create,
     cmd_workflow_delete,
@@ -3199,6 +3200,63 @@ Status meanings:
         help="Show recent WAITING detection attempts and aggregate diagnostics",
     )
     p_status.set_defaults(func=cmd_status)
+
+    # waiting-debug
+    p_waiting_debug = subparsers.add_parser(
+        "waiting-debug",
+        help="Collect and report WAITING detection debug snapshots",
+        description="Collect and report WAITING detection debug snapshots.",
+    )
+    waiting_debug_subparsers = p_waiting_debug.add_subparsers(
+        dest="waiting_debug_command", metavar="SUBCOMMAND"
+    )
+    p_waiting_collect = waiting_debug_subparsers.add_parser(
+        "collect",
+        help="Collect /debug/waiting snapshots from registered agents",
+    )
+    p_waiting_collect.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="JSONL output path (default: ~/.synapse/waiting_debug.jsonl)",
+    )
+    p_waiting_collect.add_argument(
+        "--agent",
+        help="Collect only the specified agent ID",
+    )
+    p_waiting_collect.add_argument(
+        "--include-empty",
+        action="store_true",
+        help="Record agents whose debug endpoint has no attempts",
+    )
+    p_waiting_collect.set_defaults(func=cmd_waiting_debug)
+
+    p_waiting_report = waiting_debug_subparsers.add_parser(
+        "report",
+        help="Aggregate collected WAITING debug JSONL data",
+    )
+    p_waiting_report.add_argument(
+        "--in",
+        dest="input",
+        type=Path,
+        default=None,
+        help="JSONL input path (default: ~/.synapse/waiting_debug.jsonl)",
+    )
+    p_waiting_report.add_argument(
+        "--since",
+        help="Only include records collected at or after this ISO timestamp",
+    )
+    p_waiting_report.add_argument(
+        "--agent",
+        help="Only include records for the specified agent ID",
+    )
+    p_waiting_report.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Output aggregate data as JSON",
+    )
+    p_waiting_report.set_defaults(func=cmd_waiting_debug)
 
     # logs
     p_logs = subparsers.add_parser(

--- a/synapse/commands/waiting_debug.py
+++ b/synapse/commands/waiting_debug.py
@@ -1,0 +1,371 @@
+"""WAITING detection debug collection and reporting commands."""
+
+from __future__ import annotations
+
+import json
+import sys
+import urllib.error
+import urllib.request
+from collections import Counter
+from collections.abc import Callable
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import IO, Any, Protocol
+
+from synapse.registry import AgentRegistry
+
+DEFAULT_WAITING_DEBUG_PATH = Path.home() / ".synapse" / "waiting_debug.jsonl"
+
+
+class AgentRegistryLike(Protocol):
+    def list_agents(self) -> dict[str, dict[str, Any]]: ...
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _http_get_json(url: str) -> dict[str, Any]:
+    with urllib.request.urlopen(url, timeout=3.0) as response:
+        payload = response.read().decode("utf-8")
+    data = json.loads(payload)
+    return data if isinstance(data, dict) else {}
+
+
+class WaitingDebugCollector:
+    """Collect `/debug/waiting` snapshots from registered agents."""
+
+    def __init__(
+        self,
+        registry: AgentRegistryLike | None = None,
+        fetcher: Callable[[str], dict[str, Any]] | None = None,
+        clock: Callable[[], str] | None = None,
+        stderr: IO[str] | None = None,
+    ) -> None:
+        self._registry = registry or AgentRegistry()
+        self._fetcher = fetcher or _http_get_json
+        self._clock = clock or _now_iso
+        self._stderr = stderr or sys.stderr
+
+    def collect(
+        self,
+        *,
+        out_path: Path | str = DEFAULT_WAITING_DEBUG_PATH,
+        agent_id: str | None = None,
+        include_empty: bool = False,
+    ) -> int:
+        """Collect waiting debug snapshots and append them as JSONL records."""
+        path = Path(out_path).expanduser()
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+        written = 0
+        with path.open("a", encoding="utf-8") as output:
+            for current_agent_id, info in self._iter_agents(agent_id):
+                endpoint = self._endpoint_for(info)
+                if not endpoint:
+                    self._warn(current_agent_id, "missing endpoint and port")
+                    continue
+
+                try:
+                    snapshot = self._fetcher(f"{endpoint}/debug/waiting")
+                except (
+                    OSError,
+                    TimeoutError,
+                    urllib.error.URLError,
+                    json.JSONDecodeError,
+                    ValueError,
+                ) as exc:
+                    self._warn(current_agent_id, str(exc))
+                    continue
+
+                attempts = snapshot.get("attempts")
+                if not isinstance(attempts, list):
+                    attempts = []
+                    snapshot["attempts"] = attempts
+                if not attempts and not include_empty:
+                    continue
+
+                output.write(
+                    json.dumps(
+                        {
+                            "agent_id": current_agent_id,
+                            "agent_type": info.get("agent_type"),
+                            "port": info.get("port"),
+                            "collected_at": self._clock(),
+                            "snapshot": snapshot,
+                        },
+                        sort_keys=True,
+                    )
+                    + "\n"
+                )
+                written += 1
+
+        return written
+
+    def _iter_agents(self, agent_id: str | None) -> list[tuple[str, dict[str, Any]]]:
+        agents = self._registry.list_agents()
+        if agent_id is not None:
+            info = agents.get(agent_id)
+            return [(agent_id, info)] if info is not None else []
+        return list(agents.items())
+
+    def _endpoint_for(self, info: dict[str, Any]) -> str | None:
+        endpoint = info.get("endpoint")
+        if isinstance(endpoint, str) and endpoint:
+            return endpoint.rstrip("/")
+        port = info.get("port")
+        if isinstance(port, int):
+            return f"http://localhost:{port}"
+        return None
+
+    def _warn(self, agent_id: str, reason: str) -> None:
+        print(
+            f"Warning: failed to collect waiting debug for {agent_id}: {reason}",
+            file=self._stderr,
+        )
+
+
+class WaitingDebugReporter:
+    """Aggregate waiting debug JSONL records."""
+
+    def __init__(
+        self,
+        output: IO[str] | None = None,
+        stderr: IO[str] | None = None,
+    ) -> None:
+        self._output = output or sys.stdout
+        self._stderr = stderr or sys.stderr
+
+    def report(
+        self,
+        *,
+        input_path: Path | str = DEFAULT_WAITING_DEBUG_PATH,
+        since: str | None = None,
+        agent_id: str | None = None,
+        json_output: bool = False,
+    ) -> dict[str, Any]:
+        records = list(
+            self._iter_records(Path(input_path).expanduser(), since, agent_id)
+        )
+        result = self._aggregate(records, since)
+
+        if json_output:
+            self._output.write(json.dumps(result, indent=2, sort_keys=True) + "\n")
+        else:
+            self._render_text(result)
+
+        return result
+
+    def _iter_records(
+        self, path: Path, since: str | None, agent_id: str | None
+    ) -> list[dict[str, Any]]:
+        if not path.exists():
+            return []
+
+        since_dt = _parse_iso_datetime(since) if since else None
+        records: list[dict[str, Any]] = []
+
+        with path.open(encoding="utf-8") as input_file:
+            for line_number, line in enumerate(input_file, start=1):
+                if not line.strip():
+                    continue
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError as exc:
+                    print(
+                        f"Warning: skipping invalid JSONL line {line_number}: {exc}",
+                        file=self._stderr,
+                    )
+                    continue
+                if not isinstance(record, dict):
+                    continue
+                if agent_id is not None and record.get("agent_id") != agent_id:
+                    continue
+                if since_dt is not None and not _record_is_since(record, since_dt):
+                    continue
+                records.append(record)
+
+        return records
+
+    def _aggregate(
+        self, records: list[dict[str, Any]], since: str | None
+    ) -> dict[str, Any]:
+        profiles: Counter[str] = Counter()
+        pattern_source: Counter[str] = Counter()
+        path_used: Counter[str] = Counter()
+        confidence: Counter[str] = Counter()
+        idle_gate_drops = 0
+        total_attempts = 0
+        agents_seen: set[str] = set()
+        renderer_unavailable_agents: set[str] = set()
+        collected_at_values: list[str] = []
+
+        for record in records:
+            agent_key = str(record.get("agent_id") or "")
+            if agent_key:
+                agents_seen.add(agent_key)
+            collected_at = record.get("collected_at")
+            if isinstance(collected_at, str):
+                collected_at_values.append(collected_at)
+
+            snapshot = record.get("snapshot")
+            if not isinstance(snapshot, dict):
+                snapshot = {}
+            if snapshot.get("renderer_available") is False and agent_key:
+                renderer_unavailable_agents.add(agent_key)
+
+            attempts = snapshot.get("attempts")
+            if not isinstance(attempts, list):
+                continue
+
+            for attempt in attempts:
+                if not isinstance(attempt, dict):
+                    continue
+                total_attempts += 1
+                profiles[_label(attempt.get("profile"), record.get("agent_type"))] += 1
+                pattern_source[_label(attempt.get("pattern_source"), "none")] += 1
+                path_used[_label(attempt.get("path_used"), "none")] += 1
+                confidence[_confidence_label(attempt.get("confidence"))] += 1
+                if (
+                    attempt.get("pattern_matched") is True
+                    and attempt.get("idle_gate_passed") is not True
+                ):
+                    idle_gate_drops += 1
+
+        renderer_total = len(agents_seen)
+        renderer_count = len(renderer_unavailable_agents)
+        return {
+            "period": {
+                "since": since,
+                "first_collected_at": min(collected_at_values)
+                if collected_at_values
+                else None,
+                "last_collected_at": max(collected_at_values)
+                if collected_at_values
+                else None,
+            },
+            "total_attempts": total_attempts,
+            "profiles": _sorted_dict(profiles),
+            "pattern_source": _sorted_dict(pattern_source),
+            "path_used": _sorted_dict(path_used),
+            "confidence": _sorted_dict(confidence),
+            "idle_gate_drops": {
+                "count": idle_gate_drops,
+                "total": total_attempts,
+                "ratio": _ratio(idle_gate_drops, total_attempts),
+            },
+            "renderer_unavailable_agents": {
+                "count": renderer_count,
+                "total": renderer_total,
+                "ratio": _ratio(renderer_count, renderer_total),
+            },
+        }
+
+    def _render_text(self, result: dict[str, Any]) -> None:
+        period = result["period"]
+        self._writeln("=== Waiting Debug Report ===")
+        self._writeln(f"Since:           {period.get('since') or '-'}")
+        self._writeln(f"First collected: {period.get('first_collected_at') or '-'}")
+        self._writeln(f"Last collected:  {period.get('last_collected_at') or '-'}")
+        self._writeln(f"Total attempts: {result['total_attempts']}")
+        self._writeln()
+        self._writeln("--- By profile ---")
+        self._writeln(f"Profiles: {_format_counter(result['profiles'])}")
+        self._writeln()
+        self._writeln("--- Pattern source ---")
+        self._writeln(f"Pattern source: {_format_counter(result['pattern_source'])}")
+        self._writeln()
+        self._writeln("--- Path used ---")
+        self._writeln(f"Path used: {_format_counter(result['path_used'])}")
+        self._writeln()
+        self._writeln("--- Confidence ---")
+        self._writeln(f"Confidence: {_format_counter(result['confidence'])}")
+        self._writeln()
+        self._writeln("--- Idle gate drops ---")
+        drops = result["idle_gate_drops"]
+        self._writeln(
+            "Idle gate drops: "
+            f"{drops['count']}/{drops['total']} ({drops['ratio'] * 100:.1f}%)"
+        )
+        self._writeln()
+        self._writeln("--- Renderer unavailable ---")
+        renderer = result["renderer_unavailable_agents"]
+        self._writeln(
+            "Renderer unavailable agents: "
+            f"{renderer['count']}/{renderer['total']} "
+            f"({renderer['ratio'] * 100:.1f}%)"
+        )
+
+    def _writeln(self, text: str = "") -> None:
+        self._output.write(text + "\n")
+
+
+def cmd_waiting_debug(args: Any) -> None:
+    """Dispatch waiting-debug subcommands."""
+    subcommand = getattr(args, "waiting_debug_command", None)
+    if subcommand == "collect":
+        collector = WaitingDebugCollector()
+        written = collector.collect(
+            out_path=getattr(args, "out", None) or DEFAULT_WAITING_DEBUG_PATH,
+            agent_id=getattr(args, "agent", None),
+            include_empty=getattr(args, "include_empty", False),
+        )
+        print(f"Collected {written} waiting debug snapshot(s)")
+        return
+
+    if subcommand == "report":
+        reporter = WaitingDebugReporter()
+        reporter.report(
+            input_path=getattr(args, "input", None) or DEFAULT_WAITING_DEBUG_PATH,
+            since=getattr(args, "since", None),
+            agent_id=getattr(args, "agent", None),
+            json_output=getattr(args, "json_output", False),
+        )
+        return
+
+    raise SystemExit("Specify a waiting-debug subcommand.")
+
+
+def _parse_iso_datetime(value: str | None) -> datetime | None:
+    if value is None:
+        return None
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _record_is_since(record: dict[str, Any], since_dt: datetime) -> bool:
+    collected_at = record.get("collected_at")
+    if not isinstance(collected_at, str):
+        return False
+    collected_dt = _parse_iso_datetime(collected_at)
+    if collected_dt is None:
+        return False
+    return collected_dt >= since_dt
+
+
+def _label(value: Any, fallback: Any) -> str:
+    if value is None or value == "":
+        return str(fallback if fallback not in (None, "") else "none")
+    return str(value)
+
+
+def _confidence_label(value: Any) -> str:
+    if isinstance(value, int | float):
+        return f"{float(value):.1f}"
+    return _label(value, "none")
+
+
+def _ratio(count: int, total: int) -> float:
+    return count / total if total else 0.0
+
+
+def _sorted_dict(counter: Counter[str]) -> dict[str, int]:
+    return {key: counter[key] for key in sorted(counter)}
+
+
+def _format_counter(values: dict[str, int]) -> str:
+    if not values:
+        return "-"
+    return ", ".join(f"{key}={values[key]}" for key in sorted(values))

--- a/tests/test_waiting_debug_cli.py
+++ b/tests/test_waiting_debug_cli.py
@@ -10,12 +10,11 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import patch
 
+from synapse.cli import main
 from synapse.commands.waiting_debug import (
     WaitingDebugCollector,
     WaitingDebugReporter,
 )
-
-from synapse.cli import main
 
 
 class FakeRegistry:

--- a/tests/test_waiting_debug_cli.py
+++ b/tests/test_waiting_debug_cli.py
@@ -1,0 +1,395 @@
+"""Tests for WAITING debug collection and reporting CLI."""
+
+from __future__ import annotations
+
+import json
+import sys
+import urllib.error
+from io import StringIO
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+from synapse.commands.waiting_debug import (
+    WaitingDebugCollector,
+    WaitingDebugReporter,
+)
+
+from synapse.cli import main
+
+
+class FakeRegistry:
+    def __init__(self, agents: dict[str, dict[str, Any]]) -> None:
+        self._agents = agents
+
+    def list_agents(self) -> dict[str, dict[str, Any]]:
+        return self._agents
+
+
+def _agent(
+    agent_id: str,
+    agent_type: str,
+    port: int,
+    endpoint: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "agent_id": agent_id,
+        "agent_type": agent_type,
+        "port": port,
+        "status": "READY",
+        "endpoint": endpoint or f"http://localhost:{port}",
+    }
+
+
+def _snapshot(*attempts: dict[str, Any], renderer_available: bool = True) -> dict:
+    return {
+        "renderer_available": renderer_available,
+        "attempts": list(attempts),
+    }
+
+
+def _attempt(
+    *,
+    profile: str = "codex",
+    pattern_source: str | None = "primary",
+    path_used: str = "renderer",
+    confidence: float = 1.0,
+    pattern_matched: bool = True,
+    idle_gate_passed: bool = True,
+) -> dict[str, Any]:
+    return {
+        "timestamp": 1776814438.0,
+        "profile": profile,
+        "pattern_source": pattern_source,
+        "path_used": path_used,
+        "confidence": confidence,
+        "pattern_matched": pattern_matched,
+        "idle_gate_passed": idle_gate_passed,
+    }
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    return [json.loads(line) for line in path.read_text().splitlines()]
+
+
+def test_collect_appends_one_jsonl_record_per_agent_with_attempts(tmp_path: Path):
+    out_path = tmp_path / "waiting_debug.jsonl"
+    out_path.write_text('{"existing": true}\n')
+    agents = {
+        "synapse-codex-8123": _agent("synapse-codex-8123", "codex", 8123),
+        "synapse-claude-8100": _agent("synapse-claude-8100", "claude", 8100),
+    }
+    payloads = {
+        "http://localhost:8123/debug/waiting": _snapshot(_attempt()),
+        "http://localhost:8100/debug/waiting": _snapshot(),
+    }
+    collector = WaitingDebugCollector(
+        registry=FakeRegistry(agents),
+        fetcher=payloads.__getitem__,
+        clock=lambda: "2026-04-23T10:00:00+09:00",
+    )
+
+    written = collector.collect(out_path=out_path)
+
+    records = _read_jsonl(out_path)
+    assert written == 1
+    assert records[0] == {"existing": True}
+    assert len(records) == 2
+    record = records[1]
+    assert record["agent_id"] == "synapse-codex-8123"
+    assert record["agent_type"] == "codex"
+    assert record["port"] == 8123
+    assert record["collected_at"] == "2026-04-23T10:00:00+09:00"
+    assert record["snapshot"]["attempts"][0]["pattern_source"] == "primary"
+
+
+def test_collect_include_empty_records_agents_without_attempts(tmp_path: Path):
+    out_path = tmp_path / "waiting_debug.jsonl"
+    agents = {
+        "synapse-claude-8100": _agent("synapse-claude-8100", "claude", 8100),
+    }
+    collector = WaitingDebugCollector(
+        registry=FakeRegistry(agents),
+        fetcher=lambda url: _snapshot(),
+        clock=lambda: "2026-04-23T10:00:00+09:00",
+    )
+
+    written = collector.collect(out_path=out_path, include_empty=True)
+
+    records = _read_jsonl(out_path)
+    assert written == 1
+    assert records[0]["agent_id"] == "synapse-claude-8100"
+    assert records[0]["snapshot"]["attempts"] == []
+
+
+def test_collect_continues_after_endpoint_error(tmp_path: Path):
+    out_path = tmp_path / "waiting_debug.jsonl"
+    warnings = StringIO()
+    agents = {
+        "synapse-claude-8100": _agent("synapse-claude-8100", "claude", 8100),
+        "synapse-codex-8123": _agent("synapse-codex-8123", "codex", 8123),
+    }
+
+    def fetcher(url: str) -> dict[str, Any]:
+        if url == "http://localhost:8100/debug/waiting":
+            raise urllib.error.URLError("connection refused")
+        return _snapshot(_attempt(profile="codex"))
+
+    collector = WaitingDebugCollector(
+        registry=FakeRegistry(agents),
+        fetcher=fetcher,
+        clock=lambda: "2026-04-23T10:00:00+09:00",
+        stderr=warnings,
+    )
+
+    written = collector.collect(out_path=out_path)
+
+    records = _read_jsonl(out_path)
+    assert written == 1
+    assert records[0]["agent_id"] == "synapse-codex-8123"
+    assert "Warning:" in warnings.getvalue()
+    assert "synapse-claude-8100" in warnings.getvalue()
+
+
+def test_collect_agent_filter_limits_collection(tmp_path: Path):
+    out_path = tmp_path / "waiting_debug.jsonl"
+    agents = {
+        "synapse-claude-8100": _agent("synapse-claude-8100", "claude", 8100),
+        "synapse-codex-8123": _agent("synapse-codex-8123", "codex", 8123),
+    }
+    fetched_urls: list[str] = []
+
+    def fetcher(url: str) -> dict[str, Any]:
+        fetched_urls.append(url)
+        return _snapshot(_attempt(profile="codex"))
+
+    collector = WaitingDebugCollector(
+        registry=FakeRegistry(agents),
+        fetcher=fetcher,
+        clock=lambda: "2026-04-23T10:00:00+09:00",
+    )
+
+    collector.collect(out_path=out_path, agent_id="synapse-codex-8123")
+
+    assert fetched_urls == ["http://localhost:8123/debug/waiting"]
+    assert _read_jsonl(out_path)[0]["agent_id"] == "synapse-codex-8123"
+
+
+def test_report_aggregates_waiting_debug_jsonl(tmp_path: Path):
+    input_path = tmp_path / "waiting_debug.jsonl"
+    input_path.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "agent_id": "synapse-codex-8123",
+                        "agent_type": "codex",
+                        "port": 8123,
+                        "collected_at": "2026-04-23T10:00:00+09:00",
+                        "snapshot": _snapshot(
+                            _attempt(
+                                profile="codex",
+                                pattern_source="primary",
+                                path_used="renderer",
+                                confidence=1.0,
+                                pattern_matched=True,
+                                idle_gate_passed=False,
+                            ),
+                            _attempt(
+                                profile="codex",
+                                pattern_source=None,
+                                path_used="strip_ansi",
+                                confidence=0.0,
+                                pattern_matched=False,
+                                idle_gate_passed=False,
+                            ),
+                            renderer_available=False,
+                        ),
+                    }
+                ),
+                json.dumps(
+                    {
+                        "agent_id": "synapse-claude-8100",
+                        "agent_type": "claude",
+                        "port": 8100,
+                        "collected_at": "2026-04-23T10:05:00+09:00",
+                        "snapshot": _snapshot(
+                            _attempt(
+                                profile="claude",
+                                pattern_source="heuristic",
+                                path_used="renderer",
+                                confidence=0.6,
+                            ),
+                            renderer_available=True,
+                        ),
+                    }
+                ),
+            ]
+        )
+        + "\n"
+    )
+    output = StringIO()
+    reporter = WaitingDebugReporter(output=output)
+
+    result = reporter.report(input_path=input_path)
+
+    assert result["total_attempts"] == 3
+    assert result["profiles"] == {"claude": 1, "codex": 2}
+    assert result["pattern_source"] == {"heuristic": 1, "none": 1, "primary": 1}
+    assert result["path_used"] == {"renderer": 2, "strip_ansi": 1}
+    assert result["confidence"] == {"0.0": 1, "0.6": 1, "1.0": 1}
+    assert result["idle_gate_drops"]["count"] == 1
+    assert result["idle_gate_drops"]["ratio"] == 1 / 3
+    assert result["renderer_unavailable_agents"]["count"] == 1
+    assert result["renderer_unavailable_agents"]["total"] == 2
+    assert result["renderer_unavailable_agents"]["ratio"] == 0.5
+    text = output.getvalue()
+    assert "Total attempts: 3" in text
+    assert "Profiles: claude=1, codex=2" in text
+    assert "Pattern source: heuristic=1, none=1, primary=1" in text
+    assert "Path used: renderer=2, strip_ansi=1" in text
+    assert "Confidence: 0.0=1, 0.6=1, 1.0=1" in text
+    assert "Idle gate drops: 1/3 (33.3%)" in text
+    assert "Renderer unavailable agents: 1/2 (50.0%)" in text
+
+
+def test_report_json_output_since_and_agent_filter(tmp_path: Path):
+    input_path = tmp_path / "waiting_debug.jsonl"
+    input_path.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "agent_id": "synapse-codex-8123",
+                        "agent_type": "codex",
+                        "port": 8123,
+                        "collected_at": "2026-04-23T09:55:00+09:00",
+                        "snapshot": _snapshot(_attempt(profile="codex")),
+                    }
+                ),
+                json.dumps(
+                    {
+                        "agent_id": "synapse-codex-8123",
+                        "agent_type": "codex",
+                        "port": 8123,
+                        "collected_at": "2026-04-23T10:05:00+09:00",
+                        "snapshot": _snapshot(
+                            _attempt(
+                                profile="codex",
+                                pattern_source="heuristic",
+                                confidence=0.6,
+                            )
+                        ),
+                    }
+                ),
+                json.dumps(
+                    {
+                        "agent_id": "synapse-claude-8100",
+                        "agent_type": "claude",
+                        "port": 8100,
+                        "collected_at": "2026-04-23T10:06:00+09:00",
+                        "snapshot": _snapshot(_attempt(profile="claude")),
+                    }
+                ),
+            ]
+        )
+        + "\n"
+    )
+    output = StringIO()
+    reporter = WaitingDebugReporter(output=output)
+
+    result = reporter.report(
+        input_path=input_path,
+        since="2026-04-23T10:00:00+09:00",
+        agent_id="synapse-codex-8123",
+        json_output=True,
+    )
+
+    emitted = json.loads(output.getvalue())
+    assert emitted == result
+    assert emitted["period"]["since"] == "2026-04-23T10:00:00+09:00"
+    assert emitted["total_attempts"] == 1
+    assert emitted["profiles"] == {"codex": 1}
+    assert emitted["pattern_source"] == {"heuristic": 1}
+
+
+def test_report_skips_invalid_jsonl_lines_with_warning(tmp_path: Path):
+    input_path = tmp_path / "waiting_debug.jsonl"
+    input_path.write_text(
+        "\n".join(
+            [
+                "{not json",
+                json.dumps(
+                    {
+                        "agent_id": "synapse-codex-8123",
+                        "agent_type": "codex",
+                        "port": 8123,
+                        "collected_at": "2026-04-23T10:00:00+09:00",
+                        "snapshot": _snapshot(_attempt(profile="codex")),
+                    }
+                ),
+            ]
+        )
+        + "\n"
+    )
+    warnings = StringIO()
+    reporter = WaitingDebugReporter(output=StringIO(), stderr=warnings)
+
+    result = reporter.report(input_path=input_path)
+
+    assert result["total_attempts"] == 1
+    assert "Warning:" in warnings.getvalue()
+    assert "line 1" in warnings.getvalue()
+
+
+def test_waiting_debug_cli_parses_collect_and_report_subcommands(tmp_path: Path):
+    with patch("synapse.cli.cmd_waiting_debug") as mock_cmd:
+        with patch.object(
+            sys,
+            "argv",
+            [
+                "synapse",
+                "waiting-debug",
+                "collect",
+                "--out",
+                str(tmp_path / "out.jsonl"),
+                "--agent",
+                "synapse-codex-8123",
+                "--include-empty",
+            ],
+        ):
+            main()
+
+        collect_args = mock_cmd.call_args.args[0]
+        assert collect_args.command == "waiting-debug"
+        assert collect_args.waiting_debug_command == "collect"
+        assert collect_args.out == tmp_path / "out.jsonl"
+        assert collect_args.agent == "synapse-codex-8123"
+        assert collect_args.include_empty is True
+
+    with patch("synapse.cli.cmd_waiting_debug") as mock_cmd:
+        with patch.object(
+            sys,
+            "argv",
+            [
+                "synapse",
+                "waiting-debug",
+                "report",
+                "--in",
+                str(tmp_path / "in.jsonl"),
+                "--since",
+                "2026-04-23T10:00:00+09:00",
+                "--agent",
+                "synapse-codex-8123",
+                "--json",
+            ],
+        ):
+            main()
+
+        report_args = mock_cmd.call_args.args[0]
+        assert report_args.command == "waiting-debug"
+        assert report_args.waiting_debug_command == "report"
+        assert report_args.input == tmp_path / "in.jsonl"
+        assert report_args.since == "2026-04-23T10:00:00+09:00"
+        assert report_args.agent == "synapse-codex-8123"
+        assert report_args.json_output is True


### PR DESCRIPTION
## Summary

- Add `synapse waiting-debug collect` to append `/debug/waiting` snapshots to user-scoped JSONL at `~/.synapse/waiting_debug.jsonl`.
- Add `synapse waiting-debug report` with text and JSON aggregate output for Phase 2 analysis.
- Document five-minute collection via cron/launchd and ignore project-local waiting debug artifacts.

## Scope

Phase 1.5 のみ。検出ロジック変更は Phase 2。

## Verification

- `uv run ruff check`
- `uv run mypy synapse/commands/waiting_debug.py`
- `uv run pytest tests/test_waiting_debug_cli.py -v`
- `env HOME=/tmp/synapse-test-home uv run pytest` (4207 passed, 29 skipped, 1 warning)

Note: a non-isolated full test run failed 5 pre-existing environment-sensitive tests due to ambient `~/.synapse` files/env; the same failures passed under isolated `HOME=/tmp/synapse-test-home`.