### PR TITLE
feat(ci): auto-resolve workflow for mechanical merge conflicts

### DIFF
--- a/.github/workflows/auto-resolve-conflicts.yml
+++ b/.github/workflows/auto-resolve-conflicts.yml
@@ -83,6 +83,9 @@ jobs:
         with:
           ref: ${{ steps.meta.outputs.head }}
           fetch-depth: 0
+          # Don't leave the GITHUB_TOKEN in .git/config; we push explicitly
+          # later with a scoped URL so subsequent steps can't leak the token.
+          persist-credentials: false
 
       - name: Poll mergeable status
         id: mergeable
@@ -199,19 +202,54 @@ jobs:
             echo "resolved=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Commit and push if resolved
+      - name: Validate staged files against allowlist
+        id: validate
         if: steps.resolve.outputs.resolved == 'true'
         run: |
           set -euo pipefail
+          # Defense-in-depth: a malicious PR could in theory alter the
+          # merge_* scripts to `git add` arbitrary files before the commit.
+          # Ensure the staged set is exactly the four paths we expect to
+          # touch; bail out otherwise.
+          staged=$(git diff --cached --name-only | sort -u)
+          echo "--- staged files ---"
+          echo "$staged"
+          echo "--------------------"
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            case "$f" in
+              CHANGELOG.md|uv.lock|pyproject.toml) ;;
+              plugins/*/.claude-plugin/plugin.json) ;;
+              *)
+                echo "ERROR: unexpected staged file '$f' — refusing to commit."
+                exit 1
+                ;;
+            esac
+          done <<< "$staged"
+
+      - name: Commit and push if resolved
+        if: steps.resolve.outputs.resolved == 'true' && steps.validate.outcome == 'success'
+        env:
+          PUSH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
           git commit -m "chore: auto-resolve mechanical merge conflicts with ${{ steps.meta.outputs.base }}"
-          git push origin HEAD:${{ steps.meta.outputs.head }}
+          # Push using an explicit one-shot URL rather than the persisted
+          # credential (disabled via persist-credentials: false).
+          git push "https://x-access-token:${PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+            "HEAD:${{ steps.meta.outputs.head }}"
           gh pr edit ${{ matrix.pr }} --remove-label needs-manual-rebase 2>/dev/null || true
 
       - name: Bail out — label for manual rebase
+        # Without `!cancelled()`, the default `success()` check would skip
+        # this step whenever "Mechanical resolve" or "Validate staged files"
+        # errors out — which is exactly when the label is most needed.
         if: |
+          !cancelled() &&
           steps.merge.outputs.conflict == 'true' && (
             steps.scope.outputs.mechanical != 'true' ||
-            steps.resolve.outputs.resolved != 'true'
+            steps.resolve.outputs.resolved != 'true' ||
+            steps.validate.outcome == 'failure'
           )
         run: |
           set -euo pipefail

--- a/.github/workflows/auto-resolve-conflicts.yml
+++ b/.github/workflows/auto-resolve-conflicts.yml
@@ -1,0 +1,224 @@
+name: Auto Resolve Mechanical Conflicts
+
+# Automatically resolves "mechanical" merge conflicts (CHANGELOG append,
+# uv.lock regeneration, version-line conflicts). Anything else gets a
+# "needs-manual-rebase" label for human/agent review.
+#
+# Trigger design:
+#   - push to main          → re-evaluate every open PR (base moved)
+#   - pull_request sync     → evaluate the PR that just pushed
+# Label contract:
+#   - needs-manual-rebase   → auto-resolve failed, human must act
+# Prerequisite:
+#   Create the label once:
+#     gh label create needs-manual-rebase \
+#       --color d73a4a \
+#       --description "Auto-resolve bailed out; manual merge/rebase required"
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write         # push resolved commits back to PR head
+  pull-requests: write    # add/remove label
+
+jobs:
+  enumerate:
+    name: Enumerate PRs to evaluate
+    runs-on: ubuntu-latest
+    outputs:
+      prs: ${{ steps.list.outputs.prs }}
+    steps:
+      - name: List target PRs
+        id: list
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT" = "pull_request" ]; then
+            echo "prs=[$PR_NUMBER]" >> "$GITHUB_OUTPUT"
+          else
+            # push to main: evaluate every open PR
+            prs=$(gh pr list --state open --base main --json number --jq 'map(.number)')
+            echo "prs=${prs}" >> "$GITHUB_OUTPUT"
+          fi
+
+  resolve:
+    name: Resolve PR #${{ matrix.pr }}
+    needs: enumerate
+    if: needs.enumerate.outputs.prs != '[]'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        pr: ${{ fromJSON(needs.enumerate.outputs.prs) }}
+    steps:
+      - name: Fetch PR metadata
+        id: meta
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          data=$(gh pr view ${{ matrix.pr }} --json headRefName,headRefOid,baseRefName,isCrossRepository,mergeable,mergeStateStatus)
+          echo "$data" | jq -r '"head=" + .headRefName' >> "$GITHUB_OUTPUT"
+          echo "$data" | jq -r '"base=" + .baseRefName' >> "$GITHUB_OUTPUT"
+          echo "$data" | jq -r '"fork=" + (.isCrossRepository|tostring)' >> "$GITHUB_OUTPUT"
+
+      - name: Skip forks (no push permission)
+        if: steps.meta.outputs.fork == 'true'
+        run: |
+          echo "PR #${{ matrix.pr }} is from a fork; skipping."
+          exit 0
+
+      - uses: actions/checkout@v6
+        if: steps.meta.outputs.fork == 'false'
+        with:
+          ref: ${{ steps.meta.outputs.head }}
+          fetch-depth: 0
+
+      - name: Poll mergeable status
+        id: mergeable
+        if: steps.meta.outputs.fork == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # GitHub computes `mergeable` async; it returns UNKNOWN right after a
+          # push. Poll up to ~60s until it resolves to MERGEABLE or CONFLICTING.
+          for i in $(seq 1 12); do
+            state=$(gh pr view ${{ matrix.pr }} --json mergeable --jq '.mergeable')
+            if [ "$state" != "UNKNOWN" ]; then
+              echo "state=$state" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "state=UNKNOWN" >> "$GITHUB_OUTPUT"
+
+      - name: Early exit if not conflicting
+        if: steps.meta.outputs.fork == 'false' && steps.mergeable.outputs.state != 'CONFLICTING'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "PR #${{ matrix.pr }} is not in CONFLICTING state (state=${{ steps.mergeable.outputs.state }}); nothing to do."
+          # If a stale needs-manual-rebase label exists, remove it
+          gh pr edit ${{ matrix.pr }} --remove-label needs-manual-rebase 2>/dev/null || true
+
+      - name: Attempt merge origin/${{ steps.meta.outputs.base }}
+        id: merge
+        if: steps.meta.outputs.fork == 'false' && steps.mergeable.outputs.state == 'CONFLICTING'
+        run: |
+          set -euo pipefail
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name  "github-actions[bot]"
+          git fetch origin ${{ steps.meta.outputs.base }}
+          if git merge "origin/${{ steps.meta.outputs.base }}" --no-commit --no-ff; then
+            echo "conflict=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "conflict=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Classify conflict scope
+        id: scope
+        if: steps.merge.outputs.conflict == 'true'
+        run: |
+          set -euo pipefail
+          conflicts=$(git diff --name-only --diff-filter=U)
+          echo "--- conflicting files ---"
+          echo "$conflicts"
+          echo "-------------------------"
+
+          mechanical=true
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            case "$f" in
+              CHANGELOG.md) ;;
+              uv.lock) ;;
+              pyproject.toml) ;;
+              plugins/*/\.claude-plugin/plugin.json) ;;
+              plugins/*/.claude-plugin/plugin.json) ;;
+              *) mechanical=false ;;
+            esac
+          done <<< "$conflicts"
+
+          # Preserve the file list for the next step
+          printf '%s\n' "$conflicts" > /tmp/conflict-files.txt
+          echo "mechanical=$mechanical" >> "$GITHUB_OUTPUT"
+
+      - name: Set up uv (for lock regeneration)
+        if: steps.scope.outputs.mechanical == 'true'
+        uses: astral-sh/setup-uv@v8.1.0
+
+      - name: Mechanical resolve
+        id: resolve
+        if: steps.scope.outputs.mechanical == 'true'
+        env:
+          BASE: ${{ steps.meta.outputs.base }}
+        run: |
+          set -euo pipefail
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            echo "--- resolving: $f ---"
+            case "$f" in
+              CHANGELOG.md)
+                # Union merge: keep both sides' entries
+                git show ":1:$f" > /tmp/base.txt 2>/dev/null || : > /tmp/base.txt
+                git show ":2:$f" > /tmp/ours.txt
+                git show ":3:$f" > /tmp/theirs.txt
+                python3 scripts/merge_changelog.py \
+                  /tmp/base.txt /tmp/ours.txt /tmp/theirs.txt > "$f"
+                git add "$f"
+                ;;
+              uv.lock)
+                # Regenerate deterministically from pyproject.toml (post-merge)
+                git checkout --ours pyproject.toml 2>/dev/null || true
+                rm -f "$f"
+                uv lock
+                git add "$f"
+                ;;
+              pyproject.toml|plugins/*/.claude-plugin/plugin.json)
+                # Accept the higher semver on the version line only;
+                # bail if any non-version line also conflicts
+                git show ":2:$f" > /tmp/ours.txt
+                git show ":3:$f" > /tmp/theirs.txt
+                python3 scripts/merge_version_line.py \
+                  /tmp/ours.txt /tmp/theirs.txt > "$f"
+                git add "$f"
+                ;;
+            esac
+          done < /tmp/conflict-files.txt
+
+          # Verify no conflict markers remain
+          if git diff --check; then
+            echo "resolved=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "resolved=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit and push if resolved
+        if: steps.resolve.outputs.resolved == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          git commit -m "chore: auto-resolve mechanical merge conflicts with ${{ steps.meta.outputs.base }}"
+          git push origin HEAD:${{ steps.meta.outputs.head }}
+          gh pr edit ${{ matrix.pr }} --remove-label needs-manual-rebase 2>/dev/null || true
+
+      - name: Bail out — label for manual rebase
+        if: |
+          steps.merge.outputs.conflict == 'true' && (
+            steps.scope.outputs.mechanical != 'true' ||
+            steps.resolve.outputs.resolved != 'true'
+          )
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          git merge --abort 2>/dev/null || true
+          gh pr edit ${{ matrix.pr }} --add-label needs-manual-rebase

--- a/.github/workflows/auto-resolve-conflicts.yml
+++ b/.github/workflows/auto-resolve-conflicts.yml
@@ -83,9 +83,25 @@ jobs:
         with:
           ref: ${{ steps.meta.outputs.head }}
           fetch-depth: 0
-          # Don't leave the GITHUB_TOKEN in .git/config; we push explicitly
-          # later with a scoped URL so subsequent steps can't leak the token.
-          persist-credentials: false
+          # We leave persist-credentials at the default (true) because
+          # `persist-credentials: false` makes checkout run
+          # `git submodule foreach --recursive` during its auth-cleanup
+          # phase, which fails on this repo: the main tree contains a
+          # stale gitlink at `.claude/worktrees/elastic-black` (a worktree
+          # accidentally committed as a submodule) with no matching
+          # `.gitmodules` entry — see #633 CI runs 24806172525 / 24807760781.
+          # To still avoid leaving a usable token in `.git/config` we
+          # wipe the http.*.extraheader below and push through an
+          # explicit one-shot URL.
+          persist-credentials: true
+
+      - name: Drop persisted auth from .git/config
+        if: steps.meta.outputs.fork == 'false'
+        run: |
+          # `actions/checkout` writes the token as http.<origin>.extraheader.
+          # Remove it so later steps can't reuse the token implicitly; the
+          # final push uses a scoped one-shot URL instead.
+          git config --local --unset-all "http.https://github.com/.extraheader" 2>/dev/null || true
 
       - name: Poll mergeable status
         id: mergeable

--- a/.github/workflows/auto-resolve-conflicts.yml
+++ b/.github/workflows/auto-resolve-conflicts.yml
@@ -29,13 +29,15 @@ jobs:
   enumerate:
     name: Enumerate PRs to evaluate
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}  # let `gh` find the repo without checkout
     outputs:
       prs: ${{ steps.list.outputs.prs }}
     steps:
       - name: List target PRs
         id: list
         env:
-          GH_TOKEN: ${{ github.token }}
           EVENT: ${{ github.event_name }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
@@ -53,6 +55,9 @@ jobs:
     needs: enumerate
     if: needs.enumerate.outputs.prs != '[]'
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}  # let `gh` find the repo without checkout
     strategy:
       fail-fast: false
       matrix:
@@ -60,8 +65,6 @@ jobs:
     steps:
       - name: Fetch PR metadata
         id: meta
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           data=$(gh pr view ${{ matrix.pr }} --json headRefName,headRefOid,baseRefName,isCrossRepository,mergeable,mergeStateStatus)
@@ -84,8 +87,6 @@ jobs:
       - name: Poll mergeable status
         id: mergeable
         if: steps.meta.outputs.fork == 'false'
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           # GitHub computes `mergeable` async; it returns UNKNOWN right after a
@@ -102,8 +103,6 @@ jobs:
 
       - name: Early exit if not conflicting
         if: steps.meta.outputs.fork == 'false' && steps.mergeable.outputs.state != 'CONFLICTING'
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           echo "PR #${{ matrix.pr }} is not in CONFLICTING state (state=${{ steps.mergeable.outputs.state }}); nothing to do."
           # If a stale needs-manual-rebase label exists, remove it
@@ -202,8 +201,6 @@ jobs:
 
       - name: Commit and push if resolved
         if: steps.resolve.outputs.resolved == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           git commit -m "chore: auto-resolve mechanical merge conflicts with ${{ steps.meta.outputs.base }}"
@@ -216,8 +213,6 @@ jobs:
             steps.scope.outputs.mechanical != 'true' ||
             steps.resolve.outputs.resolved != 'true'
           )
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           git merge --abort 2>/dev/null || true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Auto Resolve Mechanical Conflicts workflow (`.github/workflows/auto-resolve-conflicts.yml`):** GitHub Actions workflow that detects merge conflicts on `push` to `main` and on `pull_request` events, then auto-resolves the three "mechanical" cases — `CHANGELOG.md` union-merge (new `scripts/merge_changelog.py`), `uv.lock` regeneration via `uv lock`, and version-line conflicts in `pyproject.toml` / `plugins/*/.claude-plugin/plugin.json` (new `scripts/merge_version_line.py`, picks the higher semver). Anything outside these patterns is left untouched and the PR gets a `needs-manual-rebase` label. Forks are skipped (no push permission via default `GITHUB_TOKEN`). Create the label once with `gh label create needs-manual-rebase --color d73a4a --description "Auto-resolve bailed out; manual merge/rebase required"`.
+
 ## [0.28.1] - 2026-04-23
 
 Patch release that rolls up the Phase 1 documentation coverage and Phase 1.5 collection pipeline that landed on `main` after the `v0.28.0` tag was cut. No code changes to the WAITING detection itself; Phase 2 (detection logic changes) remains out of scope.
@@ -1071,8 +1075,6 @@ Patch release that rolls up the Phase 1 documentation coverage and Phase 1.5 col
 - Prevent path traversal in skill-creator `run_eval.py`
 - Fix false negative in skill-creator tool detection loop
 
-## [Unreleased]
-
 ## [0.15.3] - 2026-03-18
 
 ### Added
@@ -1186,23 +1188,6 @@ Patch release that rolls up the Phase 1 documentation coverage and Phase 1.5 col
 
 - Admin responses no longer contain terminal junk (ANSI escapes, status bars, spinners)
 - Reply receiver applies `_strip_terminal_junk` to auto-notify artifact responses
-
-## [0.12.1] - 2026-03-15
-
-### Added
-
-- `link-preview` Canvas format with OGP metadata fetching and server-side enrichment
-- `synapse canvas link <url>` CLI command for posting rich link preview cards
-
-### Fixed
-
-- SSRF: validate redirect targets at each hop to prevent private IP bypass via open redirects
-- OGP streaming: use `aiter_bytes()` to enforce 64KB read limit (was `aread()` + truncate)
-- Parallel OGP fetch via `asyncio.gather` for composite cards with multiple link-preview blocks
-- CSS token `--color-muted` → `--color-text-muted` for link-preview card styles
-- CLI `canvas link` exits with non-zero status on failure
-- URL validation in `post_link_preview` rejects empty and non-http(s) URLs
-- Test isolation: prevent Canvas CLI tests from writing to live server DB
 
 ## [0.12.1] - 2026-03-15
 

--- a/scripts/merge_changelog.py
+++ b/scripts/merge_changelog.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Union-merge CHANGELOG.md conflict sides.
+
+Usage:
+    python scripts/merge_changelog.py <base> <ours> <theirs>
+
+Prints the merged CHANGELOG to stdout.
+
+Strategy: treat CHANGELOG.md as an append-only, version-sectioned document.
+Each version section starts with a level-2 heading like "## [0.27.1] - YYYY-MM-DD"
+or "## [Unreleased]". We keep the preamble from `ours`, then emit each unique
+version section in descending-version order, preferring `ours` when both sides
+have the same version.
+
+Exits 2 if the structure can't be parsed from either side.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+HEADING_RE = re.compile(r"^## \[([^\]]+)\](?:\s*-\s*.*)?$", re.MULTILINE)
+
+
+def split_sections(text: str) -> tuple[str, list[tuple[str, str]]]:
+    """Split CHANGELOG into (preamble, [(version, section_text), ...])."""
+    matches = list(HEADING_RE.finditer(text))
+    if not matches:
+        return text, []
+    preamble = text[: matches[0].start()]
+    sections: list[tuple[str, str]] = []
+    for i, m in enumerate(matches):
+        version = m.group(1)
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
+        sections.append((version, text[m.start() : end]))
+    return preamble, sections
+
+
+# Any numeric semver is a triple of small ints (major.minor.patch); this
+# sentinel is larger than any plausible component so Unreleased sorts on top.
+_UNRELEASED_RANK = 10**9
+
+
+def version_key(v: str) -> tuple[int, ...]:
+    """Sort key: numeric semver descending, 'Unreleased' on top."""
+    if v.lower() == "unreleased":
+        return (_UNRELEASED_RANK,)
+    parts: list[int] = []
+    for p in v.split("."):
+        digits = re.match(r"\d+", p)
+        parts.append(int(digits.group()) if digits else 0)
+    return tuple(parts)
+
+
+def union_merge(ours: str, theirs: str) -> str:
+    ours_preamble, ours_sections = split_sections(ours)
+    theirs_preamble, theirs_sections = split_sections(theirs)
+
+    if not ours_sections and not theirs_sections:
+        print(
+            "ERROR: neither side has recognizable CHANGELOG sections", file=sys.stderr
+        )
+        sys.exit(2)
+
+    preamble = ours_preamble or theirs_preamble
+    seen: dict[str, str] = {}
+    for version, body in ours_sections:
+        seen[version] = body
+    for version, body in theirs_sections:
+        seen.setdefault(version, body)
+
+    ordered = sorted(seen.items(), key=lambda kv: version_key(kv[0]), reverse=True)
+    body = "".join(b for _, b in ordered)
+    return preamble.rstrip() + "\n\n" + body.lstrip()
+
+
+def main() -> None:
+    if len(sys.argv) != 4:
+        print("Usage: merge_changelog.py <base> <ours> <theirs>", file=sys.stderr)
+        sys.exit(1)
+    _, ours_path, theirs_path = sys.argv[1], sys.argv[2], sys.argv[3]
+    ours = Path(ours_path).read_text(encoding="utf-8")
+    theirs = Path(theirs_path).read_text(encoding="utf-8")
+    sys.stdout.write(union_merge(ours, theirs))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/merge_changelog.py
+++ b/scripts/merge_changelog.py
@@ -63,9 +63,13 @@ def union_merge(ours: str, theirs: str) -> str:
         sys.exit(2)
 
     preamble = ours_preamble or theirs_preamble
+    # Use setdefault on BOTH sides so the first occurrence of a version
+    # wins — never overwrite later in the loop. Protects CHANGELOGs that
+    # legitimately contain duplicate headings (e.g. two "## [Unreleased]"
+    # regions waiting to be folded together at release time).
     seen: dict[str, str] = {}
     for version, body in ours_sections:
-        seen[version] = body
+        seen.setdefault(version, body)
     for version, body in theirs_sections:
         seen.setdefault(version, body)
 

--- a/scripts/merge_version_line.py
+++ b/scripts/merge_version_line.py
@@ -69,15 +69,23 @@ def merge(ours: str, theirs: str) -> str:
             )
             sys.exit(3)
 
-    # All differing lines are version lines; pick the higher semver per line.
+    # All differing lines are version-lines; build per-removed-line replacement
+    # queues from the paired (removed, added) diff — NOT a full cross product.
+    # Without this pairing, a file with multiple version lines (e.g. one at
+    # line 2 and another at line 6, only line 2 actually differing) would see
+    # the unchanged line 6 overwritten by line 2's higher semver match.
+    replacements: dict[str, list[str]] = {}
+    for r, a in zip(removed, added, strict=True):
+        rv = extract_version(r.rstrip("\n"))
+        av = extract_version(a.rstrip("\n"))
+        if rv is not None and av is not None and semver_key(av) > semver_key(rv):
+            replacements.setdefault(r, []).append(a)
+
     merged = list(ours_lines)
     for idx, line in enumerate(merged):
-        for theirs_line in theirs_lines:
-            ours_v = extract_version(line.rstrip("\n"))
-            theirs_v = extract_version(theirs_line.rstrip("\n"))
-            if ours_v and theirs_v and semver_key(theirs_v) > semver_key(ours_v):
-                merged[idx] = theirs_line
-                break
+        queue = replacements.get(line)
+        if queue:
+            merged[idx] = queue.pop(0)
     return "".join(merged)
 
 

--- a/scripts/merge_version_line.py
+++ b/scripts/merge_version_line.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Merge two sides of a version-only conflict in pyproject.toml or plugin.json.
+
+Usage:
+    python scripts/merge_version_line.py <ours> <theirs>
+
+Prints the merged file to stdout.
+
+Strategy: treat the file as a line-by-line diff. If the ONLY differing lines
+are version-bearing lines (`version = "..."` in pyproject.toml, or
+`"version": "..."` in plugin.json), pick the higher semver. If any other
+line differs, exit 3 (the workflow then falls back to needs-manual-rebase).
+"""
+
+import difflib
+import re
+import sys
+from pathlib import Path
+
+VERSION_PATTERNS = [
+    re.compile(r'^(\s*)version\s*=\s*[\'"]([^\'"]+)[\'"](\s*)$'),  # pyproject.toml
+    re.compile(r'^(\s*)"version"\s*:\s*"([^"]+)"(\s*,?\s*)$'),  # plugin.json
+]
+
+
+def extract_version(line: str) -> str | None:
+    for pat in VERSION_PATTERNS:
+        m = pat.match(line)
+        if m:
+            return m.group(2)
+    return None
+
+
+def semver_key(v: str) -> tuple[int, ...]:
+    parts: list[int] = []
+    for p in v.split("."):
+        digits = re.match(r"\d+", p)
+        parts.append(int(digits.group()) if digits else 0)
+    return tuple(parts)
+
+
+def merge(ours: str, theirs: str) -> str:
+    ours_lines = ours.splitlines(keepends=True)
+    theirs_lines = theirs.splitlines(keepends=True)
+
+    diff = list(difflib.unified_diff(ours_lines, theirs_lines, n=0, lineterm=""))
+    # Partition diff lines into (removed, added) pairs ignoring hunk headers.
+    removed: list[str] = []
+    added: list[str] = []
+    for line in diff:
+        if line.startswith("---") or line.startswith("+++") or line.startswith("@@"):
+            continue
+        if line.startswith("-"):
+            removed.append(line[1:])
+        elif line.startswith("+"):
+            added.append(line[1:])
+
+    if len(removed) != len(added):
+        print("ERROR: asymmetric diff; non-version conflict detected", file=sys.stderr)
+        sys.exit(3)
+
+    for r, a in zip(removed, added, strict=True):
+        rv = extract_version(r.rstrip("\n"))
+        av = extract_version(a.rstrip("\n"))
+        if rv is None or av is None:
+            print(
+                f"ERROR: non-version line differs; bailing out.\n  ours:   {r!r}\n  theirs: {a!r}",
+                file=sys.stderr,
+            )
+            sys.exit(3)
+
+    # All differing lines are version lines; pick the higher semver per line.
+    merged = list(ours_lines)
+    for idx, line in enumerate(merged):
+        for theirs_line in theirs_lines:
+            ours_v = extract_version(line.rstrip("\n"))
+            theirs_v = extract_version(theirs_line.rstrip("\n"))
+            if ours_v and theirs_v and semver_key(theirs_v) > semver_key(ours_v):
+                merged[idx] = theirs_line
+                break
+    return "".join(merged)
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        print("Usage: merge_version_line.py <ours> <theirs>", file=sys.stderr)
+        sys.exit(1)
+    ours = Path(sys.argv[1]).read_text(encoding="utf-8")
+    theirs = Path(sys.argv[2]).read_text(encoding="utf-8")
+    sys.stdout.write(merge(ours, theirs))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_merge_changelog.py
+++ b/tests/test_merge_changelog.py
@@ -58,6 +58,20 @@ class TestUnionMerge:
         assert "ours-only" in merged
         assert "theirs-only" in merged
 
+    def test_ours_side_duplicate_heading_keeps_first_occurrence(self):
+        # Real CHANGELOGs can legitimately carry two "## [Unreleased]" blocks
+        # while a release is in flight. The first (topmost) must win.
+        ours = (
+            "# CL\n\n"
+            "## [Unreleased]\n- first-unreleased\n\n"
+            "## [Unreleased]\n- second-unreleased\n"
+        )
+        theirs = "# CL\n\n## [Unreleased]\n- theirs-unreleased\n"
+        merged = union_merge(ours, theirs)
+        assert "first-unreleased" in merged
+        assert "second-unreleased" not in merged
+        assert "theirs-unreleased" not in merged
+
     def test_overlapping_version_prefers_ours(self):
         ours = "# CL\n\n## [0.6.0] - 2026-04-01\n- ours-body\n"
         theirs = "# CL\n\n## [0.6.0] - 2026-04-01\n- theirs-body\n"

--- a/tests/test_merge_changelog.py
+++ b/tests/test_merge_changelog.py
@@ -1,0 +1,107 @@
+"""Tests for scripts/merge_changelog.py."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).parent.parent / "scripts"
+
+_scripts_path = str(SCRIPTS_DIR)
+sys.path.insert(0, _scripts_path)
+from merge_changelog import split_sections, union_merge, version_key  # noqa: E402
+
+sys.path.remove(_scripts_path)
+
+
+class TestVersionKey:
+    def test_numeric_ascending(self):
+        assert version_key("0.5.2") < version_key("0.6.0")
+        assert version_key("1.0.0") > version_key("0.99.99")
+
+    def test_unreleased_is_highest(self):
+        assert version_key("Unreleased") > version_key("99.99.99")
+        assert version_key("unreleased") > version_key("1.2.3")
+
+    def test_non_numeric_components(self):
+        # Non-numeric parts fall back to 0 without raising
+        version_key("0.5.2rc1")
+
+
+class TestSplitSections:
+    def test_preamble_and_sections(self):
+        text = (
+            "# Changelog\n\nHeader text.\n\n"
+            "## [0.6.0] - 2026-04-01\n- feature\n\n"
+            "## [0.5.0] - 2026-03-01\n- fix\n"
+        )
+        preamble, sections = split_sections(text)
+        assert "# Changelog" in preamble
+        assert len(sections) == 2
+        assert sections[0][0] == "0.6.0"
+        assert sections[1][0] == "0.5.0"
+        assert "- feature" in sections[0][1]
+
+    def test_no_sections(self):
+        preamble, sections = split_sections("Just prose.")
+        assert preamble == "Just prose."
+        assert sections == []
+
+
+class TestUnionMerge:
+    def test_disjoint_versions_kept_in_descending_order(self):
+        ours = "# Changelog\n\n## [0.6.0] - 2026-04-01\n- ours-only\n"
+        theirs = "# Changelog\n\n## [0.5.0] - 2026-03-01\n- theirs-only\n"
+        merged = union_merge(ours, theirs)
+        assert merged.index("[0.6.0]") < merged.index("[0.5.0]")
+        assert "ours-only" in merged
+        assert "theirs-only" in merged
+
+    def test_overlapping_version_prefers_ours(self):
+        ours = "# CL\n\n## [0.6.0] - 2026-04-01\n- ours-body\n"
+        theirs = "# CL\n\n## [0.6.0] - 2026-04-01\n- theirs-body\n"
+        merged = union_merge(ours, theirs)
+        assert "ours-body" in merged
+        assert "theirs-body" not in merged
+
+    def test_unreleased_comes_first(self):
+        ours = "# CL\n\n## [Unreleased]\n- pending\n"
+        theirs = "# CL\n\n## [0.6.0] - 2026-04-01\n- released\n"
+        merged = union_merge(ours, theirs)
+        assert merged.index("[Unreleased]") < merged.index("[0.6.0]")
+
+    def test_raises_when_no_sections_on_either_side(self):
+        with pytest.raises(SystemExit) as exc:
+            union_merge("prose", "more prose")
+        assert exc.value.code == 2
+
+
+class TestMergeChangelogCLI:
+    SCRIPT = str(SCRIPTS_DIR / "merge_changelog.py")
+
+    def _run(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, self.SCRIPT, *args],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+
+    def test_cli_merges_two_sides(self, tmp_path: Path):
+        base = tmp_path / "base.md"
+        ours = tmp_path / "ours.md"
+        theirs = tmp_path / "theirs.md"
+        base.write_text("# CL\n", encoding="utf-8")
+        ours.write_text("# CL\n\n## [0.6.0] - 2026-04-01\n- feat\n", encoding="utf-8")
+        theirs.write_text("# CL\n\n## [0.5.0] - 2026-03-01\n- fix\n", encoding="utf-8")
+
+        result = self._run(str(base), str(ours), str(theirs))
+        assert result.returncode == 0, result.stderr
+        assert "[0.6.0]" in result.stdout
+        assert "[0.5.0]" in result.stdout
+
+    def test_cli_wrong_arg_count(self):
+        result = self._run("only-one")
+        assert result.returncode == 1
+        assert "Usage" in result.stderr

--- a/tests/test_merge_version_line.py
+++ b/tests/test_merge_version_line.py
@@ -64,6 +64,17 @@ class TestMerge:
         result = merge(ours, theirs)
         assert '"0.27.2"' in result
 
+    def test_only_changed_version_line_is_replaced(self):
+        # Two version-bearing lines; only one actually differs. The unchanged
+        # one must stay untouched even though a naive cross-product loop
+        # would match it against the higher semver on the other side.
+        ours = 'version = "0.27.1"\nother = "x"\n# ref: version = "1.0.0"\n'
+        theirs = 'version = "0.28.0"\nother = "x"\n# ref: version = "1.0.0"\n'
+        result = merge(ours, theirs)
+        assert 'version = "0.28.0"\n' in result
+        assert '# ref: version = "1.0.0"\n' in result
+        assert 'version = "0.27.1"' not in result.split("\n", 1)[0]
+
 
 class TestMergeVersionLineCLI:
     SCRIPT = str(SCRIPTS_DIR / "merge_version_line.py")

--- a/tests/test_merge_version_line.py
+++ b/tests/test_merge_version_line.py
@@ -1,0 +1,101 @@
+"""Tests for scripts/merge_version_line.py."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).parent.parent / "scripts"
+
+_scripts_path = str(SCRIPTS_DIR)
+sys.path.insert(0, _scripts_path)
+from merge_version_line import extract_version, merge, semver_key  # noqa: E402
+
+sys.path.remove(_scripts_path)
+
+
+class TestExtractVersion:
+    def test_pyproject_toml_style(self):
+        assert extract_version('version = "0.27.1"') == "0.27.1"
+        assert extract_version("version = '1.0.0'") == "1.0.0"
+
+    def test_plugin_json_style(self):
+        assert extract_version('  "version": "0.27.1",') == "0.27.1"
+        assert extract_version('"version": "1.2.3"') == "1.2.3"
+
+    def test_non_version_line(self):
+        assert extract_version("name = 'synapse-a2a'") is None
+        assert extract_version("") is None
+
+
+class TestSemverKey:
+    def test_ordering(self):
+        assert semver_key("0.27.1") < semver_key("0.27.2")
+        assert semver_key("0.27.9") < semver_key("0.28.0")
+        assert semver_key("1.0.0") > semver_key("0.99.99")
+
+
+class TestMerge:
+    def test_only_version_differs_picks_higher(self):
+        ours = 'name = "x"\nversion = "0.27.1"\n'
+        theirs = 'name = "x"\nversion = "0.27.2"\n'
+        result = merge(ours, theirs)
+        assert '"0.27.2"' in result
+        assert '"0.27.1"' not in result
+
+    def test_lower_side_ignored(self):
+        ours = 'version = "0.28.0"\n'
+        theirs = 'version = "0.27.9"\n'
+        result = merge(ours, theirs)
+        assert '"0.28.0"' in result
+        assert '"0.27.9"' not in result
+
+    def test_non_version_conflict_bails(self):
+        ours = 'name = "x"\nversion = "0.27.1"\n'
+        theirs = 'name = "y"\nversion = "0.27.2"\n'
+        with pytest.raises(SystemExit) as exc:
+            merge(ours, theirs)
+        assert exc.value.code == 3
+
+    def test_plugin_json_version_merge(self):
+        ours = '{\n  "name": "p",\n  "version": "0.27.1"\n}\n'
+        theirs = '{\n  "name": "p",\n  "version": "0.27.2"\n}\n'
+        result = merge(ours, theirs)
+        assert '"0.27.2"' in result
+
+
+class TestMergeVersionLineCLI:
+    SCRIPT = str(SCRIPTS_DIR / "merge_version_line.py")
+
+    def _run(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, self.SCRIPT, *args],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+
+    def test_cli_merges_version_only(self, tmp_path: Path):
+        ours = tmp_path / "ours.toml"
+        theirs = tmp_path / "theirs.toml"
+        ours.write_text('version = "0.27.1"\n', encoding="utf-8")
+        theirs.write_text('version = "0.27.2"\n', encoding="utf-8")
+
+        result = self._run(str(ours), str(theirs))
+        assert result.returncode == 0, result.stderr
+        assert '"0.27.2"' in result.stdout
+
+    def test_cli_bails_on_non_version(self, tmp_path: Path):
+        ours = tmp_path / "ours.toml"
+        theirs = tmp_path / "theirs.toml"
+        ours.write_text('name = "a"\n', encoding="utf-8")
+        theirs.write_text('name = "b"\n', encoding="utf-8")
+
+        result = self._run(str(ours), str(theirs))
+        assert result.returncode == 3
+
+    def test_cli_wrong_arg_count(self):
+        result = self._run("only-one")
+        assert result.returncode == 1
+        assert "Usage" in result.stderr


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow (`auto-resolve-conflicts.yml`) that auto-resolves the three most common merge-conflict patterns so multi-agent parallel PRs (e.g. #608, #630) don't block each other on trivial overlap:

- **CHANGELOG.md** — union merge via `scripts/merge_changelog.py` (semver-descending, Unreleased pinned on top)
- **uv.lock** — regenerated deterministically with `uv lock`
- **version lines** in `pyproject.toml` / `plugins/*/.claude-plugin/plugin.json` — higher semver wins via `scripts/merge_version_line.py`

Anything outside these patterns is left untouched and the PR gets a `needs-manual-rebase` label for human/agent review. Forks are skipped (the default `GITHUB_TOKEN` cannot push to them). Mergeability is polled up to 60s to handle GitHub's async `mergeable` computation.

The workflow uses a two-job fan-out: `enumerate` lists open PRs (one on `pull_request`, all on `push to main`) as JSON, and `resolve` matrix-expands one job per PR.

## Design rationale

- **Lv2 (mechanical-only) over Lv3 (LLM semantic merge)**: most real conflicts in this repo's multi-agent PR flow are the three patterns above. LLM semantic merge has a known failure mode (see `feedback_autofix_and_review.md`: autofix can revert intentional simplify decisions), so the safer path is to auto-resolve only when the resolution is deterministic and to label everything else.
- **No opt-in label gate (yet)**: the auto-resolve scope is narrow enough that blast radius is already low. If production use surfaces surprises, we can add `auto-resolve-enabled` as an opt-in gate without restructuring.

## Setup (one-time)

~~~bash
gh label create needs-manual-rebase \
  --color d73a4a \
  --description "Auto-resolve bailed out; manual merge/rebase required"
~~~

## Test plan

- [x] `uv run pytest tests/test_merge_changelog.py tests/test_merge_version_line.py -v` (22/22 pass)
- [x] `uv run pytest tests/test_extract_changelog.py` (11/11 pass — no regression in sibling script)
- [x] `uv run ruff check` + `uv run ruff format --check` + `mypy` (all pass via pre-commit)
- [x] YAML parseable (`python -c 'import yaml; yaml.safe_load(...)'`)
- [ ] **End-to-end** — trigger on a test PR with an intentional CHANGELOG conflict and confirm the commit+label behavior on the real Actions runner (to be verified when a real conflict arises)

## Notes for reviewers

- The workflow grants `contents: write` + `pull-requests: write` on its job-level `permissions` block only; no repo-wide setting change is needed.
- Resolved commits authored by `github-actions[bot]` won't re-trigger `on: push` (by design — prevents infinite loops), so downstream CI runs stay tied to the next human push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 定型的なマージコンフリクトの自動解決機能を追加。特定ファイル（CHANGELOG.md、uv.lock、バージョン情報）のコンフリクトを自動で検出し、解決します。その他のコンフリクトは手動対応が必要です。

* **チア**
  * 自動解決ロジックの検証テストとドキュメントを追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->