### PR TITLE
chore(release): bump to 0.28.1 for post-0.28.0 Phase 1 docs + Phase 1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3532,6 +3532,7 @@ See v0.3.14 for reply PTY injection, CURRENT column, and history default changes
 - PyPI publishing instructions
 
 [Unreleased]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.27.2...HEAD
+[0.28.1]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.28.0...v0.28.1
 [0.28.0]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.27.2...v0.28.0
 [0.27.2]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.27.1...v0.27.2
 [0.27.1]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.27.0...v0.27.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.28.1] - 2026-04-23
+
+Patch release that rolls up the Phase 1 documentation coverage and Phase 1.5 collection pipeline that landed on `main` after the `v0.28.0` tag was cut. No code changes to the WAITING detection itself; Phase 2 (detection logic changes) remains out of scope.
+
+### Added
+
+- **`synapse waiting-debug` CLI — Phase 1.5 collection pipeline (#630, #632):** `synapse waiting-debug collect` appends per-agent `/debug/waiting` snapshots to `~/.synapse/waiting_debug.jsonl` (user-scoped so data accumulates across projects); `synapse waiting-debug report [--since] [--agent] [--json]` produces aggregate counts (profile, `pattern_source`, `path_used`, `confidence`, `idle_gate_drops`, `renderer_unavailable_agents`) for Phase 2 analysis. Collector continues on per-agent errors and skips empty attempts by default (`--include-empty` overrides). `.synapse/waiting_debug.*` added to `.gitignore`. New `docs/phase15-collection.md` documents the CLI plus cron and launchd scheduling recipes (5-minute cadence).
+
+### Documentation
+
+- **WAITING observability reference coverage (#608, #631):** `synapse-a2a` skill references (`api.md`, `commands.md`) now document `GET /debug/waiting` (response shape, field semantics, 503 fallback), the `--debug-waiting` flag and its aggregate output, the `renderer_available` JSON field, and the `WAITING (renderer: off)` plain-text annotation. `site-docs/guide/agent-management.md` gains new "Renderer Availability" and "WAITING Detection Diagnostics" subsections describing the pyte fallback, the `(renderer: off)` behavior, and how to read `--debug-waiting` aggregates + per-attempt rows. Canonical skill changes mirrored to `.agents/skills/` and `.claude/skills/`.
+
+### Fixed
+
+- **`tests/test_skill_structure.py::TestSyncedSkillParity` for externally-registered skills (#629):** the `opensrc` skill (registered from `vercel-labs/opensrc` into `.agents/skills/opensrc` and `.claude/skills/opensrc`) is not part of the `synapse-a2a` plugin distribution, so the `no_orphan_synced_skills` check was failing. Added `metadata.internal: true` plus `source` and `note` fields to the frontmatter; the test already exempts skills whose `metadata` contains `internal: true`.
+
 ## [0.28.0] - 2026-04-22
 
 ### Added

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ site_url: https://s-hiraoku.github.io/synapse-a2a/
 site_description: Multi-agent collaboration framework using Google A2A Protocol
 site_author: s-hiraoku
 repo_url: https://github.com/s-hiraoku/synapse-a2a
-repo_name: s-hiraoku/synapse-a2a v0.28.0
+repo_name: s-hiraoku/synapse-a2a v0.28.1
 docs_dir: site-docs
 
 theme:

--- a/plugins/synapse-a2a/.claude-plugin/plugin.json
+++ b/plugins/synapse-a2a/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synapse-a2a",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "description": "Complete plugin for Synapse A2A multi-agent framework including inter-agent communication, file safety, and history management",
   "author": {
     "name": "s-hiraoku",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synapse-a2a"
-version = "0.28.0"
+version = "0.28.1"
 description = "Agent-to-Agent communication protocol for CLI agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/site-docs/changelog.md
+++ b/site-docs/changelog.md
@@ -4,6 +4,12 @@ For the complete changelog, see [CHANGELOG.md on GitHub](https://github.com/s-hi
 
 ## Recent Highlights
 
+### v0.28.1
+
+- **Added**: `synapse waiting-debug` CLI — Phase 1.5 collection pipeline (#630, #632). `collect` appends `/debug/waiting` snapshots to `~/.synapse/waiting_debug.jsonl`; `report` prints aggregate counts (profile, `pattern_source`, `path_used`, `confidence`, `idle_gate_drops`, `renderer_unavailable_agents`) in text or JSON. `.synapse/waiting_debug.*` ignored; `docs/phase15-collection.md` documents cron and launchd scheduling at 5-minute cadence
+- **Documentation**: WAITING observability reference coverage (#608, #631) — `synapse-a2a` skill `api.md` / `commands.md` document `GET /debug/waiting`, `--debug-waiting`, `renderer_available`, and `(renderer: off)`; `site-docs/guide/agent-management.md` gains "Renderer Availability" and "WAITING Detection Diagnostics" subsections
+- **Fixed**: `TestSyncedSkillParity` for externally-registered skills (#629) — `opensrc` (from `vercel-labs/opensrc`) now carries `metadata.internal: true` in its frontmatter so the orphan-skill check correctly exempts it
+
 ### v0.28.0
 
 - **Added**: WAITING detection observability layer — Phase 1 (#608, #627). `IdleDetector` ring buffer records each detection attempt with `path_used`, `renderer_on`, `pattern_matched`, `pattern_source`, `confidence`, `idle_gate_passed`, `new_data_hex_prefix`, `rendered_text_tail`. `TerminalController` wraps `PtyRenderer` initialisation in try/except and exposes `renderer_available`. New `/debug/waiting` endpoint and `synapse status <agent> --debug-waiting` surface recent attempts + aggregates (total / match ratio / path usage / confidence / idle-gate drops). `synapse list` / `synapse status` annotate status with `(renderer: off)` and emit `renderer_available` in JSON. Phase 1 is observation only — detection logic is unchanged

--- a/site-docs/concepts/a2a-protocol.md
+++ b/site-docs/concepts/a2a-protocol.md
@@ -17,7 +17,7 @@ Every A2A agent publishes a discovery document at `/.well-known/agent.json`:
   "name": "synapse-claude-8100",
   "description": "Claude Code agent managed by Synapse A2A",
   "url": "http://localhost:8100",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "capabilities": {
     "streaming": false,
     "pushNotifications": false

--- a/site-docs/getting-started/installation.md
+++ b/site-docs/getting-started/installation.md
@@ -58,7 +58,7 @@
 synapse --version
 ```
 
-You should see the version number (e.g., `0.28.0`).
+You should see the version number (e.g., `0.28.1`).
 
 ## Initialize Configuration
 
@@ -88,7 +88,7 @@ gh skill install s-hiraoku/synapse-a2a synapse-manager
 gh skill install s-hiraoku/synapse-a2a synapse-reinst
 
 # Optional: pin to a release tag so updates are explicit
-gh skill install s-hiraoku/synapse-a2a synapse-a2a --pin v0.28.0
+gh skill install s-hiraoku/synapse-a2a synapse-a2a --pin v0.28.1
 
 # Optional: target a specific agent runtime
 gh skill install s-hiraoku/synapse-a2a synapse-a2a --agent claude-code


### PR DESCRIPTION
## Summary

Cut a 0.28.1 patch release to capture work that landed on \`main\` after the \`v0.28.0\` tag at commit \`8ef41c8\` (Canvas Harnesses viewer).

The tag was cut before:
- **#631** — Phase 1 WAITING observability skill/MCP documentation coverage
- **#632** — Phase 1.5 \`synapse waiting-debug\` collection pipeline
- **#629** — \`TestSyncedSkillParity\` exemption for the externally-registered \`opensrc\` skill

Rather than force-updating the existing \`v0.28.0\` tag (which would diverge from any consumer that already fetched it), 0.28.1 rolls these forward in a clean patch release.

## Changes

- **Version bump** across \`pyproject.toml\`, \`plugin.json\`, \`mkdocs.yml\`, and the two site-docs files that carry a version string (\`getting-started/installation.md\`, \`concepts/a2a-protocol.md\`).
- **CHANGELOG entry** — new \`[0.28.1] - 2026-04-23\` section in both \`CHANGELOG.md\` and \`site-docs/changelog.md\` covering the three PRs above.

No code changes. WAITING detection logic is unchanged; Phase 2 (detection-logic changes) stays out of scope.

## Test plan

- [ ] CI matrix green (docs-only change, no behaviour impact expected)
- [ ] CodeRabbit pass

## Follow-ups

- Tag \`v0.28.1\` on this merge commit (done manually after merge since there is no release automation wired up).
- Begin Phase 1.5 data collection via \`synapse waiting-debug collect\` on a 5-minute cron/launchd schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)