### PR TITLE
docs: add Phase 1.5 operational runbook (launchd + bump + legacy 404)

### DIFF
--- a/.agents/skills/synapse-a2a/references/commands.md
+++ b/.agents/skills/synapse-a2a/references/commands.md
@@ -304,6 +304,35 @@ Use this when a WAITING prompt did not trip the controller as expected: each att
 - Debugging why an agent is stuck in PROCESSING (check file locks)
 - Reviewing recent communication history for a specific agent
 
+### Waiting Debug Collection (`synapse waiting-debug`)
+
+Added in v0.28.1 (#630, #632). Persists the in-memory `/debug/waiting` ring buffer across every running agent so Phase 2 detection work has real data.
+
+```bash
+# Collect one snapshot per running agent into ~/.synapse/waiting_debug.jsonl
+synapse waiting-debug collect
+synapse waiting-debug collect --agent <agent-id>       # single agent
+synapse waiting-debug collect --include-empty          # record empty rings too
+synapse waiting-debug collect --out /tmp/debug.jsonl   # override output path
+
+# Aggregate / inspect
+synapse waiting-debug report
+synapse waiting-debug report --since 2026-04-23T00:00:00+00:00
+synapse waiting-debug report --agent <agent-id>
+synapse waiting-debug report --json
+synapse waiting-debug report --in /tmp/debug.jsonl
+```
+
+- **Output**: `~/.synapse/waiting_debug.jsonl` by default, one JSONL row per `{agent_id, port, collected_at, snapshot}`.
+- **Aggregate fields** (`report` output): total attempts, `profiles` / `pattern_source` / `path_used` / `confidence` distributions, `idle_gate_drops` count, `renderer_unavailable_agents` ratio.
+- **Error handling**: per-agent HTTP / parse errors log one warning to stderr and the collector continues with the next agent. Invalid JSONL lines in the input also warn and are skipped.
+
+**Prerequisite — bump the CLI first:** `synapse waiting-debug` exists only in v0.28.1+. Upgrade with `uv tool upgrade synapse-a2a` or `pipx upgrade synapse-a2a` before arming a schedule; otherwise the subcommand parser rejects `waiting-debug` on every run.
+
+**Legacy-agent caveat:** agents still running on a pre-0.28.0 binary do not expose `GET /debug/waiting` and log an expected `HTTP Error 404: Not Found`. Respawn them with the upgraded CLI (`synapse kill <id>` + spawn) to bring them into the dataset.
+
+**Schedule it** — there is no `synapse schedule` CLI for this. Use cron or launchd at a 5-minute cadence. See `docs/phase15-collection.md` for the canonical cron line and launchd plist.
+
 ### Saved Agent Definitions
 
 Manage reusable agent definitions that persist across sessions. Saved agents are stored as `.agent` files in project (`.synapse/agents/`) or user (`~/.synapse/agents/`) scope.

--- a/.agents/skills/synapse-a2a/references/commands.md
+++ b/.agents/skills/synapse-a2a/references/commands.md
@@ -329,7 +329,7 @@ synapse waiting-debug report --in /tmp/debug.jsonl
 
 **Prerequisite — bump the CLI first:** `synapse waiting-debug` exists only in v0.28.1+. Upgrade with `uv tool upgrade synapse-a2a` or `pipx upgrade synapse-a2a` before arming a schedule; otherwise the subcommand parser rejects `waiting-debug` on every run.
 
-**Legacy-agent caveat:** agents still running on a pre-0.28.0 binary do not expose `GET /debug/waiting` and log an expected `HTTP Error 404: Not Found`. Respawn them with the upgraded CLI (`synapse kill <id>` + spawn) to bring them into the dataset.
+**Legacy-agent caveat:** agents still running on a pre-0.28.0 binary do not expose `GET /debug/waiting` and log an expected `HTTP Error 404: Not Found`. Agents on v0.28.0+ whose controller lacks the `waiting_debug_snapshot` capability (e.g., a non-PTY runtime) return `HTTP Error 503: Service Unavailable` with detail `waiting debug data not available` — also expected and non-fatal. Respawn them with the upgraded CLI (`synapse kill <id>` + spawn) to bring them into the dataset.
 
 **Schedule it** — there is no `synapse schedule` CLI for this. Use cron or launchd at a 5-minute cadence. See `docs/phase15-collection.md` for the canonical cron line and launchd plist.
 

--- a/.claude/skills/synapse-a2a/references/commands.md
+++ b/.claude/skills/synapse-a2a/references/commands.md
@@ -304,6 +304,35 @@ Use this when a WAITING prompt did not trip the controller as expected: each att
 - Debugging why an agent is stuck in PROCESSING (check file locks)
 - Reviewing recent communication history for a specific agent
 
+### Waiting Debug Collection (`synapse waiting-debug`)
+
+Added in v0.28.1 (#630, #632). Persists the in-memory `/debug/waiting` ring buffer across every running agent so Phase 2 detection work has real data.
+
+```bash
+# Collect one snapshot per running agent into ~/.synapse/waiting_debug.jsonl
+synapse waiting-debug collect
+synapse waiting-debug collect --agent <agent-id>       # single agent
+synapse waiting-debug collect --include-empty          # record empty rings too
+synapse waiting-debug collect --out /tmp/debug.jsonl   # override output path
+
+# Aggregate / inspect
+synapse waiting-debug report
+synapse waiting-debug report --since 2026-04-23T00:00:00+00:00
+synapse waiting-debug report --agent <agent-id>
+synapse waiting-debug report --json
+synapse waiting-debug report --in /tmp/debug.jsonl
+```
+
+- **Output**: `~/.synapse/waiting_debug.jsonl` by default, one JSONL row per `{agent_id, port, collected_at, snapshot}`.
+- **Aggregate fields** (`report` output): total attempts, `profiles` / `pattern_source` / `path_used` / `confidence` distributions, `idle_gate_drops` count, `renderer_unavailable_agents` ratio.
+- **Error handling**: per-agent HTTP / parse errors log one warning to stderr and the collector continues with the next agent. Invalid JSONL lines in the input also warn and are skipped.
+
+**Prerequisite — bump the CLI first:** `synapse waiting-debug` exists only in v0.28.1+. Upgrade with `uv tool upgrade synapse-a2a` or `pipx upgrade synapse-a2a` before arming a schedule; otherwise the subcommand parser rejects `waiting-debug` on every run.
+
+**Legacy-agent caveat:** agents still running on a pre-0.28.0 binary do not expose `GET /debug/waiting` and log an expected `HTTP Error 404: Not Found`. Respawn them with the upgraded CLI (`synapse kill <id>` + spawn) to bring them into the dataset.
+
+**Schedule it** — there is no `synapse schedule` CLI for this. Use cron or launchd at a 5-minute cadence. See `docs/phase15-collection.md` for the canonical cron line and launchd plist.
+
 ### Saved Agent Definitions
 
 Manage reusable agent definitions that persist across sessions. Saved agents are stored as `.agent` files in project (`.synapse/agents/`) or user (`~/.synapse/agents/`) scope.

--- a/.claude/skills/synapse-a2a/references/commands.md
+++ b/.claude/skills/synapse-a2a/references/commands.md
@@ -329,7 +329,7 @@ synapse waiting-debug report --in /tmp/debug.jsonl
 
 **Prerequisite — bump the CLI first:** `synapse waiting-debug` exists only in v0.28.1+. Upgrade with `uv tool upgrade synapse-a2a` or `pipx upgrade synapse-a2a` before arming a schedule; otherwise the subcommand parser rejects `waiting-debug` on every run.
 
-**Legacy-agent caveat:** agents still running on a pre-0.28.0 binary do not expose `GET /debug/waiting` and log an expected `HTTP Error 404: Not Found`. Respawn them with the upgraded CLI (`synapse kill <id>` + spawn) to bring them into the dataset.
+**Legacy-agent caveat:** agents still running on a pre-0.28.0 binary do not expose `GET /debug/waiting` and log an expected `HTTP Error 404: Not Found`. Agents on v0.28.0+ whose controller lacks the `waiting_debug_snapshot` capability (e.g., a non-PTY runtime) return `HTTP Error 503: Service Unavailable` with detail `waiting debug data not available` — also expected and non-fatal. Respawn them with the upgraded CLI (`synapse kill <id>` + spawn) to bring them into the dataset.
 
 **Schedule it** — there is no `synapse schedule` CLI for this. Use cron or launchd at a 5-minute cadence. See `docs/phase15-collection.md` for the canonical cron line and launchd plist.
 

--- a/docs/phase15-collection.md
+++ b/docs/phase15-collection.md
@@ -156,20 +156,30 @@ synapse --version                   # expect 0.28.1 or newer
 synapse waiting-debug --help        # should list collect/report subcommands
 ```
 
-## Known Caveat: Legacy Agents Return 404
+## Known Caveat: Legacy Agents Return 404 (or 503 When Capability-Gated)
 
 Agents that were **spawned with an older `synapse` binary (v0.27.x or earlier)
 remain running with the old Python runtime** and do not expose
-`GET /debug/waiting`. When the collector reaches them it logs a one-line
-warning to stderr:
+`GET /debug/waiting` — the route is not registered, so the collector sees a
+404. When the collector reaches them it logs a one-line warning to stderr:
 
 ```text
 Warning: failed to collect waiting debug for <agent-id>: HTTP Error 404: Not Found
 ```
 
-This is expected and non-fatal — the collector continues with the next agent
-and still appends any successful snapshots to the JSONL. To bring an existing
-agent into the data set, stop and respawn it with the upgraded CLI:
+Agents running v0.28.0+ **can also fail with 503** if their controller does
+not expose `waiting_debug_snapshot` (for example, a non-PTY runtime where the
+capability is gated off). In that case the route exists but returns
+`503 Service Unavailable` with detail `waiting debug data not available`:
+
+```text
+Warning: failed to collect waiting debug for <agent-id>: HTTP Error 503: Service Unavailable
+```
+
+Both 404 (legacy) and 503 (capability gap) are expected and non-fatal — the
+collector continues with the next agent and still appends any successful
+snapshots to the JSONL. To bring an existing agent into the data set, stop
+and respawn it with the upgraded CLI:
 
 ```bash
 synapse kill <agent-id>

--- a/docs/phase15-collection.md
+++ b/docs/phase15-collection.md
@@ -110,3 +110,73 @@ Load it with:
 ```bash
 launchctl load ~/Library/LaunchAgents/dev.synapse.waiting-debug.plist
 ```
+
+Stop or disable later with:
+
+```bash
+launchctl unload ~/Library/LaunchAgents/dev.synapse.waiting-debug.plist
+```
+
+Useful additions for the plist that can bite on a fresh macOS account:
+
+- `PATH` in `EnvironmentVariables` — launchd does not inherit the login shell's
+  `PATH`, so `synapse` must be reachable via an absolute path in
+  `ProgramArguments` (recommended) or the plist must export
+  `PATH=/usr/local/bin:/usr/bin:/bin:$HOME/.local/bin`.
+- `HOME` — launchd sets `HOME` for user agents automatically, but explicitly
+  adding it to `EnvironmentVariables` makes the collector robust against
+  unusual session contexts.
+
+## Prerequisite: bump the installed `synapse` CLI
+
+`synapse waiting-debug` only exists in **v0.28.1 and newer**. The 5-minute
+cron/launchd schedule will spew `invalid choice: 'waiting-debug'` until the CLI
+is upgraded.
+
+If `synapse` was installed with `uv tool install`:
+
+```bash
+# Pull the latest release from PyPI once it is published
+uv tool upgrade synapse-a2a
+
+# Or install directly from a local checkout (useful before PyPI publish)
+uv tool install --reinstall --from /path/to/synapse-a2a synapse-a2a
+```
+
+If `synapse` was installed with `pipx`:
+
+```bash
+pipx upgrade synapse-a2a
+```
+
+Verify with:
+
+```bash
+synapse --version                   # expect 0.28.1 or newer
+synapse waiting-debug --help        # should list collect/report subcommands
+```
+
+## Known Caveat: Legacy Agents Return 404
+
+Agents that were **spawned with an older `synapse` binary (v0.27.x or earlier)
+remain running with the old Python runtime** and do not expose
+`GET /debug/waiting`. When the collector reaches them it logs a one-line
+warning to stderr:
+
+```text
+Warning: failed to collect waiting debug for <agent-id>: HTTP Error 404: Not Found
+```
+
+This is expected and non-fatal — the collector continues with the next agent
+and still appends any successful snapshots to the JSONL. To bring an existing
+agent into the data set, stop and respawn it with the upgraded CLI:
+
+```bash
+synapse kill <agent-id>
+synapse spawn <profile>            # or the appropriate team/spawn invocation
+```
+
+Only agents respawned after the CLI upgrade will start contributing rows.
+Pre-existing rooms stay invisible to Phase 2 analysis; this trade-off is
+intentional — the alternative (rolling restarts of every running agent on
+upgrade) is disruptive and not needed for Phase 2 planning.

--- a/plugins/synapse-a2a/skills/synapse-a2a/references/commands.md
+++ b/plugins/synapse-a2a/skills/synapse-a2a/references/commands.md
@@ -304,6 +304,35 @@ Use this when a WAITING prompt did not trip the controller as expected: each att
 - Debugging why an agent is stuck in PROCESSING (check file locks)
 - Reviewing recent communication history for a specific agent
 
+### Waiting Debug Collection (`synapse waiting-debug`)
+
+Added in v0.28.1 (#630, #632). Persists the in-memory `/debug/waiting` ring buffer across every running agent so Phase 2 detection work has real data.
+
+```bash
+# Collect one snapshot per running agent into ~/.synapse/waiting_debug.jsonl
+synapse waiting-debug collect
+synapse waiting-debug collect --agent <agent-id>       # single agent
+synapse waiting-debug collect --include-empty          # record empty rings too
+synapse waiting-debug collect --out /tmp/debug.jsonl   # override output path
+
+# Aggregate / inspect
+synapse waiting-debug report
+synapse waiting-debug report --since 2026-04-23T00:00:00+00:00
+synapse waiting-debug report --agent <agent-id>
+synapse waiting-debug report --json
+synapse waiting-debug report --in /tmp/debug.jsonl
+```
+
+- **Output**: `~/.synapse/waiting_debug.jsonl` by default, one JSONL row per `{agent_id, port, collected_at, snapshot}`.
+- **Aggregate fields** (`report` output): total attempts, `profiles` / `pattern_source` / `path_used` / `confidence` distributions, `idle_gate_drops` count, `renderer_unavailable_agents` ratio.
+- **Error handling**: per-agent HTTP / parse errors log one warning to stderr and the collector continues with the next agent. Invalid JSONL lines in the input also warn and are skipped.
+
+**Prerequisite — bump the CLI first:** `synapse waiting-debug` exists only in v0.28.1+. Upgrade with `uv tool upgrade synapse-a2a` or `pipx upgrade synapse-a2a` before arming a schedule; otherwise the subcommand parser rejects `waiting-debug` on every run.
+
+**Legacy-agent caveat:** agents still running on a pre-0.28.0 binary do not expose `GET /debug/waiting` and log an expected `HTTP Error 404: Not Found`. Respawn them with the upgraded CLI (`synapse kill <id>` + spawn) to bring them into the dataset.
+
+**Schedule it** — there is no `synapse schedule` CLI for this. Use cron or launchd at a 5-minute cadence. See `docs/phase15-collection.md` for the canonical cron line and launchd plist.
+
 ### Saved Agent Definitions
 
 Manage reusable agent definitions that persist across sessions. Saved agents are stored as `.agent` files in project (`.synapse/agents/`) or user (`~/.synapse/agents/`) scope.

--- a/plugins/synapse-a2a/skills/synapse-a2a/references/commands.md
+++ b/plugins/synapse-a2a/skills/synapse-a2a/references/commands.md
@@ -329,7 +329,7 @@ synapse waiting-debug report --in /tmp/debug.jsonl
 
 **Prerequisite — bump the CLI first:** `synapse waiting-debug` exists only in v0.28.1+. Upgrade with `uv tool upgrade synapse-a2a` or `pipx upgrade synapse-a2a` before arming a schedule; otherwise the subcommand parser rejects `waiting-debug` on every run.
 
-**Legacy-agent caveat:** agents still running on a pre-0.28.0 binary do not expose `GET /debug/waiting` and log an expected `HTTP Error 404: Not Found`. Respawn them with the upgraded CLI (`synapse kill <id>` + spawn) to bring them into the dataset.
+**Legacy-agent caveat:** agents still running on a pre-0.28.0 binary do not expose `GET /debug/waiting` and log an expected `HTTP Error 404: Not Found`. Agents on v0.28.0+ whose controller lacks the `waiting_debug_snapshot` capability (e.g., a non-PTY runtime) return `HTTP Error 503: Service Unavailable` with detail `waiting debug data not available` — also expected and non-fatal. Respawn them with the upgraded CLI (`synapse kill <id>` + spawn) to bring them into the dataset.
 
 **Schedule it** — there is no `synapse schedule` CLI for this. Use cron or launchd at a 5-minute cadence. See `docs/phase15-collection.md` for the canonical cron line and launchd plist.
 

--- a/site-docs/guide/agent-management.md
+++ b/site-docs/guide/agent-management.md
@@ -371,4 +371,37 @@ If `(renderer: off)` persists on an agent, restart the agent (`synapse kill <id>
 
 Use this when a prompt *should* have flipped the agent to WAITING but did not: each attempt row includes `new_data_hex_prefix` (raw bytes) and `rendered_text_tail` (what the detector saw), so you can diagnose whether the regex missed, the idle gate dropped it, or the renderer garbled it.
 
-The buffer is in-memory only — it empties on process restart. For long-running collection across multiple agents, scrape `GET /debug/waiting` into a JSONL (see [Issue #630](https://github.com/s-hiraoku/synapse-a2a/issues/630), Phase 1.5).
+The buffer is in-memory only — it empties on process restart. For long-running collection across multiple agents, use the Phase 1.5 `synapse waiting-debug` CLI (see below).
+
+### Phase 1.5: Periodic Data Collection (`synapse waiting-debug`)
+
+`synapse waiting-debug` (added in v0.28.1, see #630/#632) persists the `/debug/waiting` snapshot exposed by every running agent to `~/.synapse/waiting_debug.jsonl`, so Phase 2 detection-logic work has real data to lean on instead of guesses.
+
+```bash
+synapse waiting-debug collect                         # one-shot across all agents
+synapse waiting-debug collect --agent <id>            # single agent
+synapse waiting-debug collect --include-empty         # record agents whose ring is empty
+synapse waiting-debug report                          # human-readable aggregate
+synapse waiting-debug report --since 2026-04-23T00:00:00+00:00 --agent <id>
+synapse waiting-debug report --json                   # machine-readable for analysis
+```
+
+The report groups results by profile, `pattern_source`, `path_used`, and `confidence`, and surfaces `idle_gate_drops` (prompt visible but gate dropped it) plus the ratio of agents whose snapshot reported `renderer_available=false`.
+
+**Schedule it to run every five minutes** (see `docs/phase15-collection.md` for the canonical recipes):
+
+```bash
+# launchd (macOS)
+cp plists/dev.synapse.waiting-debug.plist ~/Library/LaunchAgents/
+launchctl load ~/Library/LaunchAgents/dev.synapse.waiting-debug.plist
+
+# cron
+crontab -e
+*/5 * * * * /usr/bin/env synapse waiting-debug collect >> ~/.synapse/waiting_debug_collect.log 2>&1
+```
+
+!!! warning "Bump the installed CLI first"
+    `synapse waiting-debug` only exists in v0.28.1+. Upgrade the globally-installed CLI (`uv tool upgrade synapse-a2a` or `pipx upgrade synapse-a2a`) before arming the schedule, otherwise every run emits `invalid choice: 'waiting-debug'`.
+
+!!! info "Legacy agents return 404"
+    Agents that are still running with a pre-0.28.0 `synapse` binary do not expose `GET /debug/waiting`. The collector logs one `HTTP Error 404: Not Found` warning per legacy agent to stderr and continues. Data accrues only for agents respawned after the CLI upgrade — stop and restart them with `synapse kill <id>` followed by the usual spawn when you want them in the dataset.

--- a/site-docs/guide/agent-management.md
+++ b/site-docs/guide/agent-management.md
@@ -403,5 +403,5 @@ crontab -e
 !!! warning "Bump the installed CLI first"
     `synapse waiting-debug` only exists in v0.28.1+. Upgrade the globally-installed CLI (`uv tool upgrade synapse-a2a` or `pipx upgrade synapse-a2a`) before arming the schedule, otherwise every run emits `invalid choice: 'waiting-debug'`.
 
-!!! info "Legacy agents return 404"
-    Agents that are still running with a pre-0.28.0 `synapse` binary do not expose `GET /debug/waiting`. The collector logs one `HTTP Error 404: Not Found` warning per legacy agent to stderr and continues. Data accrues only for agents respawned after the CLI upgrade — stop and restart them with `synapse kill <id>` followed by the usual spawn when you want them in the dataset.
+!!! info "Legacy agents return 404 (or 503 when capability-gated)"
+    Agents that are still running with a pre-0.28.0 `synapse` binary do not expose `GET /debug/waiting`. The collector logs one `HTTP Error 404: Not Found` warning per legacy agent to stderr and continues. Agents on v0.28.0+ whose controller lacks the `waiting_debug_snapshot` capability (e.g., a non-PTY runtime) instead return `HTTP Error 503: Service Unavailable` with detail `waiting debug data not available` — also expected and non-fatal. Data accrues only for agents respawned after the CLI upgrade — stop and restart them with `synapse kill <id>` followed by the usual spawn when you want them in the dataset.


### PR DESCRIPTION
## Summary

Fill in the operational on-ramp for the Phase 1.5 \`synapse waiting-debug\` pipeline (#630/#632). Three things bit me when arming the schedule on a real machine; each of them now has a callout in the right place:

1. **Bump the installed CLI first** — \`synapse waiting-debug\` only exists in v0.28.1+. Without upgrading the globally-installed \`synapse\` binary the cron/launchd job fails every 5 minutes with \`invalid choice: 'waiting-debug'\`. Added \`uv tool upgrade\` / \`pipx upgrade\` recipes.
2. **Legacy agents return 404** — agents still running on a pre-0.28.0 binary do not expose \`GET /debug/waiting\`. The collector logs one warning per legacy agent and continues. Documented as expected behaviour so operators do not chase ghosts.
3. **launchd plist gotchas** — \`PATH\` is not inherited from the login shell (recommend absolute \`ProgramArguments\` path or an explicit \`EnvironmentVariables.PATH\`), \`launchctl unload\` is the stop command, and \`HOME\` can be pinned for robustness.

## Files touched

| File | Change |
|---|---|
| \`docs/phase15-collection.md\` | Extends the existing recipe with \"Prerequisite: bump\" and \"Known Caveat: Legacy Agents Return 404\" sections; adds \`launchctl unload\` and env-var notes. |
| \`site-docs/guide/agent-management.md\` | New \"Phase 1.5: Periodic Data Collection (\`synapse waiting-debug\`)\" subsection after the existing \`--debug-waiting\` section, with admonitions for the bump prerequisite and legacy 404. |
| \`plugins/synapse-a2a/skills/synapse-a2a/references/commands.md\` | New \"Waiting Debug Collection\" subsection covering \`collect\` / \`report\` options, aggregate fields, error handling, the bump prerequisite and the legacy-agent caveat. |
| \`.agents/skills/synapse-a2a/references/commands.md\` | Mirror of canonical. |
| \`.claude/skills/synapse-a2a/references/commands.md\` | Mirror of canonical. |

## Scope

Docs only. No code or behaviour changes.

## Test plan

- [ ] CI green
- [ ] \`diff -q\` between canonical and mirrors returns no differences

## Related

- Phase 1.5 feature PR: #632
- Phase 1 feature PR: #627
- Release that shipped Phase 1.5: v0.28.1 (via PR #634)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* **Documentation**
  * `synapse waiting-debug` CLIコマンドの使用方法とインストール手順に関するドキュメントを追加しました。エージェント間でのデバッグ情報の収集、レポート機能（時間フィルタリング、JSON形式出力対応）、およびmacOSでの運用ガイダンスを含みます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->