### PR TITLE
chore(release): bump to 0.28.3 for waiting-debug Phase 1.5 polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.28.3] - 2026-04-26
+
+Patch release for the Phase 1.5 polish work tracked in #635 / #630 and merged via #638. Operationally focused: warns less right after PtyRenderer boot, honors `HOME` overrides in tests, lets cron capture JSON reports atomically, and documents the `--timeout 0` fast-fail mode so operators don't read it as "no timeout". No detection-logic changes; Phase 2 remains out of scope.
+
 ### Added
 
 - **`synapse waiting-debug collect --timeout SECONDS`** — override the HTTP timeout used when querying `/debug/waiting` on each registered agent. Default is now **5.0 s** (previously hard-coded 3.0 s), which eliminates a common warn-flood immediately after PtyRenderer boots when agents can't respond within 3 s (#635).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ site_url: https://s-hiraoku.github.io/synapse-a2a/
 site_description: Multi-agent collaboration framework using Google A2A Protocol
 site_author: s-hiraoku
 repo_url: https://github.com/s-hiraoku/synapse-a2a
-repo_name: s-hiraoku/synapse-a2a v0.28.2
+repo_name: s-hiraoku/synapse-a2a v0.28.3
 docs_dir: site-docs
 
 theme:

--- a/plugins/synapse-a2a/.claude-plugin/plugin.json
+++ b/plugins/synapse-a2a/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synapse-a2a",
-  "version": "0.28.2",
+  "version": "0.28.3",
   "description": "Complete plugin for Synapse A2A multi-agent framework including inter-agent communication, file safety, and history management",
   "author": {
     "name": "s-hiraoku",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synapse-a2a"
-version = "0.28.2"
+version = "0.28.3"
 description = "Agent-to-Agent communication protocol for CLI agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/site-docs/changelog.md
+++ b/site-docs/changelog.md
@@ -4,13 +4,14 @@ For the complete changelog, see [CHANGELOG.md on GitHub](https://github.com/s-hi
 
 ## Recent Highlights
 
-### Unreleased (post-v0.28.2)
+### v0.28.3
 
 - **Added**: `synapse waiting-debug collect --timeout SECONDS` — overrides the HTTP timeout used when querying `/debug/waiting` on each registered agent. Default raised from 3.0 s to **5.0 s**, which eliminates the common warn-flood immediately after PtyRenderer boots when agents can't respond within 3 s (#635).
-- **Added**: `synapse waiting-debug report --out PATH` — writes the aggregated JSON report to a file instead of stdout. When `--out` is set, stdout stays empty so the flag is safe to use from cron / launchd without capturing mixed text/JSON output (#635).
+- **Added**: `synapse waiting-debug report --out PATH` — writes the aggregated JSON report to a file instead of stdout. When `--out` is set, stdout stays empty so the flag is safe to use from cron / launchd without capturing mixed text/JSON output. The write is **atomic** (temp file + `os.replace`) so concurrent readers never see a half-written report (#635).
 - **Changed**: `WaitingDebugReporter._record_is_since` — records whose `collected_at` can't be parsed are still skipped for `--since` filtering, but now emit `Warning: record at line N has unparseable collected_at: '<value>' (<reason>)` to stderr instead of being silently dropped. Matches existing behaviour for invalid JSONL lines (#635).
-- **Changed**: `synapse.commands.waiting_debug.default_waiting_debug_path()` is resolved lazily per call; tests and tools that set `HOME=/tmp/...` now actually redirect collection/reporting instead of silently using the real home. The module-level `DEFAULT_WAITING_DEBUG_PATH` constant is removed (#635).
-- **Fixed**: Closes #630 — Phase 1.5 persistence pipeline is now operationally stable with the polish above.
+- **Changed**: `synapse.commands.waiting_debug.default_waiting_debug_path()` is resolved lazily per call; tests and tools that set `HOME=/tmp/...` now actually redirect collection/reporting instead of silently using the real home. New `SYNAPSE_WAITING_DEBUG_PATH` env var override is honored via `synapse/paths.py` (#635).
+- **Changed**: `--timeout` argparse validation rejects negative values (`--timeout must be >= 0`); `--timeout 0` is preserved as the deliberate "fail fast / never wait" mode (urllib non-blocking) and is **not** equivalent to "no timeout" — omit the flag for the default 5 s budget (#635).
+- **Fixed**: Closes #630 — Phase 1.5 persistence pipeline is now operationally stable with the polish above. Dead `if collected_dt is None: return False` branch in `_record_is_since` removed (unreachable when `collected_at` is `str`).
 
 ### v0.28.2
 

--- a/site-docs/concepts/a2a-protocol.md
+++ b/site-docs/concepts/a2a-protocol.md
@@ -17,7 +17,7 @@ Every A2A agent publishes a discovery document at `/.well-known/agent.json`:
   "name": "synapse-claude-8100",
   "description": "Claude Code agent managed by Synapse A2A",
   "url": "http://localhost:8100",
-  "version": "0.28.2",
+  "version": "0.28.3",
   "capabilities": {
     "streaming": false,
     "pushNotifications": false

--- a/site-docs/getting-started/installation.md
+++ b/site-docs/getting-started/installation.md
@@ -58,7 +58,7 @@
 synapse --version
 ```
 
-You should see the version number (e.g., `0.28.2`).
+You should see the version number (e.g., `0.28.3`).
 
 ## Initialize Configuration
 
@@ -88,7 +88,7 @@ gh skill install s-hiraoku/synapse-a2a synapse-manager
 gh skill install s-hiraoku/synapse-a2a synapse-reinst
 
 # Optional: pin to a release tag so updates are explicit
-gh skill install s-hiraoku/synapse-a2a synapse-a2a --pin v0.28.2
+gh skill install s-hiraoku/synapse-a2a synapse-a2a --pin v0.28.3
 
 # Optional: target a specific agent runtime
 gh skill install s-hiraoku/synapse-a2a synapse-a2a --agent claude-code

--- a/uv.lock
+++ b/uv.lock
@@ -1439,7 +1439,7 @@ wheels = [
 
 [[package]]
 name = "synapse-a2a"
-version = "0.28.2"
+version = "0.28.3"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

Cuts patch release **0.28.3**, rolling up the Phase 1.5 polish work merged via PR #638.

The CHANGELOG `[Unreleased]` block (added by #638) is renamed to `[0.28.3] - 2026-04-26` and a one-paragraph release summary is prepended, matching the v0.28.2 pattern. No code behavior changes in this PR — it's the version-bump companion to #638.

### What ships in 0.28.3

- `synapse waiting-debug collect --timeout SECONDS` (default raised 3.0 → 5.0)
- `synapse waiting-debug report --out PATH` (atomic write via `os.replace`)
- Lazy `~/.synapse/waiting_debug.jsonl` resolution + `SYNAPSE_WAITING_DEBUG_PATH` env override (`synapse/paths.py` convention)
- `--timeout` argparse rejects negative; `0` preserved as "fail fast" mode
- Reporter warns on unparseable `collected_at`; dead `collected_dt is None` branch removed
- Docs synced across guides/, plugins/, site-docs/, and skill mirrors

No detection-logic changes — Phase 2 (#608) remains out of scope.

## Files updated

- `pyproject.toml`: `0.28.2` → `0.28.3`
- `plugins/synapse-a2a/.claude-plugin/plugin.json`: `"version": "0.28.3"`
- `mkdocs.yml`: `repo_name` header version
- `site-docs/getting-started/installation.md`: verify example + `--pin v0.28.3`
- `site-docs/concepts/a2a-protocol.md`: Agent Card JSON example
- `CHANGELOG.md`: `[Unreleased]` → `[0.28.3] - 2026-04-26` (existing block + summary paragraph)
- `site-docs/changelog.md`: `Unreleased (post-v0.28.2)` → `v0.28.3` highlights, with the CodeRabbit follow-up details (atomic write, --timeout 0 caveat, env override) inlined
- `uv.lock`: `synapse-a2a` editable self-reference bumped

## Test plan
- [x] `uv run synapse --version` reports `synapse 0.28.3`
- [x] `uv run mkdocs build --strict` passes (1.69 s, no warnings)
- [x] `grep -r "0\\.28\\.2"` returns zero matches in tracked version-pinned locations (`pyproject.toml`, `plugin.json`, `mkdocs.yml`, `site-docs/getting-started/installation.md`, `site-docs/concepts/a2a-protocol.md`)
- [x] No source-tree `.py` changes — pre-commit ruff/mypy hooks correctly skipped (no files to check)

## Related

Follow-up to #638 (closes #635, closes #630).

🤖 Generated with [Claude Code](https://claude.com/claude-code)