### PR TITLE
feat: surface WAITING_FOR_INPUT agent status for non-permission A2A waits (#538)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`WAITING_FOR_INPUT` agent status (#538):** non-permission A2A `input_required` tasks now surface as a distinct registry/list/status state, while permission prompts keep the existing `WAITING` state.
+
 ## [0.28.3] - 2026-04-26
 
 Patch release for the Phase 1.5 polish work tracked in #635 / #630 and merged via #638. Operationally focused: warns less right after PtyRenderer boot, honors `HOME` overrides in tests, lets cron capture JSON reports atomically, and documents the `--timeout 0` fast-fail mode so operators don't read it as "no timeout". No detection-logic changes; Phase 2 remains out of scope.
@@ -3572,7 +3576,8 @@ See v0.3.14 for reply PTY injection, CURRENT column, and history default changes
 - External agent connectivity vision document
 - PyPI publishing instructions
 
-[Unreleased]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.28.2...HEAD
+[Unreleased]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.28.3...HEAD
+[0.28.3]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.28.2...v0.28.3
 [0.28.2]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.28.1...v0.28.2
 [0.28.1]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.28.0...v0.28.1
 [0.28.0]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.27.2...v0.28.0

--- a/synapse/a2a_compat.py
+++ b/synapse/a2a_compat.py
@@ -56,6 +56,7 @@ from synapse.registry import AgentRegistry
 from synapse.reply_stack import SenderInfo as ReplyStackSenderInfo
 from synapse.reply_stack import get_reply_stack
 from synapse.reply_target import save_reply_target
+from synapse.status import WAITING, WAITING_FOR_INPUT
 from synapse.terminal_jump import create_panes, detect_terminal_app
 from synapse.utils import (
     extract_file_parts,
@@ -264,7 +265,8 @@ def map_synapse_status_to_a2a(synapse_status: str) -> TaskState:
     mapping: dict[str, TaskState] = {
         "STARTING": "submitted",
         "BUSY": "working",
-        "WAITING": "input_required",
+        WAITING: "input_required",
+        WAITING_FOR_INPUT: "input_required",
         "READY": "completed",
         "DONE": "completed",
         "NOT_STARTED": "submitted",
@@ -1102,8 +1104,34 @@ def create_a2a_router(
     # When status transitions to READY or DONE, check working tasks.
     if controller:
 
+        def _has_non_permission_input_required_task() -> bool:
+            for task in task_store.list_tasks():
+                if task.status != "input_required":
+                    continue
+                metadata = task.metadata or {}
+                if not isinstance(metadata.get("permission"), dict):
+                    return True
+            return False
+
+        def _is_permission_waiting_status(new_status: str) -> bool:
+            if new_status == WAITING:
+                return True
+            if getattr(controller, "status", None) == WAITING:
+                return True
+            waiting_source = getattr(controller, "last_waiting_source", "none")
+            return waiting_source not in (None, "", "none")
+
+        def _sync_registry_input_wait_status(new_status: str) -> None:
+            if registry is None or agent_id is None:
+                return
+            if _is_permission_waiting_status(new_status):
+                registry.update_status(agent_id, WAITING)
+                return
+            if _has_non_permission_input_required_task():
+                registry.update_status(agent_id, WAITING_FOR_INPUT)
+
         def _on_status_change(old: str, new: str) -> None:
-            if new == "WAITING":
+            if new == WAITING:
                 for task in task_store.list_tasks():
                     if task.status != "working":
                         continue
@@ -1153,14 +1181,20 @@ def create_a2a_router(
                         self_agent_type=agent_type,
                     )
                     _run_async_from_sync(coro)
+                _sync_registry_input_wait_status(new)
                 return
 
-            if old == "WAITING":
+            if old == WAITING:
                 for task in task_store.list_tasks():
-                    if task.status == "input_required":
+                    metadata = task.metadata or {}
+                    if task.status == "input_required" and isinstance(
+                        metadata.get("permission"), dict
+                    ):
                         task_store.update_status(task.id, "working")
                 # Fall through to the READY/DONE finalization below so
                 # that WAITING → READY completes working tasks normally.
+
+            _sync_registry_input_wait_status(new)
 
             if new not in ("READY", "DONE"):
                 return

--- a/synapse/status.py
+++ b/synapse/status.py
@@ -1,7 +1,7 @@
 """Agent status constants and utilities.
 
 Status flow:
-    PROCESSING -> READY/WAITING -> PROCESSING -> ... -> DONE -> READY (after 10s)
+    PROCESSING -> READY/WAITING/WAITING_FOR_INPUT -> PROCESSING -> ... -> DONE -> READY (after 10s)
 
 Statuses:
     READY: Agent is idle (not processing anything)

--- a/synapse/status.py
+++ b/synapse/status.py
@@ -6,6 +6,7 @@ Status flow:
 Statuses:
     READY: Agent is idle (not processing anything)
     WAITING: Agent is waiting for user input (showing choices/prompt)
+    WAITING_FOR_INPUT: Agent has an A2A task waiting for a non-permission response
     PROCESSING: Agent is actively working (generating output, waiting for A2A response)
     DONE: Agent has completed a task (transitions to READY after timeout or new activity)
 """
@@ -15,17 +16,21 @@ from __future__ import annotations
 # Status constants
 READY = "READY"
 WAITING = "WAITING"
+WAITING_FOR_INPUT = "WAITING_FOR_INPUT"
 PROCESSING = "PROCESSING"
 DONE = "DONE"
 SHUTTING_DOWN = "SHUTTING_DOWN"
 
 # All valid statuses
-ALL_STATUSES = frozenset({READY, WAITING, PROCESSING, DONE, SHUTTING_DOWN})
+ALL_STATUSES = frozenset(
+    {READY, WAITING, WAITING_FOR_INPUT, PROCESSING, DONE, SHUTTING_DOWN}
+)
 
 # Status display colors (for Rich TUI)
 STATUS_STYLES = {
     READY: "bold green",  # Green: idle, ready for input
     WAITING: "bold cyan",  # Cyan: waiting for user input/choice
+    WAITING_FOR_INPUT: "bold orange3",  # Orange: waiting for A2A/human response
     PROCESSING: "bold yellow",  # Yellow: actively working
     DONE: "bold blue",  # Blue: completed successfully
     SHUTTING_DOWN: "bold red",  # Red: graceful shutdown in progress

--- a/tests/test_a2a_compat.py
+++ b/tests/test_a2a_compat.py
@@ -293,6 +293,10 @@ class TestStatusMapping:
         """NOT_STARTED should map to submitted."""
         assert map_synapse_status_to_a2a("NOT_STARTED") == "submitted"
 
+    def test_map_waiting_for_input_to_input_required(self):
+        """WAITING_FOR_INPUT should map to input_required."""
+        assert map_synapse_status_to_a2a("WAITING_FOR_INPUT") == "input_required"
+
     def test_map_unknown_to_working(self):
         """Unknown status should default to working."""
         assert map_synapse_status_to_a2a("UNKNOWN") == "working"
@@ -382,6 +386,116 @@ class TestA2ARouterEndpoints:
         permission = updated.metadata["permission"]
         assert permission["waiting_confidence"] == 0.6
         assert permission["waiting_source"] == "heuristic"
+
+    def test_input_required_task_updates_registry_waiting_for_input(
+        self, mock_controller
+    ):
+        """Non-permission input_required tasks should surface in registry."""
+        from synapse.a2a_compat import task_store
+        from synapse.a2a_models import Message, TextPart
+
+        with task_store._lock:
+            task_store._tasks.clear()
+
+        mock_controller.status = "PROCESSING"
+        mock_controller.last_waiting_source = "none"
+        mock_registry = MagicMock()
+
+        create_a2a_router(
+            mock_controller,
+            "test-agent",
+            8000,
+            "\n",
+            agent_id="synapse-test-agent-8000",
+            registry=mock_registry,
+        )
+        on_status_change = mock_controller.on_status_change.call_args.args[0]
+
+        task = task_store.create(Message(parts=[TextPart(text="Confirm spec?")]))
+        task_store.update_status(task.id, "input_required")
+
+        on_status_change("READY", "PROCESSING")
+
+        mock_registry.update_status.assert_called_with(
+            "synapse-test-agent-8000", "WAITING_FOR_INPUT"
+        )
+
+    def test_permission_waiting_keeps_registry_waiting(self, mock_controller):
+        """Permission prompts should keep registry WAITING when both states exist."""
+        from synapse.a2a_compat import task_store
+        from synapse.a2a_models import Message, TextPart
+
+        with task_store._lock:
+            task_store._tasks.clear()
+
+        mock_controller.status = "WAITING"
+        mock_controller.get_context.return_value = "Allow Bash command?"
+        mock_controller.last_waiting_source = "regex"
+        mock_registry = MagicMock()
+
+        create_a2a_router(
+            mock_controller,
+            "test-agent",
+            8000,
+            "\n",
+            agent_id="synapse-test-agent-8000",
+            registry=mock_registry,
+        )
+        on_status_change = mock_controller.on_status_change.call_args.args[0]
+
+        task = task_store.create(Message(parts=[TextPart(text="Confirm spec?")]))
+        task_store.update_status(task.id, "input_required")
+
+        on_status_change("PROCESSING", "WAITING")
+
+        mock_registry.update_status.assert_any_call(
+            "synapse-test-agent-8000", "WAITING"
+        )
+        assert ("synapse-test-agent-8000", "WAITING_FOR_INPUT") not in [
+            call.args for call in mock_registry.update_status.call_args_list
+        ]
+
+    def test_permission_clear_preserves_non_permission_input_required(
+        self, mock_controller
+    ):
+        """Clearing permission WAITING should reveal verifier input_required tasks."""
+        from synapse.a2a_compat import task_store
+        from synapse.a2a_models import Message, TextPart
+
+        with task_store._lock:
+            task_store._tasks.clear()
+
+        mock_controller.status = "READY"
+        mock_controller.last_waiting_source = "none"
+        mock_registry = MagicMock()
+
+        create_a2a_router(
+            mock_controller,
+            "test-agent",
+            8000,
+            "\n",
+            agent_id="synapse-test-agent-8000",
+            registry=mock_registry,
+        )
+        on_status_change = mock_controller.on_status_change.call_args.args[0]
+
+        permission_task = task_store.create(
+            Message(parts=[TextPart(text="Permission prompt")]),
+            metadata={"permission": {"pty_context": "Allow Bash?"}},
+        )
+        verifier_task = task_store.create(
+            Message(parts=[TextPart(text="Confirm spec?")])
+        )
+        task_store.update_status(permission_task.id, "input_required")
+        task_store.update_status(verifier_task.id, "input_required")
+
+        on_status_change("WAITING", "READY")
+
+        assert task_store.get(permission_task.id).status != "input_required"
+        assert task_store.get(verifier_task.id).status == "input_required"
+        mock_registry.update_status.assert_any_call(
+            "synapse-test-agent-8000", "WAITING_FOR_INPUT"
+        )
 
     def test_tasks_send_outputs_plain_message(self, client, mock_controller):
         """/tasks/send should output message with A2A prefix and sender for agent identification."""

--- a/tests/test_cmd_list_watch.py
+++ b/tests/test_cmd_list_watch.py
@@ -769,15 +769,17 @@ class TestRichRenderer:
         assert table.row_count == 1
 
     def test_waiting_for_input_status_has_distinct_style(self):
-        """WAITING_FOR_INPUT should render with a yellow/orange style."""
+        """WAITING_FOR_INPUT should render with the canonical orange3 style."""
         from synapse.commands.renderers.rich_renderer import RichRenderer
+        from synapse.status import STATUS_STYLES, WAITING, WAITING_FOR_INPUT
 
         renderer = RichRenderer()
 
-        text = renderer._format_status("WAITING_FOR_INPUT")
+        text = renderer._format_status(WAITING_FOR_INPUT)
 
-        assert text.plain == "WAITING_FOR_INPUT"
-        assert "yellow" in text.style or "orange" in text.style
+        assert text.plain == WAITING_FOR_INPUT
+        assert str(text.style) == STATUS_STYLES[WAITING_FOR_INPUT]
+        assert str(text.style) != STATUS_STYLES[WAITING]
 
     def test_build_empty_table(self):
         """Should build empty table with port ranges."""

--- a/tests/test_cmd_list_watch.py
+++ b/tests/test_cmd_list_watch.py
@@ -768,6 +768,17 @@ class TestRichRenderer:
         # Table should have rows
         assert table.row_count == 1
 
+    def test_waiting_for_input_status_has_distinct_style(self):
+        """WAITING_FOR_INPUT should render with a yellow/orange style."""
+        from synapse.commands.renderers.rich_renderer import RichRenderer
+
+        renderer = RichRenderer()
+
+        text = renderer._format_status("WAITING_FOR_INPUT")
+
+        assert text.plain == "WAITING_FOR_INPUT"
+        assert "yellow" in text.style or "orange" in text.style
+
     def test_build_empty_table(self):
         """Should build empty table with port ranges."""
         from synapse.commands.renderers.rich_renderer import RichRenderer

--- a/tests/test_cmd_status.py
+++ b/tests/test_cmd_status.py
@@ -115,6 +115,15 @@ class TestStatusMetadata:
         text = output.getvalue()
         assert "Status:      WAITING (renderer: off)" in text
 
+    def test_displays_waiting_for_input_status(self):
+        """Should show WAITING_FOR_INPUT as its own status."""
+        info = _make_agent_info(status="WAITING_FOR_INPUT")
+        cmd, output = _make_command(agent_info=info)
+        cmd.run("my-claude")
+
+        text = output.getvalue()
+        assert "Status:      WAITING_FOR_INPUT" in text
+
 
 class TestStatusCurrentTask:
     """Tests for current task with elapsed time."""
@@ -196,6 +205,15 @@ class TestStatusJsonOutput:
         assert data["agent_id"] == "synapse-claude-8100"
         assert data["status"] == "READY"
         assert data["renderer_available"] is True
+
+    def test_json_output_preserves_waiting_for_input(self):
+        """JSON output should expose WAITING_FOR_INPUT unchanged."""
+        info = _make_agent_info(status="WAITING_FOR_INPUT")
+        cmd, output = _make_command(agent_info=info)
+        cmd.run("my-claude", json_output=True)
+
+        data = json.loads(output.getvalue())
+        assert data["status"] == "WAITING_FOR_INPUT"
 
     def test_json_not_found(self):
         """Should output error JSON when agent not found."""

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import pytest
 
 from synapse.registry import AgentRegistry, NameConflictError, resolve_uds_path
+from synapse.status import STATUS_STYLES, WAITING_FOR_INPUT, is_valid_status
 
 
 @pytest.fixture
@@ -75,6 +76,17 @@ def test_register_with_custom_status(registry):
     with open(expected_file) as f:
         data = json.load(f)
         assert data["status"] == "BUSY"
+
+
+def test_waiting_for_input_is_valid_registry_status(registry):
+    """WAITING_FOR_INPUT should be a first-class registry status."""
+    agent_id = "test_waiting_for_input_agent"
+    registry.register(agent_id, "claude", 8100)
+
+    assert is_valid_status(WAITING_FOR_INPUT) is True
+    assert WAITING_FOR_INPUT in STATUS_STYLES
+    assert registry.update_status(agent_id, WAITING_FOR_INPUT) is True
+    assert registry.get_agent(agent_id)["status"] == WAITING_FOR_INPUT
 
 
 def test_register_includes_endpoint(registry):


### PR DESCRIPTION
## Summary

Implements [#538](https://github.com/s-hiraoku/synapse-a2a/issues/538) using the issue's recommended approach: A2A `input_required` task status is already in the spec, but Synapse's registry never reflected it. Now it does.

A second status value, `WAITING_FOR_INPUT`, is now distinct from the existing `WAITING` (which stays reserved for permission prompts). The two are surfaced with different Rich colours so an operator can tell at a glance whether an agent is waiting on a permission `Y/n` prompt or sitting on a non-permission "Confirm spec?"-style A2A turn.

## Behaviour

- **New value** `WAITING_FOR_INPUT` added to `synapse.status` constants, `ALL_STATUSES`, and `STATUS_STYLES` (`bold orange3` — distinct from the `bold cyan` used for `WAITING`).
- **A2A status reconciliation** runs on every controller status transition inside `a2a_compat.create_a2a_router`. Three local helpers split the decision cleanly:
  - `_has_non_permission_input_required_task()` walks `task_store` and ignores tasks with `metadata.permission` set (those belong to `WAITING`).
  - `_is_permission_waiting_status(new)` is `True` if the new status is `WAITING`, the controller is currently `WAITING`, or `last_waiting_source` indicates a permission regex match — preserving precedence so permission prompts always win.
  - `_sync_registry_input_wait_status(new)` writes `WAITING` when permission is active, otherwise `WAITING_FOR_INPUT` when a non-permission `input_required` task exists, otherwise leaves the registry alone (existing READY/DONE finalisation is untouched).
- **Mapping** `map_synapse_status_to_a2a` now maps `WAITING_FOR_INPUT → input_required` alongside `WAITING`.

## Scope

Kept tight per the task brief:

- `controller.py` **untouched**. PTY-level detection remains the controller's job; surfacing the result on the registry is the a2a_compat callback's job. (Phase 2 / #608 will revisit the global state-machine.)
- `registry.py` **untouched** — registry stores arbitrary status strings, the new value is added at the constants level only.
- ~48 existing `\"WAITING\"` string literals across `synapse/` are **not refactored**. Those belong to a future Phase 2 cleanup.
- The CHANGELOG also gains the missing `0.28.3` compare-link line that release #639 forgot.

## Tests (7 new)

- `tests/test_registry.py` — round-trip persistence of `WAITING_FOR_INPUT`.
- `tests/test_a2a_compat.py` — mapping to `input_required`, non-permission task → registry `WAITING_FOR_INPUT`, and a precedence test that asserts `WAITING_FOR_INPUT` is *not* in `update_status.call_args_list` when permission `WAITING` is active.
- `tests/test_cmd_status.py` — text + JSON status outputs include the new value.
- `tests/test_cmd_list_watch.py` — Rich style is the orange one, not the cyan `WAITING` one.

## Verification

- [x] focused new tests **7 pass**
- [x] affected suite **178 pass** (`tests/test_registry.py tests/test_a2a_compat.py tests/test_cmd_status.py tests/test_cmd_list_watch.py`)
- [x] `uv run mypy synapse/` — **0 issues** across 114 files
- [x] `ruff` / `ruff format` clean (pre-commit)
- [x] full `uv run pytest tests/` — same 5 pre-existing local-env failures as PR #638 / #639 (`test_settings.py::TestInstructionFilePaths`, `test_file_safety.py::TestFileSafetyFromEnv`, etc.) reproduced on the parent commit — unrelated to this PR.

## Out of scope (for follow-up)

- **#569** task_store / controller.status divergence — observed live during this very implementation: the codex agent that wrote this code was stuck displaying `WAITING` on the registry while internal `/debug/waiting` reported `0% pattern_matched in last 50 attempts`. That's the existing detection-precision bug, not the new state.
- **#571** Approval Gate common substrate — auto-approval of `WAITING_FOR_INPUT` waits.
- **#608** Phase 2 full state-machine refactor.
- **Canvas integration** — the issue mentions Canvas visualisation but that surface lives in a separate PR.

## Implementation note

This work was written by a Codex agent (`issue538-codex`, port 8121) coordinated over A2A from a Claude parent. Both agents share the Co-Authored-By trailer on the commit so credit is recorded.

## Related

Closes #538

🤖 Generated with [Claude Code](https://claude.com/claude-code) and Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * エージェントの新しいステータス「WAITING_FOR_INPUT」を導入しました。入力待ちのタスクが、従来とは別のステータスで表示されるようになります。

* **ドキュメント**
  * 新しいステータスに関する変更ログを更新しました。

* **テスト**
  * 新しいステータスの動作検証テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->