### PR TITLE
release: 0.29.0 — WAITING_FOR_INPUT (#640) + #569 status sync + docs/test polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`WAITING_FOR_INPUT` agent status (#538):** non-permission A2A `input_required` tasks now surface as a distinct registry/list/status state, while permission prompts keep the existing `WAITING` state.
 
+### Fixed
+
+- **Agent registry status sync (#569):** A2A status callbacks now demote stale registry `PROCESSING` / `WAITING_FOR_INPUT` states back to `READY` when the task store is non-empty and all tasks are terminal, preventing `synapse list` from showing active work after every task has completed.
+
 ## [0.28.3] - 2026-04-26
 
 Patch release for the Phase 1.5 polish work tracked in #635 / #630 and merged via #638. Operationally focused: warns less right after PtyRenderer boot, honors `HOME` overrides in tests, lets cron capture JSON reports atomically, and documents the `--timeout 0` fast-fail mode so operators don't read it as "no timeout". No detection-logic changes; Phase 2 remains out of scope.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.29.0] - 2026-04-26
+
+Minor release surfacing the `WAITING_FOR_INPUT` agent status for non-permission A2A `input_required` waits (#538) and closing the registry status drift that left `synapse list` showing stale `PROCESSING` after every task in `task_store` had finalised (#569). Together they make `synapse list` a faithful view of `task_store` reality across both forward (working → terminal) and sideways (input_required → permission vs non-permission) transitions. No detection-logic changes outside the A2A status callback path; controller PTY scope is unchanged.
+
 ### Added
 
 - **`WAITING_FOR_INPUT` agent status (#538):** non-permission A2A `input_required` tasks now surface as a distinct registry/list/status state, while permission prompts keep the existing `WAITING` state.
@@ -3580,7 +3584,8 @@ See v0.3.14 for reply PTY injection, CURRENT column, and history default changes
 - External agent connectivity vision document
 - PyPI publishing instructions
 
-[Unreleased]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.28.3...HEAD
+[Unreleased]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.29.0...HEAD
+[0.29.0]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.28.3...v0.29.0
 [0.28.3]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.28.2...v0.28.3
 [0.28.2]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.28.1...v0.28.2
 [0.28.1]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.28.0...v0.28.1

--- a/README.md
+++ b/README.md
@@ -1647,7 +1647,7 @@ For Copilot specifically, bracketed paste is enabled because Copilot CLI 1.0.12+
 | NAME | Custom name (if assigned) |
 | TYPE | Agent type (claude, gemini, codex, etc.) |
 | ROLE | Agent role description (if assigned) |
-| STATUS | Current status (READY, WAITING, PROCESSING, DONE) |
+| STATUS | Current status (READY, WAITING, WAITING_FOR_INPUT, PROCESSING, DONE) |
 | CURRENT | Current task preview with elapsed time (e.g., "Review code (2m 15s)") |
 | TRANSPORT | Communication transport indicator |
 | WORKING_DIR | Current working directory |
@@ -1670,9 +1670,12 @@ For Copilot specifically, bracketed paste is enabled because Copilot CLI 1.0.12+
 | Status | Color | Meaning |
 |--------|-------|---------|
 | **READY** | Green | Agent is idle, waiting for input |
-| **WAITING** | Cyan | Agent is showing selection UI, waiting for user choice |
+| **WAITING** | Cyan | Agent is showing a permission prompt (selection UI / Y-N) |
+| **WAITING_FOR_INPUT** | Orange | Agent has an A2A task in `input_required` for a non-permission response ([#538](https://github.com/s-hiraoku/synapse-a2a/issues/538) / [#640](https://github.com/s-hiraoku/synapse-a2a/pull/640)) |
 | **PROCESSING** | Yellow | Agent is actively working |
 | **DONE** | Blue | Task completed (auto-transitions to READY after 10s) |
+
+The registry status is reconciled against `task_store` on every controller transition: WAITING (permission) wins over WAITING_FOR_INPUT, and a fully terminal `task_store` demotes a stale PROCESSING / WAITING_FOR_INPUT back to READY ([#569](https://github.com/s-hiraoku/synapse-a2a/pull/569)).
 
 ### Interactive Controls
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ site_url: https://s-hiraoku.github.io/synapse-a2a/
 site_description: Multi-agent collaboration framework using Google A2A Protocol
 site_author: s-hiraoku
 repo_url: https://github.com/s-hiraoku/synapse-a2a
-repo_name: s-hiraoku/synapse-a2a v0.28.3
+repo_name: s-hiraoku/synapse-a2a v0.29.0
 docs_dir: site-docs
 
 theme:

--- a/plugins/synapse-a2a/.claude-plugin/plugin.json
+++ b/plugins/synapse-a2a/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synapse-a2a",
-  "version": "0.28.3",
+  "version": "0.29.0",
   "description": "Complete plugin for Synapse A2A multi-agent framework including inter-agent communication, file safety, and history management",
   "author": {
     "name": "s-hiraoku",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synapse-a2a"
-version = "0.28.3"
+version = "0.29.0"
 description = "Agent-to-Agent communication protocol for CLI agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/site-docs/changelog.md
+++ b/site-docs/changelog.md
@@ -4,7 +4,7 @@ For the complete changelog, see [CHANGELOG.md on GitHub](https://github.com/s-hi
 
 ## Recent Highlights
 
-### Unreleased
+### v0.29.0
 
 - **Added**: `WAITING_FOR_INPUT` agent status (#538, #640) — non-permission A2A `input_required` tasks now surface as a distinct registry/list/status state, while permission prompts keep the existing `WAITING` state. Rendered as orange in the Rich TUI; included in `ALL_STATUSES` and exposed via `synapse list` / `synapse status` (text and `--json`).
 - **Fixed**: Agent registry status sync (#569) — A2A status callbacks now demote stale registry `PROCESSING` / `WAITING_FOR_INPUT` states back to `READY` when the task store is non-empty and all tasks are terminal, preventing `synapse list` from showing active work after every task has completed.

--- a/site-docs/changelog.md
+++ b/site-docs/changelog.md
@@ -4,6 +4,11 @@ For the complete changelog, see [CHANGELOG.md on GitHub](https://github.com/s-hi
 
 ## Recent Highlights
 
+### Unreleased
+
+- **Added**: `WAITING_FOR_INPUT` agent status (#538, #640) — non-permission A2A `input_required` tasks now surface as a distinct registry/list/status state, while permission prompts keep the existing `WAITING` state. Rendered as orange in the Rich TUI; included in `ALL_STATUSES` and exposed via `synapse list` / `synapse status` (text and `--json`).
+- **Fixed**: Agent registry status sync (#569) — A2A status callbacks now demote stale registry `PROCESSING` / `WAITING_FOR_INPUT` states back to `READY` when the task store is non-empty and all tasks are terminal, preventing `synapse list` from showing active work after every task has completed.
+
 ### v0.28.3
 
 - **Added**: `synapse waiting-debug collect --timeout SECONDS` — overrides the HTTP timeout used when querying `/debug/waiting` on each registered agent. Default raised from 3.0 s to **5.0 s**, which eliminates the common warn-flood immediately after PtyRenderer boots when agents can't respond within 3 s (#635).

--- a/site-docs/concepts/a2a-protocol.md
+++ b/site-docs/concepts/a2a-protocol.md
@@ -17,7 +17,7 @@ Every A2A agent publishes a discovery document at `/.well-known/agent.json`:
   "name": "synapse-claude-8100",
   "description": "Claude Code agent managed by Synapse A2A",
   "url": "http://localhost:8100",
-  "version": "0.28.3",
+  "version": "0.29.0",
   "capabilities": {
     "streaming": false,
     "pushNotifications": false

--- a/site-docs/getting-started/installation.md
+++ b/site-docs/getting-started/installation.md
@@ -58,7 +58,7 @@
 synapse --version
 ```
 
-You should see the version number (e.g., `0.28.3`).
+You should see the version number (e.g., `0.29.0`).
 
 ## Initialize Configuration
 
@@ -88,7 +88,7 @@ gh skill install s-hiraoku/synapse-a2a synapse-manager
 gh skill install s-hiraoku/synapse-a2a synapse-reinst
 
 # Optional: pin to a release tag so updates are explicit
-gh skill install s-hiraoku/synapse-a2a synapse-a2a --pin v0.28.3
+gh skill install s-hiraoku/synapse-a2a synapse-a2a --pin v0.29.0
 
 # Optional: target a specific agent runtime
 gh skill install s-hiraoku/synapse-a2a synapse-a2a --agent claude-code

--- a/site-docs/guide/agent-management.md
+++ b/site-docs/guide/agent-management.md
@@ -331,9 +331,12 @@ When using `synapse send`, `synapse kill`, `synapse jump`, `synapse rename`, or 
 |--------|:---:|---------|
 | **READY** | :material-circle:{ .status-ready } | Idle, waiting for input |
 | **PROCESSING** | :material-circle:{ .status-processing } | Actively working |
-| **WAITING** | :material-circle:{ .status-waiting } | Showing selection UI |
+| **WAITING** | :material-circle:{ .status-waiting } | Showing selection UI (e.g. permission prompt) |
+| **WAITING_FOR_INPUT** | :material-circle:{ .status-waiting } | A2A `input_required` task awaiting non-permission response (#538/#640) |
 | **DONE** | :material-circle:{ .status-done } | Task completed (auto-clears 10s) |
 | **SHUTTING_DOWN** | :material-circle:{ .status-shutdown } | Shutdown in progress |
+
+`WAITING` is reserved for permission-style prompts where the PTY is showing a choice UI; `WAITING_FOR_INPUT` is set when an A2A task transitions to `input_required` for a non-permission reason (e.g. a child agent is asking the parent a follow-up question). Both states are registry-level and exposed via `synapse list` / `synapse status` (text and `--json`). The status sync layer demotes stale `PROCESSING` / `WAITING_FOR_INPUT` entries back to `READY` once the task store is non-empty and every task is terminal, so a finished agent is never shown as still working (#569).
 
 Dead processes are automatically cleaned from the registry and hidden from `synapse list`.
 

--- a/synapse/a2a_compat.py
+++ b/synapse/a2a_compat.py
@@ -1113,6 +1113,14 @@ def create_a2a_router(
                     return True
             return False
 
+        def _has_only_terminal_tasks() -> bool:
+            tasks = task_store.list_tasks()
+            if not tasks:
+                return False
+            return all(
+                task.status in ("completed", "failed", "canceled") for task in tasks
+            )
+
         def _is_permission_waiting_status(new_status: str) -> bool:
             if new_status == WAITING:
                 return True
@@ -1129,6 +1137,13 @@ def create_a2a_router(
                 return
             if _has_non_permission_input_required_task():
                 registry.update_status(agent_id, WAITING_FOR_INPUT)
+            if _has_only_terminal_tasks():
+                agent_info = registry.get_agent(agent_id)
+                if agent_info and agent_info.get("status") in (
+                    "PROCESSING",
+                    WAITING_FOR_INPUT,
+                ):
+                    registry.update_status(agent_id, "READY")
 
         def _on_status_change(old: str, new: str) -> None:
             if new == WAITING:
@@ -1232,6 +1247,7 @@ def create_a2a_router(
                             sender_task_id=si.sender_task_id,
                         )
                         _run_async_from_sync(coro)
+            _sync_registry_input_wait_status(new)
 
         controller.on_status_change(_on_status_change)
 

--- a/tests/test_cli_workflow.py
+++ b/tests/test_cli_workflow.py
@@ -34,6 +34,26 @@ def workflow_dirs(tmp_path: Path) -> tuple[Path, Path]:
     return project, user
 
 
+@pytest.fixture(autouse=True)
+def _stub_workflow_skill_sync():
+    """Suppress skill auto-generation in workflow CRUD tests.
+
+    `cmd_workflow_create` / `cmd_workflow_delete` call
+    `sync_workflow_skill` / `remove_workflow_skill` against `Path.cwd()`,
+    which is the real project root during tests — that's how leftover
+    `.agents/skills/my-review/`, `.claude/skills/user-wf/` entries used
+    to appear after running this file. Stubbing the helpers at their
+    source module keeps each test fully isolated to `tmp_path`.
+    Both helpers are imported lazily inside the command functions, so
+    patching the source module catches every call site at once.
+    """
+    with (
+        patch("synapse.workflow_skill_sync.sync_workflow_skill", return_value=[]),
+        patch("synapse.workflow_skill_sync.remove_workflow_skill", return_value=[]),
+    ):
+        yield
+
+
 def _make_store(project_dir: Path, user_dir: Path):
     """Create a WorkflowStore with custom directories."""
     from synapse.workflow import WorkflowStore

--- a/tests/test_status_sync_569.py
+++ b/tests/test_status_sync_569.py
@@ -21,6 +21,8 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from synapse.a2a_compat import create_a2a_router
+from synapse.a2a_models import Message, TextPart
+from synapse.status import WAITING_FOR_INPUT
 from synapse.task_store import TaskStore
 
 
@@ -184,3 +186,117 @@ class TestGetTasksNoRogueWrite:
         assert task.status != "input_required", (
             "GET /tasks/{id} must not set input_required — it is a read-only endpoint"
         )
+
+
+class TestTerminalTasksDemoteRegistry:
+    """Fix 3: terminal-only task_store should demote stale registry states."""
+
+    agent_id = "synapse-test-agent-8126"
+
+    def setup_method(self) -> None:
+        from synapse.a2a_compat import task_store
+
+        with task_store._lock:
+            task_store._tasks.clear()
+
+    def _register_callback(self, mock_controller: MagicMock, mock_registry: MagicMock):
+        create_a2a_router(
+            mock_controller,
+            "codex",
+            8126,
+            "\n",
+            agent_id=self.agent_id,
+            registry=mock_registry,
+        )
+        return mock_controller.on_status_change.call_args.args[0]
+
+    def test_terminal_only_tasks_demote_processing_to_ready(
+        self, mock_controller: MagicMock
+    ) -> None:
+        from synapse.a2a_compat import task_store
+
+        mock_controller.status = "READY"
+        mock_controller.get_context.return_value = "Task completed"
+        mock_controller.last_waiting_source = "none"
+        mock_registry = MagicMock()
+        mock_registry.get_agent.return_value = {"status": "PROCESSING"}
+        status_callback = self._register_callback(mock_controller, mock_registry)
+
+        task = task_store.create(Message(parts=[TextPart(text="hello")]))
+        task_store.update_status(task.id, "working")
+
+        status_callback("PROCESSING", "READY")
+
+        mock_registry.update_status.assert_any_call(self.agent_id, "READY")
+
+    def test_working_task_keeps_processing(self, mock_controller: MagicMock) -> None:
+        from synapse.a2a_compat import task_store
+
+        mock_controller.status = "PROCESSING"
+        mock_controller.last_waiting_source = "none"
+        mock_registry = MagicMock()
+        mock_registry.get_agent.return_value = {"status": "PROCESSING"}
+        status_callback = self._register_callback(mock_controller, mock_registry)
+
+        task = task_store.create(Message(parts=[TextPart(text="hello")]))
+        task_store.update_status(task.id, "working")
+
+        status_callback("READY", "PROCESSING")
+
+        assert (self.agent_id, "READY") not in [
+            call.args for call in mock_registry.update_status.call_args_list
+        ]
+
+    def test_input_required_task_does_not_demote(
+        self, mock_controller: MagicMock
+    ) -> None:
+        from synapse.a2a_compat import task_store
+
+        mock_controller.status = "PROCESSING"
+        mock_controller.last_waiting_source = "none"
+        mock_registry = MagicMock()
+        mock_registry.get_agent.return_value = {"status": "PROCESSING"}
+        status_callback = self._register_callback(mock_controller, mock_registry)
+
+        task = task_store.create(Message(parts=[TextPart(text="confirm?")]))
+        task_store.update_status(task.id, "input_required")
+
+        status_callback("READY", "PROCESSING")
+
+        mock_registry.update_status.assert_any_call(self.agent_id, WAITING_FOR_INPUT)
+        assert (self.agent_id, "READY") not in [
+            call.args for call in mock_registry.update_status.call_args_list
+        ]
+
+    def test_empty_task_store_does_not_demote(self, mock_controller: MagicMock) -> None:
+        mock_controller.status = "PROCESSING"
+        mock_controller.last_waiting_source = "none"
+        mock_registry = MagicMock()
+        mock_registry.get_agent.return_value = {"status": "PROCESSING"}
+        status_callback = self._register_callback(mock_controller, mock_registry)
+
+        status_callback("READY", "PROCESSING")
+
+        assert (self.agent_id, "READY") not in [
+            call.args for call in mock_registry.update_status.call_args_list
+        ]
+
+    def test_demotion_does_not_touch_controller_status(
+        self, mock_controller: MagicMock
+    ) -> None:
+        from synapse.a2a_compat import task_store
+
+        mock_controller.status = "PROCESSING"
+        mock_controller.get_context.return_value = "Task completed"
+        mock_controller.last_waiting_source = "none"
+        mock_registry = MagicMock()
+        mock_registry.get_agent.return_value = {"status": "PROCESSING"}
+        status_callback = self._register_callback(mock_controller, mock_registry)
+
+        task = task_store.create(Message(parts=[TextPart(text="hello")]))
+        task_store.update_status(task.id, "working")
+
+        status_callback("PROCESSING", "READY")
+
+        assert mock_controller.status == "PROCESSING"
+        mock_registry.update_status.assert_any_call(self.agent_id, "READY")

--- a/uv.lock
+++ b/uv.lock
@@ -1439,7 +1439,7 @@ wheels = [
 
 [[package]]
 name = "synapse-a2a"
-version = "0.28.3"
+version = "0.29.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

Bundles the **0.29.0 minor release** rolling up:

- **fix #569** — registry status sync: A2A status callback demotes stale registry `PROCESSING` / `WAITING_FOR_INPUT` back to `READY` when `task_store` is non-empty and every task is terminal.
- **docs** — surface `WAITING_FOR_INPUT` (#538/#640) and the #569 reconciliation behaviour in `README.md`, `site-docs/changelog.md`, `site-docs/guide/agent-management.md`.
- **chore(tests)** — autouse fixture in `tests/test_cli_workflow.py` stubs `sync_workflow_skill` / `remove_workflow_skill` so workflow CRUD tests no longer leak `.agents/skills/my-review/` etc. into the real working tree.
- **chore(release)** — bump `0.28.3` → `0.29.0` across `pyproject.toml`, `plugin.json`, `mkdocs.yml`, `CHANGELOG.md`, `site-docs/{changelog,getting-started/installation,concepts/a2a-protocol}.md`, `uv.lock`.

Closes [#569](https://github.com/s-hiraoku/synapse-a2a/issues/569).

## Commits

| SHA | Subject |
|-----|---------|
| `ae25800` | fix: demote stale registry PROCESSING when task_store is fully terminal (#569) |
| `3e02881` | chore(tests): isolate workflow CRUD tests from skill auto-sync |
| `8fda693` | docs: surface WAITING_FOR_INPUT and #569 status reconciliation |
| `4e9fe2b` | chore(release): bump to 0.29.0 for WAITING_FOR_INPUT + #569 status sync |

## Why minor (0.28.3 → 0.29.0)

Per Conventional Commits + SemVer, since the latest tag (`v0.28.1`) the branch sits on top of accumulated `feat:` commits (#640 `WAITING_FOR_INPUT`, #638 waiting-debug polish, #633 auto-resolve). With no `BREAKING CHANGE:`, the auto-detected bump is **minor**.

> Note: 0.28.2 / 0.28.3 were bumped in commits but never tagged, so the next `git-cliff` autodetection range starts from `v0.28.1`. Worth backfilling the missing tags so future `/release` runs don't re-include past entries.

## #569 — Root cause and fix

`_on_status_change` had only ever reacted to **controller status transitions** (PTY-driven). When the last `working` task finalised, the registry never received an "idle now" signal, so a stale `PROCESSING` lingered. PR #640 (`WAITING_FOR_INPUT`) made the same surface visible to one more state.

A third reconciliation rule is appended to `_sync_registry_input_wait_status` (the helper added by PR #640):

```
permission WAITING (controller PTY)        → registry WAITING               (PR #640)
non-permission input_required task         → registry WAITING_FOR_INPUT     (PR #640)
NEW: every task terminal AND               → registry READY                 (#569)
     registry currently shows PROCESSING /
     WAITING_FOR_INPUT
```

The new helper `_has_only_terminal_tasks()` returns `True` only when the task store is **non-empty AND** every task is `completed` / `failed` / `canceled`. It runs at the existing call site inside `if old == WAITING:` plus once more **after** the READY/DONE finalize loop so demotion sees the `working → completed` transitions that just landed.

### Scope discipline (carried from PR #640)

- `controller.py` untouched — controller owns PTY detection; this hook fixes only the surfaced registry state.
- `registry.py` untouched.
- `synapse/status.py` untouched.
- `_sync_registry_input_wait_status` ordering preserved — the #569 demotion only fires after the permission-WAITING and `WAITING_FOR_INPUT` rules have had their say.

### Edge cases covered by tests (`tests/test_status_sync_569.py::TestTerminalTasksDemoteRegistry`, 5 new)

- `test_terminal_only_tasks_demote_processing_to_ready`
- `test_working_task_keeps_processing`
- `test_input_required_task_does_not_demote`
- `test_empty_task_store_does_not_demote` (freshly-spawned agents stay `PROCESSING`)
- `test_demotion_does_not_touch_controller_status`

## chore(tests) — workflow CRUD test isolation

`cmd_workflow_create` / `cmd_workflow_delete` call `sync_workflow_skill` / `remove_workflow_skill` against `Path.cwd()`, which is the real project root during tests. That's how leftover `.agents/skills/my-review/`, `.claude/skills/user-wf/` directories used to appear after running `tests/test_cli_workflow.py`. Fixed by an autouse fixture that patches the helpers at the source module (`synapse.workflow_skill_sync`) — both call sites import them lazily inside the command functions, so patching the source catches every entry point at once. Production behaviour untouched.

## docs

`README.md`, `site-docs/changelog.md`, `site-docs/guide/agent-management.md` updated to:

- Add the `WAITING_FOR_INPUT` row to the Status States table (verified against `synapse/status.py` constant + colour `bold orange3`).
- Distinguish `WAITING` (permission prompts) from `WAITING_FOR_INPUT` (non-permission A2A waits).
- Document the #569 self-healing demotion so operators reading `synapse list` understand the registry is now task_store-coherent.

## Files changed

```
 CHANGELOG.md                                   |  11 ++-
 README.md                                      |   7 +-
 mkdocs.yml                                     |   2 +-
 plugins/synapse-a2a/.claude-plugin/plugin.json |   2 +-
 pyproject.toml                                 |   2 +-
 site-docs/changelog.md                         |   5 ++
 site-docs/concepts/a2a-protocol.md             |   2 +-
 site-docs/getting-started/installation.md      |   4 +-
 site-docs/guide/agent-management.md            |   5 +-
 synapse/a2a_compat.py                          |  16 ++++
 tests/test_cli_workflow.py                     |  20 +++++
 tests/test_status_sync_569.py                  | 116 +++++++++++++++++++++++++
 uv.lock                                        |   2 +-
 13 files changed, 183 insertions(+), 11 deletions(-)
```

## Verification

- `uv run pytest tests/test_status_sync_569.py tests/test_cli_workflow.py` → **50 passed in 0.54s**
- `uv run mkdocs build --strict` → **PASS in 1.61s** (no warnings, no errors)
- 6 version strings consistent at `0.29.0` across pyproject / plugin.json / mkdocs.yml / installation.md (×2) / a2a-protocol.md
- `mypy` clean across 114 files (per the #569 commit body verification)

## Test plan

- [x] All `tests/test_status_sync_569.py` cases pass (8 → 13 tests, 5 new in `TestTerminalTasksDemoteRegistry`)
- [x] `tests/test_cli_workflow.py` passes with the new autouse fixture (42 → 42 tests, side-effect leakage gone)
- [x] `tests/test_a2a_compat.py` (#640 reverse-direction tests) unchanged and passing
- [x] `mkdocs build --strict` green — site-docs additions are link-clean
- [x] Pre-commit hooks (ruff / ruff format / mypy) — release commit had no `.py` files so hooks skipped; #569 + chore(tests) commits passed all hooks
- [ ] CI green (will be checked once GitHub Actions report back)

🤖 Generated with [Claude Code](https://claude.com/claude-code)