### PR TITLE
feat: delay sends to READY agents to avoid interrupting user input (#467)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Delay sends to READY agents (#467).
+
 ## [0.29.0] - 2026-04-26
 
 Minor release surfacing the `WAITING_FOR_INPUT` agent status for non-permission A2A `input_required` waits (#538) and closing the registry status drift that left `synapse list` showing stale `PROCESSING` after every task in `task_store` had finalised (#569). Together they make `synapse list` a faithful view of `task_store` reality across both forward (working → terminal) and sideways (input_required → permission vs non-permission) transitions. No detection-logic changes outside the A2A status callback path; controller PTY scope is unchanged.

--- a/synapse/tools/a2a.py
+++ b/synapse/tools/a2a.py
@@ -1,6 +1,7 @@
 import argparse
 import contextlib
 import json
+import math
 import os
 import shlex
 import sys
@@ -282,6 +283,8 @@ def cmd_send(args: argparse.Namespace) -> None:
             try:
                 ready_delay = float(os.environ.get("SYNAPSE_SEND_READY_DELAY", "2"))
             except ValueError:
+                ready_delay = 2.0
+            if not math.isfinite(ready_delay):
                 ready_delay = 2.0
             ready_delay = max(ready_delay, 0.0)
 

--- a/synapse/tools/a2a.py
+++ b/synapse/tools/a2a.py
@@ -270,6 +270,45 @@ def cmd_send(args: argparse.Namespace) -> None:
                     file=sys.stderr,
                 )
 
+    # Give READY targets a short window to flip to PROCESSING before injecting
+    # a message, which avoids interrupting a user who is still typing at prompt.
+    if (
+        response_mode != "silent"
+        and not getattr(args, "force", False)
+        and getattr(args, "priority", 0) != 5
+    ):
+        status = target_agent.get("status", "")
+        if status == "READY":
+            try:
+                ready_delay = float(os.environ.get("SYNAPSE_SEND_READY_DELAY", "2"))
+            except ValueError:
+                ready_delay = 2.0
+            ready_delay = max(ready_delay, 0.0)
+
+            if ready_delay > 0:
+                poll_interval = 0.25
+                elapsed = 0.0
+                while elapsed < ready_delay:
+                    time.sleep(poll_interval)
+                    elapsed += poll_interval
+
+                    reg = AgentRegistry()
+                    agents = reg.list_agents()
+                    refreshed = next(
+                        (
+                            agent
+                            for agent in agents.values()
+                            if agent.get("agent_id") == agent_id
+                        ),
+                        None,
+                    )
+                    if refreshed:
+                        target_agent = refreshed
+                        if refreshed.get("status", "") == "PROCESSING":
+                            break
+                    else:
+                        break
+
     # Check working_dir mismatch (skip with --force)
     if not getattr(args, "force", False) and _warn_working_dir_mismatch(
         target_agent, agents

--- a/tests/test_send_processing_wait.py
+++ b/tests/test_send_processing_wait.py
@@ -48,8 +48,10 @@ def _make_task():
 class TestSendProcessingWait:
     """Tests for cmd_send waiting on PROCESSING targets."""
 
-    def test_ready_target_sends_immediately(self, capsys):
-        """READY targets should not wait before sending."""
+    def test_ready_target_sends_immediately_when_ready_delay_disabled(
+        self, capsys, monkeypatch
+    ):
+        """READY targets should not trigger PROCESSING wait output."""
         from synapse.tools.a2a import cmd_send
 
         args = _make_args()
@@ -57,6 +59,7 @@ class TestSendProcessingWait:
         reg = MagicMock()
         reg.list_agents.return_value = {target["agent_id"]: target}
         task = _make_task()
+        monkeypatch.setenv("SYNAPSE_SEND_READY_DELAY", "0")
 
         with (
             patch("synapse.tools.a2a.AgentRegistry", return_value=reg),
@@ -91,6 +94,7 @@ class TestSendProcessingWait:
         task = _make_task()
 
         monkeypatch.setenv("SYNAPSE_SEND_WAIT_TIMEOUT", "5")
+        monkeypatch.setenv("SYNAPSE_SEND_READY_DELAY", "0")
 
         with (
             patch(

--- a/tests/test_send_ready_delay_467.py
+++ b/tests/test_send_ready_delay_467.py
@@ -1,0 +1,185 @@
+"""Tests for delaying sends to READY targets in synapse send (#467)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+
+def _make_args(
+    *,
+    force: bool = False,
+    priority: int = 3,
+    response_mode: str = "notify",
+):
+    args = MagicMock()
+    args.target = "claude"
+    args.message = "hello"
+    args.message_file = None
+    args.task_file = None
+    args.stdin = False
+    args.attach = None
+    args.priority = priority
+    args.sender = None
+    args.response_mode = response_mode
+    args.force = force
+    return args
+
+
+def _make_target(status: str = "READY"):
+    return {
+        "agent_id": "synapse-claude-8104",
+        "agent_type": "claude",
+        "name": "claude-helper",
+        "pid": 1234,
+        "port": 8104,
+        "endpoint": "http://localhost:8104",
+        "working_dir": "/tmp/project",
+        "status": status,
+    }
+
+
+def _make_task():
+    task = MagicMock()
+    task.id = "task-id"
+    task.status = "completed"
+    task.artifacts = []
+    return task
+
+
+def _make_registry(target):
+    reg = MagicMock()
+    reg.list_agents.return_value = (
+        {target["agent_id"]: target} if target is not None else {}
+    )
+    return reg
+
+
+def _run_cmd_send(args, registries, *, monkeypatch, sleep_calls):
+    from synapse.tools.a2a import cmd_send
+
+    task = _make_task()
+
+    def fake_sleep(seconds):
+        sleep_calls.append(seconds)
+
+    with (
+        patch("synapse.tools.a2a.AgentRegistry", side_effect=registries),
+        patch("synapse.tools.a2a.A2AClient") as mock_client_cls,
+        patch("synapse.tools.a2a.is_process_running", return_value=True),
+        patch("synapse.tools.a2a.is_port_open", return_value=True),
+        patch("synapse.tools.a2a.build_sender_info", return_value={}),
+        patch("synapse.tools.a2a._record_sent_message"),
+        patch("synapse.tools.a2a.time.sleep", side_effect=fake_sleep),
+        patch("os.getcwd", return_value="/tmp/project"),
+    ):
+        mock_client_cls.return_value.send_to_local.return_value = task
+        cmd_send(args)
+
+
+class TestSendReadyDelay467:
+    """Tests for cmd_send delaying briefly before sending to READY targets."""
+
+    def test_ready_status_triggers_delay(self, monkeypatch):
+        """READY targets should sleep at least once before sending."""
+        target = _make_target("READY")
+        sleep_calls: list[float] = []
+        registries = [
+            _make_registry(target),
+            *[_make_registry(target) for _ in range(8)],
+        ]
+
+        _run_cmd_send(
+            _make_args(),
+            registries,
+            monkeypatch=monkeypatch,
+            sleep_calls=sleep_calls,
+        )
+
+        assert sleep_calls
+        assert sleep_calls == [0.25] * 8
+
+    def test_processing_during_delay_breaks_immediately(self, monkeypatch):
+        """READY delay should stop early when the target becomes PROCESSING."""
+        ready = _make_target("READY")
+        processing = _make_target("PROCESSING")
+        sleep_calls: list[float] = []
+
+        _run_cmd_send(
+            _make_args(),
+            [_make_registry(ready), _make_registry(processing)],
+            monkeypatch=monkeypatch,
+            sleep_calls=sleep_calls,
+        )
+
+        assert sleep_calls == [0.25]
+
+    def test_ready_delay_zero_disables_feature(self, monkeypatch):
+        """SYNAPSE_SEND_READY_DELAY=0 should send without sleeping."""
+        target = _make_target("READY")
+        sleep_calls: list[float] = []
+        monkeypatch.setenv("SYNAPSE_SEND_READY_DELAY", "0")
+
+        _run_cmd_send(
+            _make_args(),
+            [_make_registry(target)],
+            monkeypatch=monkeypatch,
+            sleep_calls=sleep_calls,
+        )
+
+        assert sleep_calls == []
+
+    def test_silent_mode_skips_ready_delay(self, monkeypatch):
+        """Silent sends should skip READY delay like PROCESSING wait."""
+        target = _make_target("READY")
+        sleep_calls: list[float] = []
+
+        _run_cmd_send(
+            _make_args(response_mode="silent"),
+            [_make_registry(target)],
+            monkeypatch=monkeypatch,
+            sleep_calls=sleep_calls,
+        )
+
+        assert sleep_calls == []
+
+    def test_force_flag_skips_ready_delay(self, monkeypatch):
+        """--force should skip READY delay like PROCESSING wait."""
+        target = _make_target("READY")
+        sleep_calls: list[float] = []
+
+        _run_cmd_send(
+            _make_args(force=True),
+            [_make_registry(target)],
+            monkeypatch=monkeypatch,
+            sleep_calls=sleep_calls,
+        )
+
+        assert sleep_calls == []
+
+    def test_priority_5_skips_ready_delay(self, monkeypatch):
+        """Emergency priority should skip READY delay."""
+        target = _make_target("READY")
+        sleep_calls: list[float] = []
+
+        _run_cmd_send(
+            _make_args(priority=5),
+            [_make_registry(target)],
+            monkeypatch=monkeypatch,
+            sleep_calls=sleep_calls,
+        )
+
+        assert sleep_calls == []
+
+    def test_target_disappearing_during_delay_continues_send(self, monkeypatch):
+        """If refresh no longer finds the target, stop delaying and send."""
+        ready = _make_target("READY")
+        sleep_calls: list[float] = []
+
+        _run_cmd_send(
+            _make_args(),
+            [_make_registry(ready), _make_registry(None)],
+            monkeypatch=monkeypatch,
+            sleep_calls=sleep_calls,
+        )
+
+        assert sleep_calls == [0.25]

--- a/tests/test_send_ready_delay_467.py
+++ b/tests/test_send_ready_delay_467.py
@@ -183,3 +183,25 @@ class TestSendReadyDelay467:
         )
 
         assert sleep_calls == [0.25]
+
+    def test_non_finite_env_value_falls_back_to_default(self, monkeypatch):
+        """SYNAPSE_SEND_READY_DELAY=inf/nan must fall back to 2.0, not loop forever."""
+        for raw in ("inf", "-inf", "nan"):
+            monkeypatch.setenv("SYNAPSE_SEND_READY_DELAY", raw)
+            target = _make_target("READY")
+            sleep_calls: list[float] = []
+            registries = [
+                _make_registry(target),
+                *[_make_registry(target) for _ in range(8)],
+            ]
+
+            _run_cmd_send(
+                _make_args(),
+                registries,
+                monkeypatch=monkeypatch,
+                sleep_calls=sleep_calls,
+            )
+
+            assert sleep_calls == [0.25] * 8, (
+                f"env={raw!r} should fall back to 2.0s window (8 polls), got {sleep_calls!r}"
+            )


### PR DESCRIPTION
## Summary

Closes #467.

When a target agent is in `READY` state (prompt visible), the user may be typing at the CLI. Injecting an A2A message at that exact moment interrupts their input. This PR adds a short poll window (default **2 seconds**, configurable via `SYNAPSE_SEND_READY_DELAY`) before sending: if the user hits Enter during the window the agent flips to `PROCESSING` and we send immediately; otherwise we proceed after the timeout. No stderr noise on timeout — that path is normal, not exceptional.

The implementation mirrors #466 (PROCESSING wait) symmetrically, immediately after the existing PROCESSING-wait block in `cmd_send`. Bypass guards are unified (silent / `--force` / priority=5).

- `WAITING` and `WAITING_FOR_INPUT` are intentionally **not** delayed — those states represent user/permission gates, not input-in-progress
- Poll interval is **250 ms**, so we react within a quarter-second of the user committing input
- `SYNAPSE_SEND_READY_DELAY=0` disables the feature entirely
- Invalid env values fall back to `2.0`
- Target disappearing from registry mid-delay falls through to normal send path (matches PROCESSING wait behavior)

## Files

- `synapse/tools/a2a.py` — +39 lines, READY-delay block immediately after PROCESSING wait
- `tests/test_send_ready_delay_467.py` — 7 new tests
- `tests/test_send_processing_wait.py` — 2 lines monkeypatch `SYNAPSE_SEND_READY_DELAY=0` to keep existing tests fast (no behavior change)
- `CHANGELOG.md` — `[Unreleased] / Added`

## Scope

- ✅ `synapse/controller.py` unchanged (issue mandate: READ-ONLY)
- ✅ `synapse/registry.py` unchanged
- ✅ `synapse/status.py` unchanged
- Option B (queue-on-READY) deferred to #608 Phase 2 scope

## Test plan

- [x] `uv run pytest tests/test_send_ready_delay_467.py tests/test_send_processing_wait.py -q` — 13 passed
- [x] `uv run pytest tests/test_send_ready_delay_467.py tests/test_a2a_compat.py -q` — 87 passed
- [x] `uv run mypy synapse/` — Success: no issues found in 114 source files
- [x] pre-commit hooks (ruff, ruff format, mypy) pass on commit
- [ ] Manual: send to a freshly READY codex agent and verify the 2-second window is silent + delivery still happens

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * エージェントが`READY`状態に達するまで、メッセージの送信を遅延させるようになりました。設定可能な遅延時間（デフォルト2秒）の間、エージェント状態を監視します。サイレントモード、強制送信、または優先度5の場合は、この遅延はスキップされます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->