### PR TITLE
fix: workflow target type resolution respects caller working directory (#568)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Delay sends to READY agents (#467).
 - **`/dev-issue <number>` slash command (skill):** bootstraps a new issue implementation in one step — fetches the issue and related closed PRs in parallel, greps the repo for code hotspots from the body, infers a branch prefix from labels and a slug from the title, generates a structured task brief at `/tmp/issue<num>-task.md` (mirroring the handwritten brief format used in recent issue → codex spawn flows like #467), creates a fresh branch from latest `origin/main`, and (by default) spawns a codex agent with `synapse spawn codex --task-file ... --notify`. Supports `--solo` (skip spawn) and `--dry-run` (brief only, no branch / no spawn). Canonical at `.agents/skills/dev-issue/SKILL.md`, mirrored as a symlink at `.claude/skills/dev-issue/` and as a copy at `plugins/synapse-a2a/skills/dev-issue/` for plugin distribution.
 
+### Fixed
+
+- Workflow target type resolution now respects the caller working directory (#568).
+
 ## [0.29.0] - 2026-04-26
 
 Minor release surfacing the `WAITING_FOR_INPUT` agent status for non-permission A2A `input_required` waits (#538) and closing the registry status drift that left `synapse list` showing stale `PROCESSING` after every task in `task_store` had finalised (#569). Together they make `synapse list` a faithful view of `task_store` reality across both forward (working → terminal) and sideways (input_required → permission vs non-permission) transitions. No detection-logic changes outside the A2A status callback path; controller PTY scope is unchanged.

--- a/synapse/canvas/server.py
+++ b/synapse/canvas/server.py
@@ -164,6 +164,7 @@ def _resolve_agent_endpoint(
     target: str,
     *,
     caller_working_dir: str | None = None,
+    bare_type_same_dir_only: bool = False,
 ) -> str | None:
     """Resolve an agent target to its HTTP endpoint.
 
@@ -173,6 +174,8 @@ def _resolve_agent_endpoint(
         target: Agent ID, name, or type to resolve.
         caller_working_dir: Optional caller directory used to prefer same-dir
             type fallback matches.
+        bare_type_same_dir_only: When True, type targets must resolve within
+            caller_working_dir and never fall back to a global type match.
 
     Returns:
         HTTP endpoint URL, or None if not found.
@@ -203,6 +206,8 @@ def _resolve_agent_endpoint(
         if len(same_dir_matches) == 1:
             _log_type_fallback(target, same_dir_matches[0])
             return same_dir_matches[0].get("endpoint")
+        if bare_type_same_dir_only:
+            return None
 
     if len(type_matches) == 1:
         _log_type_fallback(target, type_matches[0])

--- a/synapse/workflow_runner.py
+++ b/synapse/workflow_runner.py
@@ -433,7 +433,11 @@ def _resolve_target_endpoint(target: str) -> str | None:
     """Resolve a workflow target to its current HTTP endpoint."""
     from synapse.canvas.server import _resolve_agent_endpoint
 
-    return _resolve_agent_endpoint(target)
+    return _resolve_agent_endpoint(
+        target,
+        caller_working_dir=os.getcwd(),
+        bare_type_same_dir_only=True,
+    )
 
 
 def _force_loopback_endpoint(endpoint: str) -> str:

--- a/tests/test_workflow_target_semantics_568.py
+++ b/tests/test_workflow_target_semantics_568.py
@@ -1,0 +1,233 @@
+"""Regression tests for workflow target resolution semantics from issue #568."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from synapse.workflow import WorkflowStep
+from synapse.workflow_runner import StepResult, _execute_step, _resolve_target_endpoint
+
+
+def _agent(
+    agent_id: str,
+    agent_type: str,
+    endpoint: str,
+    *,
+    name: str | None = None,
+    working_dir: str = "/repo/current",
+) -> dict[str, Any]:
+    return {
+        "agent_id": agent_id,
+        "agent_type": agent_type,
+        "name": name,
+        "endpoint": endpoint,
+        "working_dir": working_dir,
+        "pid": 1234,
+    }
+
+
+def _patch_registry(
+    monkeypatch: pytest.MonkeyPatch, entries: list[dict[str, Any]]
+) -> None:
+    from synapse.canvas import server as canvas_server
+
+    monkeypatch.setattr(
+        canvas_server,
+        "_iter_registry_entries",
+        lambda live_only=True: iter(entries),
+    )
+
+
+def _patch_workflow_cwd(monkeypatch: pytest.MonkeyPatch, cwd: str) -> None:
+    import synapse.workflow_runner as workflow_runner
+
+    monkeypatch.setattr(workflow_runner.os, "getcwd", lambda: cwd)
+
+
+def test_bare_type_with_same_dir_match_resolves(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_workflow_cwd(monkeypatch, "/repo/current")
+    _patch_registry(
+        monkeypatch,
+        [
+            _agent(
+                "synapse-claude-8100",
+                "claude",
+                "http://localhost:8100",
+                working_dir="/repo/other",
+            ),
+            _agent(
+                "synapse-claude-8101",
+                "claude",
+                "http://localhost:8101",
+                working_dir="/repo/current",
+            ),
+        ],
+    )
+
+    assert _resolve_target_endpoint("claude") == "http://localhost:8101"
+
+
+def test_bare_type_with_only_other_dir_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_workflow_cwd(monkeypatch, "/repo/current")
+    _patch_registry(
+        monkeypatch,
+        [
+            _agent(
+                "synapse-claude-8100",
+                "claude",
+                "http://localhost:8100",
+                working_dir="/repo/other",
+            ),
+        ],
+    )
+
+    assert _resolve_target_endpoint("claude") is None
+
+
+def test_bare_type_with_no_matches_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_workflow_cwd(monkeypatch, "/repo/current")
+    _patch_registry(
+        monkeypatch,
+        [
+            _agent(
+                "synapse-codex-8124",
+                "codex",
+                "http://localhost:8124",
+                working_dir="/repo/current",
+            ),
+        ],
+    )
+
+    assert _resolve_target_endpoint("claude") is None
+
+
+def test_specific_name_resolves_globally(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_workflow_cwd(monkeypatch, "/repo/current")
+    _patch_registry(
+        monkeypatch,
+        [
+            _agent(
+                "synapse-claude-8100",
+                "claude",
+                "http://localhost:8100",
+                name="my-agent",
+                working_dir="/repo/other",
+            ),
+        ],
+    )
+
+    assert _resolve_target_endpoint("my-agent") == "http://localhost:8100"
+
+
+@pytest.mark.asyncio
+async def test_self_target_unaffected(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _resolve_self(sender_info):
+        return "http://localhost:8122"
+
+    async def _send(endpoint, wf_step, sender_info):
+        return 0, "ok", "", "task-1"
+
+    def _resolve_target(target: str) -> str | None:
+        raise AssertionError("self target should not use bare target resolution")
+
+    monkeypatch.setattr(
+        "synapse.workflow_runner._resolve_self_target_endpoint",
+        _resolve_self,
+    )
+    monkeypatch.setattr("synapse.workflow_runner._send_workflow_request", _send)
+    monkeypatch.setattr(
+        "synapse.workflow_runner._resolve_target_endpoint",
+        _resolve_target,
+    )
+
+    step = StepResult(step_index=0, target="self", message="status")
+    await _execute_step(
+        WorkflowStep(target="self", message="status"),
+        step,
+        sender_info={"agent_id": "synapse-codex-8122", "agent_type": "codex"},
+    )
+
+    assert step.status == "completed"
+    assert step.output == "ok"
+
+
+def test_canvas_caller_uses_legacy_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    from synapse.canvas import server as canvas_server
+
+    _patch_registry(
+        monkeypatch,
+        [
+            _agent(
+                "synapse-claude-8100",
+                "claude",
+                "http://localhost:8100",
+                working_dir="/repo/other",
+            ),
+        ],
+    )
+
+    assert (
+        canvas_server._resolve_agent_endpoint(
+            "claude",
+            caller_working_dir="/repo/current",
+        )
+        == "http://localhost:8100"
+    )
+
+
+@pytest.mark.asyncio
+async def test_auto_spawn_triggered_when_strict_resolution_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_workflow_cwd(monkeypatch, "/repo/current")
+    entries = [
+        _agent(
+            "synapse-claude-8100",
+            "claude",
+            "http://localhost:8100",
+            working_dir="/repo/other",
+        ),
+    ]
+    _patch_registry(monkeypatch, entries)
+
+    spawned_targets: list[str] = []
+    send_endpoints: list[str] = []
+
+    def _spawn(target: str) -> bool:
+        spawned_targets.append(target)
+        entries.append(
+            _agent(
+                "synapse-claude-8101",
+                "claude",
+                "http://localhost:8101",
+                working_dir="/repo/current",
+            )
+        )
+        return True
+
+    async def _send(endpoint, wf_step, sender_info):
+        send_endpoints.append(endpoint)
+        return 0, "spawned ok", "", "task-1"
+
+    monkeypatch.setattr("synapse.workflow_runner._try_spawn_and_wait", _spawn)
+    monkeypatch.setattr("synapse.workflow_runner._send_workflow_request", _send)
+
+    step = StepResult(step_index=0, target="claude", message="do work")
+    await _execute_step(
+        WorkflowStep(target="claude", message="do work"),
+        step,
+        workflow_auto_spawn=True,
+    )
+
+    assert spawned_targets == ["claude"]
+    assert send_endpoints == ["http://localhost:8101"]
+    assert step.status == "completed"
+    assert step.output == "spawned ok"


### PR DESCRIPTION
## Summary

Fixes #568.

`synapse workflow run` was resolving bare-type targets (`target: claude`, `target: codex`, etc.) against the **global** agent registry, so workflows dispatched to agents in unrelated directories — e.g., \`nix-claude\` at \`~/nix-config\` — and failed with the working-dir mismatch warning. \`auto_spawn\` never fired because a global type match was always returned first.

## Root cause

\`synapse/workflow_runner.py:_resolve_target_endpoint\` called \`_resolve_agent_endpoint(target)\` without \`caller_working_dir\`, so the same-dir filter inside \`_resolve_agent_endpoint\` was inert. Even with the working dir passed, the existing \`if len(type_matches) == 1: return type_matches[0]\` fallback (canvas/server.py:207-209) would still surface a global match, blocking \`auto_spawn\`.

## Fix

1. \`workflow_runner._resolve_target_endpoint\` now passes \`caller_working_dir=os.getcwd()\` and a new \`bare_type_same_dir_only=True\` flag.
2. \`canvas.server._resolve_agent_endpoint\` accepts \`bare_type_same_dir_only: bool = False\`. When True, bare-type matches are restricted to the caller's working dir; if same-dir produces zero matches, return \`None\` (no global fallback) so \`auto_spawn\` can run.
3. Default is \`False\`, preserving Canvas/admin route behavior — they keep the legacy global-type fallback.

## Behavior matrix

| target form | Resolution path | Changed? |
|---|---|---|
| \`target: claude\` (bare type) | Same-dir only; None → auto_spawn | ✅ Yes |
| \`target: my-agent\` (specific name) | Global by name | ❌ No |
| \`target: self\` | \`_is_self_target\` short-circuit, never reaches \`_resolve_target_endpoint\` | ❌ No |
| Canvas \`/admin\` API resolving an agent | Legacy fallback (flag=False) | ❌ No |

## Test plan

- [x] \`uv run pytest tests/test_workflow_target_semantics_568.py -q\` — 7 passed (red phase had 3 failed / 4 passed before fix)
- [x] \`uv run pytest tests/test_workflow_target_semantics_568.py tests/test_workflow_runner*.py tests/test_canvas_*.py -q\` — 535 passed, 1 skipped
- [x] \`uv run mypy synapse/\` — Success: no issues found in 114 source files
- [x] pre-commit hooks (ruff, ruff format, mypy) pass on commit

## Test coverage

- \`test_bare_type_with_same_dir_match_resolves\` — single same-dir claude resolves to it
- \`test_bare_type_with_only_other_dir_returns_none\` — no same-dir candidate → None (instead of falling through to other-dir agent)
- \`test_bare_type_with_no_matches_returns_none\` — no candidate at all
- \`test_specific_name_resolves_globally\` — name match is unaffected
- \`test_self_target_unaffected\` — \`target: self\` short-circuit still works
- \`test_canvas_caller_uses_legacy_fallback\` — flag=False keeps the global fallback for Canvas
- \`test_auto_spawn_triggered_when_strict_resolution_fails\` — None resolution now correctly hands off to auto_spawn

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ワークフロー対象型の解決がコーラー作業ディレクトリを正しく尊重するように修正されました。複数のエージェントが存在する場合に、呼び出し元の作業ディレクトリに一致するエージェントが適切に選択されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->