### PR TITLE
feat: SENDING_REPLY sub-state for outbound A2A sends (#644)

### DIFF
--- a/.agents/skills/synapse-a2a/SKILL.md
+++ b/.agents/skills/synapse-a2a/SKILL.md
@@ -206,6 +206,7 @@ to opt out):
 | Status | Meaning | Action |
 |--------|---------|--------|
 | `READY` | Idle, can accept new work | `synapse send` |
+| `SENDING_REPLY` | Temporarily sending an outbound A2A send/reply POST | Wait; previous status is restored after the POST finishes |
 | `PROCESSING` | Actively working a task | Wait, or `synapse interrupt` if stuck |
 | `WAITING` | Awaiting a permission/approval prompt | `synapse approve` / `synapse reject` |
 | `WAITING_FOR_INPUT` | Task is paused asking for non-permission input (#538) | `synapse reply <task_id>` with the answer |

--- a/.agents/skills/synapse-a2a/references/api.md
+++ b/.agents/skills/synapse-a2a/references/api.md
@@ -220,6 +220,8 @@ When `--wait` or `--notify` is used, Synapse expects an explicit reply:
 
 This flow ensures reliable request-response patterns between agents.
 
+While an agent is performing an outbound A2A send/reply POST, the registry status is set to `SENDING_REPLY`. The previous status is restored in `finally` after the POST completes; terminal/protective statuses (`DONE`, `SHUTTING_DOWN`, `RATE_LIMITED`) are not overwritten by this transient transport state.
+
 **Failure semantics:**
 - `synapse reply --fail "<reason>"` records a failed explicit reply locally and returns a structured `failed` task to the sender (`REPLY_FAILED`)
 - If a `--wait` or `--notify` task completes without an explicit `synapse reply`, the receiver-side task is automatically marked as `MISSING_REPLY`

--- a/.agents/skills/synapse-a2a/references/commands.md
+++ b/.agents/skills/synapse-a2a/references/commands.md
@@ -21,7 +21,7 @@ synapse list --json
 - Auto-refresh when agent status changes (via file watcher)
 - Color-coded status display:
   - READY = green (idle, waiting for input)
-  - SENDING_REPLY = yellow (temporarily sending an outbound A2A send/reply POST)
+  - SENDING_REPLY = bold cyan (temporarily sending an outbound A2A send/reply POST)
   - WAITING = cyan (awaiting user input - selection, confirmation; auto-expires after `waiting_expiry`, default 10s)
   - PROCESSING = yellow (busy handling a task)
   - DONE = blue (task completed, auto-clears after 10s)
@@ -674,7 +674,7 @@ synapse history search "error" "authentication" --logic AND
 synapse history search "bug" --agent claude --limit 20
 ```
 
-Agent filters match messages where the agent is involved as sender or receiver, so status views and history queries show the target agent's conversation context rather than unrelated global messages.
+`synapse status <agent>`'s Recent Messages section filters by sender or recipient, so it shows the target agent's conversation context rather than unrelated global messages. `synapse history list/search --agent <name>` filters only by `agent_name` (the producer of the observation row), not by sender/receiver.
 
 ### View Statistics
 

--- a/.agents/skills/synapse-a2a/references/commands.md
+++ b/.agents/skills/synapse-a2a/references/commands.md
@@ -21,6 +21,7 @@ synapse list --json
 - Auto-refresh when agent status changes (via file watcher)
 - Color-coded status display:
   - READY = green (idle, waiting for input)
+  - SENDING_REPLY = yellow (temporarily sending an outbound A2A send/reply POST)
   - WAITING = cyan (awaiting user input - selection, confirmation; auto-expires after `waiting_expiry`, default 10s)
   - PROCESSING = yellow (busy handling a task)
   - DONE = blue (task completed, auto-clears after 10s)
@@ -286,7 +287,7 @@ synapse status my-claude --debug-waiting --json
 **Text output sections:**
 - **Agent Info**: ID, type, name, role, port, status (with `(renderer: off)` annotation when `PtyRenderer` failed), PID, working directory, uptime
 - **Current Task**: Task preview with elapsed time (e.g., `Review code (2m 15s)`)
-- **Recent Messages**: Last 5 messages from history (task ID, direction, sender, preview)
+- **Recent Messages**: Last 5 history messages involving the selected agent (task ID, direction, sender, preview)
 - **File Locks**: Files currently locked by this agent (if File Safety is enabled)
 
 **JSON output** includes all the same data in structured format, with `uptime_seconds` and `current_task.elapsed_seconds` as numeric values for programmatic use. Adds `renderer_available: bool` when the controller reports it.
@@ -303,6 +304,7 @@ Use this when a WAITING prompt did not trip the controller as expected: each att
 - Checking what an agent is currently working on and how long it has been running
 - Debugging why an agent is stuck in PROCESSING (check file locks)
 - Reviewing recent communication history for a specific agent
+- Confirming a transient `SENDING_REPLY` state is just an outbound A2A POST in progress
 
 ### Waiting Debug Collection (`synapse waiting-debug`)
 
@@ -671,6 +673,8 @@ synapse history search "error" "authentication" --logic AND
 # Filter by agent
 synapse history search "bug" --agent claude --limit 20
 ```
+
+Agent filters match messages where the agent is involved as sender or receiver, so status views and history queries show the target agent's conversation context rather than unrelated global messages.
 
 ### View Statistics
 

--- a/.agents/skills/synapse-a2a/references/messaging.md
+++ b/.agents/skills/synapse-a2a/references/messaging.md
@@ -84,6 +84,8 @@ synapse reply "Analysis result: ..."
 
 Synapse automatically tracks senders who expect a reply (marked with `[REPLY EXPECTED]` in the delivered message). `synapse reply` knows who to respond to without additional configuration.
 
+During outbound A2A send/reply POSTs, the sender may briefly appear as `SENDING_REPLY` in `synapse list` or `synapse status`. This is a transient transport state: Synapse restores the previous status after the POST finishes and does not overwrite terminal/protective states such as `DONE`, `SHUTTING_DOWN`, or `RATE_LIMITED`.
+
 ### Broadcasting to All Agents
 
 Send a message to every agent sharing the same working directory:

--- a/.agents/skills/synapse-manager/SKILL.md
+++ b/.agents/skills/synapse-manager/SKILL.md
@@ -41,10 +41,10 @@ Review WORKING_DIR, ROLE, STATUS, TYPE. Only READY agents can accept work immedi
 Other relevant statuses: `SENDING_REPLY` (brief outbound A2A send/reply POST;
 wait for the previous status to return), `PROCESSING` (busy), `WAITING`
 (permission prompt — use `synapse approve`/`synapse reject`), `WAITING_FOR_INPUT`
-(#538 — task paused asking for input, reply via `synapse reply <task_id>`),
-`RATE_LIMITED` (#561 — LLM provider rate limit hit; wait for the window to reset
-before re-sending), `DONE` (demotes to READY ~10s later), `SHUTTING_DOWN` (do not
-send).
+(#538 — task paused asking for input, reply via `synapse reply "<message>"` or
+`synapse reply "<message>" --to <sender_id>`), `RATE_LIMITED` (#561 — LLM
+provider rate limit hit; wait for the window to reset before re-sending), `DONE`
+(demotes to READY ~10s later), `SHUTTING_DOWN` (do not send).
 
 **Spawn only when no existing agent can handle the task:**
 ```bash

--- a/.agents/skills/synapse-manager/SKILL.md
+++ b/.agents/skills/synapse-manager/SKILL.md
@@ -38,11 +38,13 @@ synapse list --json
 ```
 
 Review WORKING_DIR, ROLE, STATUS, TYPE. Only READY agents can accept work immediately.
-Other relevant statuses: `PROCESSING` (busy), `WAITING` (permission prompt — use
-`synapse approve`/`synapse reject`), `WAITING_FOR_INPUT` (#538 — task paused asking
-for input, reply via `synapse reply <task_id>`), `RATE_LIMITED` (#561 — LLM provider
-rate limit hit; wait for the window to reset before re-sending), `DONE`
-(demotes to READY ~10s later), `SHUTTING_DOWN` (do not send).
+Other relevant statuses: `SENDING_REPLY` (brief outbound A2A send/reply POST;
+wait for the previous status to return), `PROCESSING` (busy), `WAITING`
+(permission prompt — use `synapse approve`/`synapse reject`), `WAITING_FOR_INPUT`
+(#538 — task paused asking for input, reply via `synapse reply <task_id>`),
+`RATE_LIMITED` (#561 — LLM provider rate limit hit; wait for the window to reset
+before re-sending), `DONE` (demotes to READY ~10s later), `SHUTTING_DOWN` (do not
+send).
 
 **Spawn only when no existing agent can handle the task:**
 ```bash

--- a/.claude/skills/synapse-a2a/SKILL.md
+++ b/.claude/skills/synapse-a2a/SKILL.md
@@ -206,6 +206,7 @@ to opt out):
 | Status | Meaning | Action |
 |--------|---------|--------|
 | `READY` | Idle, can accept new work | `synapse send` |
+| `SENDING_REPLY` | Temporarily sending an outbound A2A send/reply POST | Wait; previous status is restored after the POST finishes |
 | `PROCESSING` | Actively working a task | Wait, or `synapse interrupt` if stuck |
 | `WAITING` | Awaiting a permission/approval prompt | `synapse approve` / `synapse reject` |
 | `WAITING_FOR_INPUT` | Task is paused asking for non-permission input (#538) | `synapse reply <task_id>` with the answer |

--- a/.claude/skills/synapse-a2a/references/api.md
+++ b/.claude/skills/synapse-a2a/references/api.md
@@ -220,6 +220,8 @@ When `--wait` or `--notify` is used, Synapse expects an explicit reply:
 
 This flow ensures reliable request-response patterns between agents.
 
+While an agent is performing an outbound A2A send/reply POST, the registry status is set to `SENDING_REPLY`. The previous status is restored in `finally` after the POST completes; terminal/protective statuses (`DONE`, `SHUTTING_DOWN`, `RATE_LIMITED`) are not overwritten by this transient transport state.
+
 **Failure semantics:**
 - `synapse reply --fail "<reason>"` records a failed explicit reply locally and returns a structured `failed` task to the sender (`REPLY_FAILED`)
 - If a `--wait` or `--notify` task completes without an explicit `synapse reply`, the receiver-side task is automatically marked as `MISSING_REPLY`

--- a/.claude/skills/synapse-a2a/references/commands.md
+++ b/.claude/skills/synapse-a2a/references/commands.md
@@ -21,7 +21,7 @@ synapse list --json
 - Auto-refresh when agent status changes (via file watcher)
 - Color-coded status display:
   - READY = green (idle, waiting for input)
-  - SENDING_REPLY = yellow (temporarily sending an outbound A2A send/reply POST)
+  - SENDING_REPLY = bold cyan (temporarily sending an outbound A2A send/reply POST)
   - WAITING = cyan (awaiting user input - selection, confirmation; auto-expires after `waiting_expiry`, default 10s)
   - PROCESSING = yellow (busy handling a task)
   - DONE = blue (task completed, auto-clears after 10s)
@@ -674,7 +674,7 @@ synapse history search "error" "authentication" --logic AND
 synapse history search "bug" --agent claude --limit 20
 ```
 
-Agent filters match messages where the agent is involved as sender or receiver, so status views and history queries show the target agent's conversation context rather than unrelated global messages.
+`synapse status <agent>`'s Recent Messages section filters by sender or recipient, so it shows the target agent's conversation context rather than unrelated global messages. `synapse history list/search --agent <name>` filters only by `agent_name` (the producer of the observation row), not by sender/receiver.
 
 ### View Statistics
 

--- a/.claude/skills/synapse-a2a/references/commands.md
+++ b/.claude/skills/synapse-a2a/references/commands.md
@@ -21,6 +21,7 @@ synapse list --json
 - Auto-refresh when agent status changes (via file watcher)
 - Color-coded status display:
   - READY = green (idle, waiting for input)
+  - SENDING_REPLY = yellow (temporarily sending an outbound A2A send/reply POST)
   - WAITING = cyan (awaiting user input - selection, confirmation; auto-expires after `waiting_expiry`, default 10s)
   - PROCESSING = yellow (busy handling a task)
   - DONE = blue (task completed, auto-clears after 10s)
@@ -286,7 +287,7 @@ synapse status my-claude --debug-waiting --json
 **Text output sections:**
 - **Agent Info**: ID, type, name, role, port, status (with `(renderer: off)` annotation when `PtyRenderer` failed), PID, working directory, uptime
 - **Current Task**: Task preview with elapsed time (e.g., `Review code (2m 15s)`)
-- **Recent Messages**: Last 5 messages from history (task ID, direction, sender, preview)
+- **Recent Messages**: Last 5 history messages involving the selected agent (task ID, direction, sender, preview)
 - **File Locks**: Files currently locked by this agent (if File Safety is enabled)
 
 **JSON output** includes all the same data in structured format, with `uptime_seconds` and `current_task.elapsed_seconds` as numeric values for programmatic use. Adds `renderer_available: bool` when the controller reports it.
@@ -303,6 +304,7 @@ Use this when a WAITING prompt did not trip the controller as expected: each att
 - Checking what an agent is currently working on and how long it has been running
 - Debugging why an agent is stuck in PROCESSING (check file locks)
 - Reviewing recent communication history for a specific agent
+- Confirming a transient `SENDING_REPLY` state is just an outbound A2A POST in progress
 
 ### Waiting Debug Collection (`synapse waiting-debug`)
 
@@ -671,6 +673,8 @@ synapse history search "error" "authentication" --logic AND
 # Filter by agent
 synapse history search "bug" --agent claude --limit 20
 ```
+
+Agent filters match messages where the agent is involved as sender or receiver, so status views and history queries show the target agent's conversation context rather than unrelated global messages.
 
 ### View Statistics
 

--- a/.claude/skills/synapse-a2a/references/messaging.md
+++ b/.claude/skills/synapse-a2a/references/messaging.md
@@ -84,6 +84,8 @@ synapse reply "Analysis result: ..."
 
 Synapse automatically tracks senders who expect a reply (marked with `[REPLY EXPECTED]` in the delivered message). `synapse reply` knows who to respond to without additional configuration.
 
+During outbound A2A send/reply POSTs, the sender may briefly appear as `SENDING_REPLY` in `synapse list` or `synapse status`. This is a transient transport state: Synapse restores the previous status after the POST finishes and does not overwrite terminal/protective states such as `DONE`, `SHUTTING_DOWN`, or `RATE_LIMITED`.
+
 ### Broadcasting to All Agents
 
 Send a message to every agent sharing the same working directory:

--- a/.claude/skills/synapse-manager/SKILL.md
+++ b/.claude/skills/synapse-manager/SKILL.md
@@ -41,10 +41,10 @@ Review WORKING_DIR, ROLE, STATUS, TYPE. Only READY agents can accept work immedi
 Other relevant statuses: `SENDING_REPLY` (brief outbound A2A send/reply POST;
 wait for the previous status to return), `PROCESSING` (busy), `WAITING`
 (permission prompt — use `synapse approve`/`synapse reject`), `WAITING_FOR_INPUT`
-(#538 — task paused asking for input, reply via `synapse reply <task_id>`),
-`RATE_LIMITED` (#561 — LLM provider rate limit hit; wait for the window to reset
-before re-sending), `DONE` (demotes to READY ~10s later), `SHUTTING_DOWN` (do not
-send).
+(#538 — task paused asking for input, reply via `synapse reply "<message>"` or
+`synapse reply "<message>" --to <sender_id>`), `RATE_LIMITED` (#561 — LLM
+provider rate limit hit; wait for the window to reset before re-sending), `DONE`
+(demotes to READY ~10s later), `SHUTTING_DOWN` (do not send).
 
 **Spawn only when no existing agent can handle the task:**
 ```bash

--- a/.claude/skills/synapse-manager/SKILL.md
+++ b/.claude/skills/synapse-manager/SKILL.md
@@ -38,11 +38,13 @@ synapse list --json
 ```
 
 Review WORKING_DIR, ROLE, STATUS, TYPE. Only READY agents can accept work immediately.
-Other relevant statuses: `PROCESSING` (busy), `WAITING` (permission prompt — use
-`synapse approve`/`synapse reject`), `WAITING_FOR_INPUT` (#538 — task paused asking
-for input, reply via `synapse reply <task_id>`), `RATE_LIMITED` (#561 — LLM provider
-rate limit hit; wait for the window to reset before re-sending), `DONE`
-(demotes to READY ~10s later), `SHUTTING_DOWN` (do not send).
+Other relevant statuses: `SENDING_REPLY` (brief outbound A2A send/reply POST;
+wait for the previous status to return), `PROCESSING` (busy), `WAITING`
+(permission prompt — use `synapse approve`/`synapse reject`), `WAITING_FOR_INPUT`
+(#538 — task paused asking for input, reply via `synapse reply <task_id>`),
+`RATE_LIMITED` (#561 — LLM provider rate limit hit; wait for the window to reset
+before re-sending), `DONE` (demotes to READY ~10s later), `SHUTTING_DOWN` (do not
+send).
 
 **Spawn only when no existing agent can handle the task:**
 ```bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Surface child agent reply-send stalls via `SENDING_REPLY` sub-state and per-agent Recent Messages filter (#644).
 - Surface LLM provider rate limits as `RATE_LIMITED` agent status (#561).
 - Delay sends to READY agents (#467).
 - **`/dev-issue <number>` slash command (skill):** bootstraps a new issue implementation in one step — fetches the issue and related closed PRs in parallel, greps the repo for code hotspots from the body, infers a branch prefix from labels and a slug from the title, generates a structured task brief at `/tmp/issue<num>-task.md` (mirroring the handwritten brief format used in recent issue → codex spawn flows like #467), creates a fresh branch from latest `origin/main`, and (by default) spawns a codex agent with `synapse spawn codex --task-file ... --notify`. Supports `--solo` (skip spawn) and `--dry-run` (brief only, no branch / no spawn). Canonical at `.agents/skills/dev-issue/SKILL.md`, mirrored as a symlink at `.claude/skills/dev-issue/` and as a copy at `plugins/synapse-a2a/skills/dev-issue/` for plugin distribution.

--- a/README.md
+++ b/README.md
@@ -1651,7 +1651,7 @@ For Copilot specifically, bracketed paste is enabled because Copilot CLI 1.0.12+
 | NAME | Custom name (if assigned) |
 | TYPE | Agent type (claude, gemini, codex, etc.) |
 | ROLE | Agent role description (if assigned) |
-| STATUS | Current status (READY, WAITING, WAITING_FOR_INPUT, PROCESSING, RATE_LIMITED, DONE) |
+| STATUS | Current status (READY, WAITING, WAITING_FOR_INPUT, PROCESSING, SENDING_REPLY, RATE_LIMITED, DONE) |
 | CURRENT | Current task preview with elapsed time (e.g., "Review code (2m 15s)") |
 | TRANSPORT | Communication transport indicator |
 | WORKING_DIR | Current working directory |
@@ -1677,6 +1677,7 @@ For Copilot specifically, bracketed paste is enabled because Copilot CLI 1.0.12+
 | **WAITING** | Cyan | Agent is showing a permission prompt (selection UI / Y-N) |
 | **WAITING_FOR_INPUT** | Orange | Agent has an A2A task in `input_required` for a non-permission response ([#538](https://github.com/s-hiraoku/synapse-a2a/issues/538) / [#640](https://github.com/s-hiraoku/synapse-a2a/pull/640)) |
 | **PROCESSING** | Yellow | Agent is actively working |
+| **SENDING_REPLY** | Cyan | Agent is posting an outbound A2A send/reply request. This transient state restores the previous status when the POST finishes and does not overwrite terminal states such as DONE, SHUTTING_DOWN, or RATE_LIMITED |
 | **RATE_LIMITED** | Bold Magenta | LLM provider rate limit hit; surfaced when the error_detector returns the `RATE_LIMITED` error code. Overrides PROCESSING / READY / WAITING_FOR_INPUT until the agent recovers ([#561](https://github.com/s-hiraoku/synapse-a2a/issues/561) / [#648](https://github.com/s-hiraoku/synapse-a2a/pull/648), forthcoming in 0.30.x) |
 | **DONE** | Blue | Task completed (auto-transitions to READY after 10s) |
 
@@ -1717,7 +1718,7 @@ The `PROCESSING` to `READY` transition uses compound signals to prevent prematur
 - **`task_active` flag**: Suppresses READY when an A2A task is being processed (timeout: `task_protection_timeout`, default 30s)
 - **File locks**: Suppresses READY when the agent holds file locks via FileSafetyManager
 
-Use `synapse status <agent>` to inspect the detailed state of a specific agent, including current task elapsed time and file locks.
+Use `synapse status <agent>` to inspect the detailed state of a specific agent, including current task elapsed time and file locks. Its Recent Messages section shows messages where the selected agent was involved as sender or receiver, rather than unrelated global history.
 
 ---
 

--- a/guides/references.md
+++ b/guides/references.md
@@ -307,7 +307,7 @@ synapse list --json       # JSON 配列出力（AI/スクリプト向け）
 | NAME | カスタム名 |
 | TYPE | エージェントタイプ（プロファイル名） |
 | ROLE | エージェントの役割説明 |
-| STATUS | 現在の状態（READY/PROCESSING/SENDING_REPLY/RATE_LIMITED/DONE） |
+| STATUS | 現在の状態（例: READY/PROCESSING/WAITING/WAITING_FOR_INPUT/SENDING_REPLY/RATE_LIMITED/DONE/SHUTTING_DOWN） |
 | TRANSPORT | 通信中の方式 |
 | CURRENT | 現在のタスクプレビュー |
 | WORKING_DIR | 作業ディレクトリ |

--- a/guides/references.md
+++ b/guides/references.md
@@ -307,7 +307,7 @@ synapse list --json       # JSON 配列出力（AI/スクリプト向け）
 | NAME | カスタム名 |
 | TYPE | エージェントタイプ（プロファイル名） |
 | ROLE | エージェントの役割説明 |
-| STATUS | 現在の状態（READY/PROCESSING/DONE） |
+| STATUS | 現在の状態（READY/PROCESSING/SENDING_REPLY/RATE_LIMITED/DONE） |
 | TRANSPORT | 通信中の方式 |
 | CURRENT | 現在のタスクプレビュー |
 | WORKING_DIR | 作業ディレクトリ |
@@ -315,6 +315,7 @@ synapse list --json       # JSON 配列出力（AI/スクリプト向け）
 | EDITING_FILE | 編集中のファイル（File Safety 有効時のみ表示） |
 
 **Note**: 行を選択すると詳細パネルが表示され、Port/PID/Endpoint/フルパスなどが確認できます。
+**Note**: `synapse status <agent>` の Recent Messages は、指定したエージェントが送信元または受信先として関与した履歴だけを表示します。
 
 **TRANSPORT 列の値**:
 
@@ -540,6 +541,7 @@ synapse send <target> <message|--message-file PATH|--task-file PATH|--stdin> [--
 **Note**: 送信元エージェントが特定できない場合（`SYNAPSE_AGENT_ID` 未設定かつ PID マッチングも失敗）、`Warning: Could not identify sender agent. Set SYNAPSE_AGENT_ID or use --from.` を表示します。サンドボックス環境では `--from` を明示指定してください。
 **Note**: `local send failed` エラー時は `SYNAPSE_LOG_LEVEL=DEBUG` を設定して再実行すると、HTTP ステータス等の詳細ログが出力されます（UDS/TCP 接続失敗、HTTP 409 "Agent busy" 等）。
 **Note**: 配信前ウェイト — ターゲットが PROCESSING の場合は最大 30 秒 idle を待ち、READY の場合はデフォルト 2 秒の遅延を入れてから配信します (`SYNAPSE_SEND_READY_DELAY` で上書き可、ユーザーの入力中テキスト保護目的、[#467](https://github.com/s-hiraoku/synapse-a2a/issues/467) / [#642](https://github.com/s-hiraoku/synapse-a2a/pull/642))。READY ディレイ中にターゲットが PROCESSING に遷移した場合は即時送信。`--force` / priority 5 / `--silent` ではどちらもスキップされます。
+**Note**: outbound A2A send/reply POST 中、送信元は一時的に `SENDING_REPLY` になります。完了後は直前のステータスへ戻り、`DONE` / `SHUTTING_DOWN` / `RATE_LIMITED` は上書きされません。
 
 **レスポンスモードの使い分け**:
 
@@ -2340,6 +2342,7 @@ Host: localhost:8100
 |----|------|
 | `PROCESSING` | 処理中・起動中 |
 | `READY` | 待機中（プロンプト表示） |
+| `SENDING_REPLY` | outbound A2A send/reply POST 中（一時表示。完了後は直前のステータスへ戻る） |
 | `NOT_STARTED` | 未起動 |
 
 **curl 例**:

--- a/guides/usage.md
+++ b/guides/usage.md
@@ -881,7 +881,7 @@ synapse list --json               # JSON 配列出力（AI/スクリプト向け
 | NAME | カスタム名（設定されている場合） |
 | TYPE | エージェントタイプ (claude, gemini, codex など) |
 | ROLE | ロール説明（設定されている場合） |
-| STATUS | 現在のステータス (READY, WAITING, PROCESSING, DONE) |
+| STATUS | 現在のステータス (READY, WAITING, PROCESSING, SENDING_REPLY, RATE_LIMITED, DONE) |
 | TRANSPORT | 通信トランスポート表示 |
 | CURRENT | 現在のタスクプレビュー |
 | WORKING_DIR | 作業ディレクトリ |
@@ -898,6 +898,7 @@ synapse list --json               # JSON 配列出力（AI/スクリプト向け
 - `-`: 通信なし
 
 **Note**: 行を選択すると詳細パネルが表示され、Port/PID/Endpoint/フルパスなどが確認できます。
+**Note**: `synapse status <agent>` の Recent Messages は、指定したエージェントが送信元または受信先として関与した履歴だけを表示します。
 
 ---
 
@@ -934,6 +935,8 @@ synapse send <agent> "メッセージ" [--from AGENT_ID] [--priority <n>] [--wai
 - **READY ディレイ ([#467](https://github.com/s-hiraoku/synapse-a2a/issues/467) / [#642](https://github.com/s-hiraoku/synapse-a2a/pull/642))**: ターゲットが READY の場合、デフォルト 2 秒の遅延を入れてから配信します。これによりユーザーが入力中のテキストを上書きしてしまうのを避けます。`SYNAPSE_SEND_READY_DELAY`（秒）で上書き可能。待機中にターゲットが PROCESSING に遷移したら、即座に送信を実行します。
 
 いずれも `--force` / priority 5 / `--silent` 送信ではスキップされます。
+
+**送信中ステータス**: `synapse send` / `synapse reply` の outbound POST 中、送信元エージェントは一時的に `SENDING_REPLY` と表示されます。POST 完了後は直前のステータスへ戻り、`DONE` / `SHUTTING_DOWN` / `RATE_LIMITED` などの終端・保護ステータスは上書きしません。
 
 **レスポンスモードの使い分け**:
 
@@ -1596,6 +1599,7 @@ curl http://localhost:8100/status
 | `PROCESSING` | 処理中・起動中 |
 | `READY` | 待機中（プロンプト表示中） |
 | `WAITING` | 権限プロンプト待ち（A2A では `input_required` にマッピング）。親エージェントには自動通知され、Approval Gate か `POST /tasks/{id}/permission/approve` / `/deny` で応答可能 |
+| `SENDING_REPLY` | outbound A2A send/reply POST 中（一時表示。完了後は直前のステータスへ戻る） |
 | `NOT_STARTED` | 未起動 |
 
 ---

--- a/plugins/synapse-a2a/skills/synapse-a2a/SKILL.md
+++ b/plugins/synapse-a2a/skills/synapse-a2a/SKILL.md
@@ -206,6 +206,7 @@ to opt out):
 | Status | Meaning | Action |
 |--------|---------|--------|
 | `READY` | Idle, can accept new work | `synapse send` |
+| `SENDING_REPLY` | Temporarily sending an outbound A2A send/reply POST | Wait; previous status is restored after the POST finishes |
 | `PROCESSING` | Actively working a task | Wait, or `synapse interrupt` if stuck |
 | `WAITING` | Awaiting a permission/approval prompt | `synapse approve` / `synapse reject` |
 | `WAITING_FOR_INPUT` | Task is paused asking for non-permission input (#538) | `synapse reply <task_id>` with the answer |

--- a/plugins/synapse-a2a/skills/synapse-a2a/references/api.md
+++ b/plugins/synapse-a2a/skills/synapse-a2a/references/api.md
@@ -220,6 +220,8 @@ When `--wait` or `--notify` is used, Synapse expects an explicit reply:
 
 This flow ensures reliable request-response patterns between agents.
 
+While an agent is performing an outbound A2A send/reply POST, the registry status is set to `SENDING_REPLY`. The previous status is restored in `finally` after the POST completes; terminal/protective statuses (`DONE`, `SHUTTING_DOWN`, `RATE_LIMITED`) are not overwritten by this transient transport state.
+
 **Failure semantics:**
 - `synapse reply --fail "<reason>"` records a failed explicit reply locally and returns a structured `failed` task to the sender (`REPLY_FAILED`)
 - If a `--wait` or `--notify` task completes without an explicit `synapse reply`, the receiver-side task is automatically marked as `MISSING_REPLY`

--- a/plugins/synapse-a2a/skills/synapse-a2a/references/commands.md
+++ b/plugins/synapse-a2a/skills/synapse-a2a/references/commands.md
@@ -21,7 +21,7 @@ synapse list --json
 - Auto-refresh when agent status changes (via file watcher)
 - Color-coded status display:
   - READY = green (idle, waiting for input)
-  - SENDING_REPLY = yellow (temporarily sending an outbound A2A send/reply POST)
+  - SENDING_REPLY = bold cyan (temporarily sending an outbound A2A send/reply POST)
   - WAITING = cyan (awaiting user input - selection, confirmation; auto-expires after `waiting_expiry`, default 10s)
   - PROCESSING = yellow (busy handling a task)
   - DONE = blue (task completed, auto-clears after 10s)

--- a/plugins/synapse-a2a/skills/synapse-a2a/references/commands.md
+++ b/plugins/synapse-a2a/skills/synapse-a2a/references/commands.md
@@ -674,7 +674,7 @@ synapse history search "error" "authentication" --logic AND
 synapse history search "bug" --agent claude --limit 20
 ```
 
-Agent filters match messages where the agent is involved as sender or receiver, so status views and history queries show the target agent's conversation context rather than unrelated global messages.
+`synapse status <agent>`'s Recent Messages section filters by sender or recipient, so it shows the target agent's conversation context rather than unrelated global messages. `synapse history list/search --agent <name>` filters only by `agent_name` (the producer of the observation row), not by sender/receiver.
 
 ### View Statistics
 

--- a/plugins/synapse-a2a/skills/synapse-a2a/references/commands.md
+++ b/plugins/synapse-a2a/skills/synapse-a2a/references/commands.md
@@ -21,6 +21,7 @@ synapse list --json
 - Auto-refresh when agent status changes (via file watcher)
 - Color-coded status display:
   - READY = green (idle, waiting for input)
+  - SENDING_REPLY = yellow (temporarily sending an outbound A2A send/reply POST)
   - WAITING = cyan (awaiting user input - selection, confirmation; auto-expires after `waiting_expiry`, default 10s)
   - PROCESSING = yellow (busy handling a task)
   - DONE = blue (task completed, auto-clears after 10s)
@@ -286,7 +287,7 @@ synapse status my-claude --debug-waiting --json
 **Text output sections:**
 - **Agent Info**: ID, type, name, role, port, status (with `(renderer: off)` annotation when `PtyRenderer` failed), PID, working directory, uptime
 - **Current Task**: Task preview with elapsed time (e.g., `Review code (2m 15s)`)
-- **Recent Messages**: Last 5 messages from history (task ID, direction, sender, preview)
+- **Recent Messages**: Last 5 history messages involving the selected agent (task ID, direction, sender, preview)
 - **File Locks**: Files currently locked by this agent (if File Safety is enabled)
 
 **JSON output** includes all the same data in structured format, with `uptime_seconds` and `current_task.elapsed_seconds` as numeric values for programmatic use. Adds `renderer_available: bool` when the controller reports it.
@@ -303,6 +304,7 @@ Use this when a WAITING prompt did not trip the controller as expected: each att
 - Checking what an agent is currently working on and how long it has been running
 - Debugging why an agent is stuck in PROCESSING (check file locks)
 - Reviewing recent communication history for a specific agent
+- Confirming a transient `SENDING_REPLY` state is just an outbound A2A POST in progress
 
 ### Waiting Debug Collection (`synapse waiting-debug`)
 
@@ -671,6 +673,8 @@ synapse history search "error" "authentication" --logic AND
 # Filter by agent
 synapse history search "bug" --agent claude --limit 20
 ```
+
+Agent filters match messages where the agent is involved as sender or receiver, so status views and history queries show the target agent's conversation context rather than unrelated global messages.
 
 ### View Statistics
 

--- a/plugins/synapse-a2a/skills/synapse-a2a/references/messaging.md
+++ b/plugins/synapse-a2a/skills/synapse-a2a/references/messaging.md
@@ -84,6 +84,8 @@ synapse reply "Analysis result: ..."
 
 Synapse automatically tracks senders who expect a reply (marked with `[REPLY EXPECTED]` in the delivered message). `synapse reply` knows who to respond to without additional configuration.
 
+During outbound A2A send/reply POSTs, the sender may briefly appear as `SENDING_REPLY` in `synapse list` or `synapse status`. This is a transient transport state: Synapse restores the previous status after the POST finishes and does not overwrite terminal/protective states such as `DONE`, `SHUTTING_DOWN`, or `RATE_LIMITED`.
+
 ### Broadcasting to All Agents
 
 Send a message to every agent sharing the same working directory:

--- a/plugins/synapse-a2a/skills/synapse-manager/SKILL.md
+++ b/plugins/synapse-a2a/skills/synapse-manager/SKILL.md
@@ -41,10 +41,10 @@ Review WORKING_DIR, ROLE, STATUS, TYPE. Only READY agents can accept work immedi
 Other relevant statuses: `SENDING_REPLY` (brief outbound A2A send/reply POST;
 wait for the previous status to return), `PROCESSING` (busy), `WAITING`
 (permission prompt — use `synapse approve`/`synapse reject`), `WAITING_FOR_INPUT`
-(#538 — task paused asking for input, reply via `synapse reply <task_id>`),
-`RATE_LIMITED` (#561 — LLM provider rate limit hit; wait for the window to reset
-before re-sending), `DONE` (demotes to READY ~10s later), `SHUTTING_DOWN` (do not
-send).
+(#538 — task paused asking for input, reply via `synapse reply "<message>"` or
+`synapse reply "<message>" --to <sender_id>`), `RATE_LIMITED` (#561 — LLM
+provider rate limit hit; wait for the window to reset before re-sending), `DONE`
+(demotes to READY ~10s later), `SHUTTING_DOWN` (do not send).
 
 **Spawn only when no existing agent can handle the task:**
 ```bash

--- a/plugins/synapse-a2a/skills/synapse-manager/SKILL.md
+++ b/plugins/synapse-a2a/skills/synapse-manager/SKILL.md
@@ -38,11 +38,13 @@ synapse list --json
 ```
 
 Review WORKING_DIR, ROLE, STATUS, TYPE. Only READY agents can accept work immediately.
-Other relevant statuses: `PROCESSING` (busy), `WAITING` (permission prompt — use
-`synapse approve`/`synapse reject`), `WAITING_FOR_INPUT` (#538 — task paused asking
-for input, reply via `synapse reply <task_id>`), `RATE_LIMITED` (#561 — LLM provider
-rate limit hit; wait for the window to reset before re-sending), `DONE`
-(demotes to READY ~10s later), `SHUTTING_DOWN` (do not send).
+Other relevant statuses: `SENDING_REPLY` (brief outbound A2A send/reply POST;
+wait for the previous status to return), `PROCESSING` (busy), `WAITING`
+(permission prompt — use `synapse approve`/`synapse reject`), `WAITING_FOR_INPUT`
+(#538 — task paused asking for input, reply via `synapse reply <task_id>`),
+`RATE_LIMITED` (#561 — LLM provider rate limit hit; wait for the window to reset
+before re-sending), `DONE` (demotes to READY ~10s later), `SHUTTING_DOWN` (do not
+send).
 
 **Spawn only when no existing agent can handle the task:**
 ```bash

--- a/site-docs/guide/agent-management.md
+++ b/site-docs/guide/agent-management.md
@@ -143,7 +143,7 @@ This shows:
 
 - **Agent Info**: ID, type, name, role, port, status, PID, working directory, uptime
 - **Current Task**: Task preview with elapsed time since the task was received
-- **Recent Messages**: Last 5 incoming/outgoing A2A messages from history
+- **Recent Messages**: Last 5 A2A messages where the agent is the sender or recipient
 - **File Locks**: Files currently locked by this agent (when File Safety is enabled)
 
 For machine-readable output:
@@ -331,13 +331,14 @@ When using `synapse send`, `synapse kill`, `synapse jump`, `synapse rename`, or 
 |--------|:---:|---------|
 | **READY** | :material-circle:{ .status-ready } | Idle, waiting for input |
 | **PROCESSING** | :material-circle:{ .status-processing } | Actively working |
+| **SENDING_REPLY** | :material-circle:{ .status-waiting } | Sending an outbound A2A `send`/`reply` POST |
 | **WAITING** | :material-circle:{ .status-waiting } | Showing selection UI (e.g. permission prompt) |
 | **WAITING_FOR_INPUT** | :material-circle:{ .status-waiting } | A2A `input_required` task awaiting non-permission response (#538/#640) |
 | **RATE_LIMITED** | :material-circle:{ .status-waiting } | LLM provider rate limit detected — bold magenta in `synapse list` (#561) |
 | **DONE** | :material-circle:{ .status-done } | Task completed (auto-clears 10s) |
 | **SHUTTING_DOWN** | :material-circle:{ .status-shutdown } | Shutdown in progress |
 
-`WAITING` is reserved for permission-style prompts where the PTY is showing a choice UI; `WAITING_FOR_INPUT` is set when an A2A task transitions to `input_required` for a non-permission reason (e.g. a child agent is asking the parent a follow-up question). `RATE_LIMITED` is set when the underlying LLM provider returns a rate-limit signal in the agent's PTY output, so an agent that is simply waiting on quota is no longer indistinguishable from an actively working `PROCESSING` agent. All three states are registry-level and exposed via `synapse list` / `synapse status` (text and `--json`). The status sync layer demotes stale `PROCESSING` / `WAITING_FOR_INPUT` entries back to `READY` once the task store is non-empty and every task is terminal, so a finished agent is never shown as still working (#569).
+`SENDING_REPLY` is a transient sender-side state while `synapse send` or `synapse reply` posts an outbound A2A request. Synapse restores the agent's previous status afterward and does not overwrite `DONE`, `SHUTTING_DOWN`, or `RATE_LIMITED`. `WAITING` is reserved for permission-style prompts where the PTY is showing a choice UI; `WAITING_FOR_INPUT` is set when an A2A task transitions to `input_required` for a non-permission reason (e.g. a child agent is asking the parent a follow-up question). `RATE_LIMITED` is set when the underlying LLM provider returns a rate-limit signal in the agent's PTY output, so an agent that is simply waiting on quota is no longer indistinguishable from an actively working `PROCESSING` agent. These states are registry-level and exposed via `synapse list` / `synapse status` (text and `--json`). The status sync layer demotes stale `PROCESSING` / `WAITING_FOR_INPUT` entries back to `READY` once the task store is non-empty and every task is terminal, so a finished agent is never shown as still working (#569).
 
 Dead processes are automatically cleaned from the registry and hidden from `synapse list`.
 

--- a/site-docs/reference/cli.md
+++ b/site-docs/reference/cli.md
@@ -97,7 +97,7 @@ synapse status <target> --json           # Output as JSON
 synapse status <target> --debug-waiting  # Dump the in-memory WAITING-detection ring
 ```
 
-Shows a comprehensive view of a single agent including metadata, uptime, current task with elapsed time, recent message history, and file locks. See [Agent Management — Detailed Status](../guide/agent-management.md#detailed-status) for more.
+Shows a comprehensive view of a single agent including metadata, uptime, current task with elapsed time, recent message history, and file locks. Recent Messages includes the last 5 history entries where the selected agent is the sender or recipient. See [Agent Management — Detailed Status](../guide/agent-management.md#detailed-status) for more.
 
 | Flag | Description |
 |------|-------------|
@@ -256,6 +256,8 @@ synapse send <target> "<message>" [OPTIONS]
 **PROCESSING wait**: When the target agent's status is `PROCESSING`, `synapse send` automatically waits (polling every 1 second) for the agent to become `READY` before delivering the message. This prevents messages from being queued behind an in-progress task. The wait is skipped for `--silent` sends, priority-5 (critical) sends, and when `--force` is specified. The timeout is controlled by `SYNAPSE_SEND_WAIT_TIMEOUT` (default: 30 seconds).
 
 **READY-delay** (#467, #642): When the target is already `READY`, `synapse send` pauses briefly (default **2 seconds**, polling every 250 ms) before injecting the message. This avoids interrupting a user who is still typing at the agent's prompt; if the agent flips to `PROCESSING` during the window the send proceeds immediately. The delay is configurable via `SYNAPSE_SEND_READY_DELAY` (seconds, set to `0` to disable) and is bypassed for `--silent`, priority-5, and `--force` sends.
+
+**Outbound status** (#644): During the outbound A2A POST, the sender briefly shows `SENDING_REPLY` in `synapse list` / `synapse status`. The previous status is restored afterward, and terminal or protected states (`DONE`, `SHUTTING_DOWN`, `RATE_LIMITED`) are not overwritten.
 
 !!! tip "Choosing response mode"
     - `--notify` (default): Returns immediately; you get a PTY notification when the receiver completes. Best for most use cases.

--- a/synapse/a2a_compat.py
+++ b/synapse/a2a_compat.py
@@ -60,6 +60,7 @@ from synapse.status import (
     PROCESSING,
     RATE_LIMITED,
     READY,
+    SENDING_REPLY,
     WAITING,
     WAITING_FOR_INPUT,
 )
@@ -1159,8 +1160,10 @@ def create_a2a_router(
                 agent_info = registry.get_agent(agent_id)
                 if agent_info and agent_info.get("status") in (
                     "PROCESSING",
+                    SENDING_REPLY,
                     WAITING_FOR_INPUT,
                 ):
+                    # SENDING_REPLY is a short-lived outbound-send sub-state.
                     registry.update_status(agent_id, "READY")
 
         def _on_status_change(old: str, new: str) -> None:

--- a/synapse/commands/status.py
+++ b/synapse/commands/status.py
@@ -249,8 +249,9 @@ class StatusCommand:
             return []
         try:
             agent_name = info.get("agent_type", "unknown")
+            agent_id = info.get("agent_id")
             return self._history_manager.list_observations(
-                agent_name=agent_name, limit=5
+                agent_name=agent_name, agent_id=agent_id, limit=5
             )
         except Exception:  # broad catch: history lookup is optional status info
             return []

--- a/synapse/history.py
+++ b/synapse/history.py
@@ -18,6 +18,48 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 
+def _metadata_agent_ids(metadata: dict[str, Any]) -> set[str]:
+    """Extract sender/recipient agent IDs from observation metadata."""
+    agent_ids: set[str] = set()
+    for key in (
+        "sender_id",
+        "recipient_id",
+        "recipient_agent_id",
+        "target_agent_id",
+        "target_id",
+    ):
+        value = metadata.get(key)
+        if isinstance(value, str):
+            agent_ids.add(value)
+
+    sender = metadata.get("sender")
+    if isinstance(sender, dict):
+        sender_id = sender.get("sender_id")
+        if isinstance(sender_id, str):
+            agent_ids.add(sender_id)
+
+    recipient = metadata.get("recipient")
+    if isinstance(recipient, dict):
+        recipient_id = recipient.get("recipient_id") or recipient.get("agent_id")
+        if isinstance(recipient_id, str):
+            agent_ids.add(recipient_id)
+
+    target = metadata.get("target")
+    if isinstance(target, dict):
+        target_id = target.get("target_agent_id") or target.get("agent_id")
+        if isinstance(target_id, str):
+            agent_ids.add(target_id)
+
+    return agent_ids
+
+
+def _observation_matches_agent_id(observation: dict[str, Any], agent_id: str) -> bool:
+    metadata = observation.get("metadata")
+    if not isinstance(metadata, dict):
+        return False
+    return agent_id in _metadata_agent_ids(metadata)
+
+
 @contextlib.contextmanager
 def _db_connection(
     db_path: str, row_factory: bool = False
@@ -292,12 +334,14 @@ class HistoryManager:
         self,
         limit: int = 50,
         agent_name: str | None = None,
+        agent_id: str | None = None,
     ) -> list[dict[str, Any]]:
         """List observations with optional filtering.
 
         Args:
             limit: Maximum number of observations to return
             agent_name: Optional filter by agent name
+            agent_id: Optional filter by sender or recipient agent ID
 
         Returns:
             List of observation dicts, ordered by timestamp (newest first)
@@ -315,20 +359,24 @@ class HistoryManager:
                             SELECT * FROM observations
                             WHERE agent_name = ?
                             ORDER BY timestamp DESC
-                            LIMIT ?
                             """,
-                            (agent_name, limit),
+                            (agent_name,),
                         )
                     else:
                         cursor.execute(
                             """
                             SELECT * FROM observations
                             ORDER BY timestamp DESC
-                            LIMIT ?
                             """,
-                            (limit,),
                         )
-                    return [self._row_to_dict(row) for row in cursor.fetchall()]
+                    observations = [self._row_to_dict(row) for row in cursor.fetchall()]
+                    if agent_id:
+                        observations = [
+                            obs
+                            for obs in observations
+                            if _observation_matches_agent_id(obs, agent_id)
+                        ]
+                    return observations[:limit]
             except sqlite3.Error as e:
                 print(f"Warning: Failed to list observations: {e}", file=sys.stderr)
                 return []

--- a/synapse/status.py
+++ b/synapse/status.py
@@ -4,6 +4,8 @@ Status flow:
     PROCESSING -> READY/WAITING/WAITING_FOR_INPUT -> PROCESSING -> ... -> DONE -> READY (after 10s)
     PROCESSING/READY/WAITING_FOR_INPUT -> RATE_LIMITED (on LLM provider rate-limit error;
         next controller PTY tick overwrites RATE_LIMITED when fresh output is observed)
+    READY/PROCESSING/WAITING/WAITING_FOR_INPUT -> SENDING_REPLY -> previous status
+        (while an agent is posting an outbound A2A send/reply)
 
 Statuses:
     READY: Agent is idle (not processing anything)
@@ -12,6 +14,7 @@ Statuses:
     PROCESSING: Agent is actively working (generating output, waiting for A2A response)
     DONE: Agent has completed a task (transitions to READY after timeout or new activity)
     RATE_LIMITED: Agent hit an LLM provider rate limit
+    SENDING_REPLY: Agent is sending an outbound A2A reply/message
 """
 
 from __future__ import annotations
@@ -23,11 +26,21 @@ WAITING_FOR_INPUT = "WAITING_FOR_INPUT"
 PROCESSING = "PROCESSING"
 DONE = "DONE"
 RATE_LIMITED = "RATE_LIMITED"
+SENDING_REPLY = "SENDING_REPLY"
 SHUTTING_DOWN = "SHUTTING_DOWN"
 
 # All valid statuses
 ALL_STATUSES = frozenset(
-    {READY, WAITING, WAITING_FOR_INPUT, PROCESSING, DONE, RATE_LIMITED, SHUTTING_DOWN}
+    {
+        READY,
+        WAITING,
+        WAITING_FOR_INPUT,
+        PROCESSING,
+        DONE,
+        RATE_LIMITED,
+        SENDING_REPLY,
+        SHUTTING_DOWN,
+    }
 )
 
 # Status display colors (for Rich TUI)
@@ -38,6 +51,7 @@ STATUS_STYLES = {
     PROCESSING: "bold yellow",  # Yellow: actively working
     DONE: "bold blue",  # Blue: completed successfully
     RATE_LIMITED: "bold magenta",  # Magenta: LLM provider rate limit hit
+    SENDING_REPLY: "bold cyan",  # Cyan: outbound A2A send/reply in progress
     SHUTTING_DOWN: "bold red",  # Red: graceful shutdown in progress
 }
 

--- a/synapse/tools/a2a.py
+++ b/synapse/tools/a2a.py
@@ -30,6 +30,16 @@ from synapse.registry import (
 )
 from synapse.reply_stack import SenderInfo
 from synapse.reply_target import clear_reply_target, load_reply_target
+from synapse.status import (
+    DONE,
+    PROCESSING,
+    RATE_LIMITED,
+    READY,
+    SENDING_REPLY,
+    SHUTTING_DOWN,
+    WAITING,
+    WAITING_FOR_INPUT,
+)
 from synapse.tools.a2a_helpers import (  # noqa: F401 -- re-export
     _add_message_source_flags,
     _add_response_mode_flags,
@@ -61,6 +71,36 @@ from synapse.tools.a2a_helpers import (  # noqa: F401 -- re-export
     get_parent_pid,
     is_descendant_of,
 )
+
+_SENDING_REPLY_SOURCE_STATUSES = frozenset(
+    {READY, PROCESSING, WAITING, WAITING_FOR_INPUT}
+)
+_SENDING_REPLY_PROTECTED_STATUSES = frozenset({DONE, SHUTTING_DOWN, RATE_LIMITED})
+
+
+def _set_sending_reply_status(
+    registry: AgentRegistry, sender_agent_id: str | None
+) -> str | None:
+    """Set the sender registry status while an outbound A2A POST is active."""
+    if not sender_agent_id:
+        return None
+    agent_info = registry.get_agent(sender_agent_id)
+    if not agent_info:
+        return None
+    original_status = agent_info.get("status")
+    if original_status in _SENDING_REPLY_PROTECTED_STATUSES:
+        return None
+    if original_status not in _SENDING_REPLY_SOURCE_STATUSES:
+        return None
+    registry.update_status(sender_agent_id, SENDING_REPLY)
+    return str(original_status)
+
+
+def _restore_sending_reply_status(
+    registry: AgentRegistry, sender_agent_id: str | None, original_status: str | None
+) -> None:
+    if sender_agent_id and original_status:
+        registry.update_status(sender_agent_id, original_status)
 
 
 def cmd_list(args: argparse.Namespace) -> None:
@@ -321,20 +361,25 @@ def cmd_send(args: argparse.Namespace) -> None:
 
     # Add metadata (sender info and response_mode)
     client = A2AClient()
-    task = client.send_to_local(
-        endpoint=str(target_agent["endpoint"]),
-        message=message,
-        file_parts=file_parts,
-        priority=args.priority,
-        wait_for_completion=(response_mode == "wait"),
-        timeout=60,
-        sender_info=sender_info or None,
-        response_mode=response_mode,
-        uds_path=uds_path,
-        registry=reg,
-        sender_agent_id=sender_info.get("sender_id") if sender_info else None,
-        target_agent_id=agent_id,
-    )
+    outbound_sender_id = sender_info.get("sender_id") if sender_info else sender_id
+    original_status = _set_sending_reply_status(reg, outbound_sender_id)
+    try:
+        task = client.send_to_local(
+            endpoint=str(target_agent["endpoint"]),
+            message=message,
+            file_parts=file_parts,
+            priority=args.priority,
+            wait_for_completion=(response_mode == "wait"),
+            timeout=60,
+            sender_info=sender_info or None,
+            response_mode=response_mode,
+            uds_path=uds_path,
+            registry=reg,
+            sender_agent_id=sender_info.get("sender_id") if sender_info else None,
+            target_agent_id=agent_id,
+        )
+    finally:
+        _restore_sending_reply_status(reg, outbound_sender_id, original_status)
 
     if not task:
         print("Error sending message: local send failed", file=sys.stderr)
@@ -767,16 +812,21 @@ def cmd_reply(args: argparse.Namespace) -> None:
     # Send reply using A2AClient (prefer UDS if available)
     # sender_info is guaranteed to be dict here (str case exits above)
     client = A2AClient()
-    result = client.send_to_local(
-        endpoint=target_endpoint or "http://localhost",
-        message=message,
-        priority=3,  # Normal priority for replies
-        sender_info=sender_info,
-        response_mode="silent",  # Reply doesn't expect a reply back
-        in_reply_to=task_id,
-        uds_path=target_uds_path or None,
-        extra_metadata=extra_metadata,
-    )
+    reg = AgentRegistry()
+    original_status = _set_sending_reply_status(reg, my_agent_id)
+    try:
+        result = client.send_to_local(
+            endpoint=target_endpoint or "http://localhost",
+            message=message,
+            priority=3,  # Normal priority for replies
+            sender_info=sender_info,
+            response_mode="silent",  # Reply doesn't expect a reply back
+            in_reply_to=task_id,
+            uds_path=target_uds_path or None,
+            extra_metadata=extra_metadata,
+        )
+    finally:
+        _restore_sending_reply_status(reg, my_agent_id, original_status)
 
     if not result:
         print("Error: Failed to send reply", file=sys.stderr)

--- a/synapse/tools/a2a.py
+++ b/synapse/tools/a2a.py
@@ -99,8 +99,23 @@ def _set_sending_reply_status(
 def _restore_sending_reply_status(
     registry: AgentRegistry, sender_agent_id: str | None, original_status: str | None
 ) -> None:
-    if sender_agent_id and original_status:
-        registry.update_status(sender_agent_id, original_status)
+    """Restore the sender's status after an outbound A2A POST.
+
+    Only restores when the live status is still ``SENDING_REPLY``. If the
+    controller has moved the agent to a protected status (e.g. ``DONE``,
+    ``RATE_LIMITED``, ``SHUTTING_DOWN``) during the send, leave it alone so
+    the protected state wins — the contract is that ``_set_sending_reply_status``
+    refuses to start a SENDING_REPLY transition over those statuses, and the
+    finally block must not silently undo a controller intervention either.
+    """
+    if not sender_agent_id or not original_status:
+        return
+    agent_info = registry.get_agent(sender_agent_id)
+    if not agent_info:
+        return
+    if agent_info.get("status") != SENDING_REPLY:
+        return
+    registry.update_status(sender_agent_id, original_status)
 
 
 def cmd_list(args: argparse.Namespace) -> None:

--- a/tests/test_sending_reply_status_644.py
+++ b/tests/test_sending_reply_status_644.py
@@ -67,11 +67,21 @@ def _sender(status: str = PROCESSING) -> dict[str, object]:
 
 def _mock_registry(current_status: str) -> MagicMock:
     registry = MagicMock()
+    state = {"status": current_status}
+
+    def _get_agent(_agent_id: str) -> dict[str, object]:
+        return _sender(state["status"])
+
+    def _update_status(_agent_id: str, status: str) -> bool:
+        state["status"] = status
+        return True
+
     registry.list_agents.return_value = {
         "synapse-claude-8104": _agent(),
         "synapse-codex-8121": _sender(current_status),
     }
-    registry.get_agent.return_value = _sender(current_status)
+    registry.get_agent.side_effect = _get_agent
+    registry.update_status.side_effect = _update_status
     return registry
 
 
@@ -184,6 +194,38 @@ def test_sending_reply_does_not_overwrite_terminal_status(current_status: str) -
 
     assert ("synapse-codex-8121", "SENDING_REPLY") not in [
         call.args for call in registry.update_status.call_args_list
+    ]
+
+
+@pytest.mark.parametrize("intervening_status", [DONE, RATE_LIMITED, SHUTTING_DOWN])
+def test_restore_skips_when_controller_moves_to_protected_status(
+    intervening_status: str,
+) -> None:
+    """If the controller moves the agent to a protected status mid-send,
+    the finally block must NOT clobber it back to the original status."""
+    from synapse.tools.a2a import (
+        _restore_sending_reply_status,
+        _set_sending_reply_status,
+    )
+
+    registry = _mock_registry(PROCESSING)
+
+    original_status = _set_sending_reply_status(registry, "synapse-codex-8121")
+    assert original_status == PROCESSING
+
+    # Controller intervenes: agent enters a protected status while POST is in flight.
+    registry.update_status("synapse-codex-8121", intervening_status)
+
+    # Finally block runs.
+    _restore_sending_reply_status(registry, "synapse-codex-8121", original_status)
+
+    # The protected status must survive — no PROCESSING write should follow it.
+    final_status = registry.get_agent("synapse-codex-8121")["status"]
+    assert final_status == intervening_status
+
+    update_calls = [call.args for call in registry.update_status.call_args_list]
+    assert ("synapse-codex-8121", PROCESSING) not in update_calls[
+        update_calls.index(("synapse-codex-8121", intervening_status)) :
     ]
 
 

--- a/tests/test_sending_reply_status_644.py
+++ b/tests/test_sending_reply_status_644.py
@@ -1,0 +1,298 @@
+"""Tests for surfacing reply-send stalls as observable status (#644)."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from synapse.a2a_client import A2ATask
+from synapse.commands.status import StatusCommand
+from synapse.history import HistoryManager
+from synapse.status import (
+    ALL_STATUSES,
+    DONE,
+    PROCESSING,
+    RATE_LIMITED,
+    READY,
+    SHUTTING_DOWN,
+    STATUS_STYLES,
+    WAITING_FOR_INPUT,
+)
+from synapse.tools.a2a import cmd_reply, cmd_send
+
+
+def _send_args() -> argparse.Namespace:
+    return argparse.Namespace(
+        target="claude",
+        message="hello",
+        priority=3,
+        sender="synapse-codex-8121",
+        response_mode="notify",
+        force=True,
+        local_only=False,
+        attach=None,
+    )
+
+
+def _reply_args() -> argparse.Namespace:
+    return argparse.Namespace(message="done", fail=None, to=None)
+
+
+def _agent(status: str = PROCESSING) -> dict[str, object]:
+    return {
+        "agent_id": "synapse-claude-8104",
+        "agent_type": "claude",
+        "port": 8104,
+        "pid": 1234,
+        "endpoint": "http://localhost:8104",
+        "status": status,
+        "working_dir": str(Path.cwd()),
+    }
+
+
+def _sender(status: str = PROCESSING) -> dict[str, object]:
+    return {
+        "agent_id": "synapse-codex-8121",
+        "agent_type": "codex",
+        "port": 8121,
+        "pid": 4321,
+        "endpoint": "http://localhost:8121",
+        "status": status,
+        "working_dir": str(Path.cwd()),
+    }
+
+
+def _mock_registry(current_status: str) -> MagicMock:
+    registry = MagicMock()
+    registry.list_agents.return_value = {
+        "synapse-claude-8104": _agent(),
+        "synapse-codex-8121": _sender(current_status),
+    }
+    registry.get_agent.return_value = _sender(current_status)
+    return registry
+
+
+def _reply_stack_responses() -> list[MagicMock]:
+    list_response = MagicMock(status_code=200)
+    list_response.json.return_value = {
+        "sender_ids": ["synapse-claude-8104"],
+        "targets": [{"sender_id": "synapse-claude-8104"}],
+    }
+    get_response = MagicMock(status_code=200)
+    get_response.json.return_value = {
+        "sender_endpoint": "http://localhost:8104",
+        "sender_task_id": "parent-task",
+        "receiver_task_id": "child-task",
+    }
+    pop_response = MagicMock(status_code=200)
+    return [list_response, get_response, pop_response]
+
+
+def test_sending_reply_constant_exists_in_status_module() -> None:
+    import synapse.status as status
+
+    assert status.SENDING_REPLY == "SENDING_REPLY"
+    assert status.SENDING_REPLY in ALL_STATUSES
+    assert status.SENDING_REPLY in STATUS_STYLES
+
+
+def test_send_toggles_status_to_sending_reply_during_post() -> None:
+    registry = _mock_registry(PROCESSING)
+    captured_statuses: list[str] = []
+
+    def send_to_local(**_kwargs: object) -> A2ATask:
+        captured_statuses.extend(
+            call.args[1] for call in registry.update_status.mock_calls
+        )
+        return A2ATask(id="task-123", status="working")
+
+    with (
+        patch("synapse.tools.a2a.AgentRegistry", return_value=registry),
+        patch("synapse.tools.a2a.is_process_running", return_value=True),
+        patch("synapse.tools.a2a.is_port_open", return_value=True),
+        patch(
+            "synapse.tools.a2a.build_sender_info",
+            return_value={"sender_id": "synapse-codex-8121"},
+        ),
+        patch("synapse.tools.a2a.A2AClient") as client_cls,
+    ):
+        client_cls.return_value.send_to_local.side_effect = send_to_local
+        cmd_send(_send_args())
+
+    assert captured_statuses == ["SENDING_REPLY"]
+    assert ("synapse-codex-8121", PROCESSING) in [
+        call.args for call in registry.update_status.call_args_list
+    ]
+
+
+def test_reply_toggles_status_to_sending_reply_during_post() -> None:
+    registry = _mock_registry(WAITING_FOR_INPUT)
+    captured_statuses: list[str] = []
+
+    def send_to_local(**_kwargs: object) -> A2ATask:
+        captured_statuses.extend(
+            call.args[1] for call in registry.update_status.mock_calls
+        )
+        return A2ATask(id="reply-task", status="completed")
+
+    local_reply_response = MagicMock(status_code=200)
+    with (
+        patch("synapse.tools.a2a.AgentRegistry", return_value=registry),
+        patch(
+            "synapse.tools.a2a.build_sender_info",
+            return_value={
+                "sender_id": "synapse-codex-8121",
+                "sender_endpoint": "http://localhost:8121",
+            },
+        ),
+        patch("synapse.tools.a2a.requests.get") as requests_get,
+        patch("synapse.tools.a2a.requests.post", return_value=local_reply_response),
+        patch("synapse.tools.a2a.clear_reply_target"),
+        patch("synapse.tools.a2a.A2AClient") as client_cls,
+    ):
+        requests_get.side_effect = _reply_stack_responses()
+        client_cls.return_value.send_to_local.side_effect = send_to_local
+        cmd_reply(_reply_args())
+
+    assert captured_statuses == ["SENDING_REPLY"]
+    assert ("synapse-codex-8121", WAITING_FOR_INPUT) in [
+        call.args for call in registry.update_status.call_args_list
+    ]
+
+
+@pytest.mark.parametrize("current_status", [DONE, SHUTTING_DOWN, RATE_LIMITED])
+def test_sending_reply_does_not_overwrite_terminal_status(current_status: str) -> None:
+    registry = _mock_registry(current_status)
+
+    with (
+        patch("synapse.tools.a2a.AgentRegistry", return_value=registry),
+        patch("synapse.tools.a2a.is_process_running", return_value=True),
+        patch("synapse.tools.a2a.is_port_open", return_value=True),
+        patch(
+            "synapse.tools.a2a.build_sender_info",
+            return_value={"sender_id": "synapse-codex-8121"},
+        ),
+        patch("synapse.tools.a2a.A2AClient") as client_cls,
+    ):
+        client_cls.return_value.send_to_local.return_value = A2ATask(
+            id="task-123", status="working"
+        )
+        cmd_send(_send_args())
+
+    assert ("synapse-codex-8121", "SENDING_REPLY") not in [
+        call.args for call in registry.update_status.call_args_list
+    ]
+
+
+def test_sending_reply_restores_status_on_http_failure() -> None:
+    registry = _mock_registry(READY)
+
+    with (
+        patch("synapse.tools.a2a.AgentRegistry", return_value=registry),
+        patch("synapse.tools.a2a.is_process_running", return_value=True),
+        patch("synapse.tools.a2a.is_port_open", return_value=True),
+        patch(
+            "synapse.tools.a2a.build_sender_info",
+            return_value={"sender_id": "synapse-codex-8121"},
+        ),
+        patch("synapse.tools.a2a.A2AClient") as client_cls,
+    ):
+        client_cls.return_value.send_to_local.return_value = None
+        with pytest.raises(SystemExit):
+            cmd_send(_send_args())
+
+    assert registry.update_status.call_args_list[-1].args == (
+        "synapse-codex-8121",
+        READY,
+    )
+
+
+def _history(tmp_path: Path) -> HistoryManager:
+    return HistoryManager(str(tmp_path / "history.db"))
+
+
+def _save_history(
+    history: HistoryManager,
+    *,
+    task_id: str,
+    metadata: dict[str, object],
+    agent_name: str = "codex",
+) -> None:
+    history.save_observation(
+        task_id=task_id,
+        agent_name=agent_name,
+        session_id="test",
+        input_text=f"input {task_id}",
+        output_text=f"output {task_id}",
+        status="completed",
+        metadata=metadata,
+    )
+
+
+def test_recent_messages_filtered_by_sender_or_recipient(tmp_path: Path) -> None:
+    history = _history(tmp_path)
+    _save_history(
+        history,
+        task_id="task-a-out",
+        metadata={"sender": {"sender_id": "synapse-codex-8121"}},
+    )
+    _save_history(
+        history,
+        task_id="task-b-internal",
+        metadata={
+            "sender": {"sender_id": "synapse-codex-8122"},
+            "target_agent_id": "synapse-codex-8123",
+        },
+    )
+
+    messages = StatusCommand(MagicMock(), history_manager=history)._get_history(
+        {"agent_id": "synapse-codex-8121", "agent_type": "codex"}
+    )
+
+    assert [message["task_id"] for message in messages] == ["task-a-out"]
+
+
+def test_recent_messages_includes_both_inbound_and_outbound_for_target(
+    tmp_path: Path,
+) -> None:
+    history = _history(tmp_path)
+    _save_history(
+        history,
+        task_id="outbound",
+        metadata={"sender": {"sender_id": "synapse-codex-8121"}},
+    )
+    _save_history(
+        history,
+        task_id="inbound",
+        metadata={
+            "sender": {"sender_id": "synapse-claude-8104"},
+            "target_agent_id": "synapse-codex-8121",
+        },
+    )
+
+    messages = StatusCommand(MagicMock(), history_manager=history)._get_history(
+        {"agent_id": "synapse-codex-8121", "agent_type": "codex"}
+    )
+
+    assert {message["task_id"] for message in messages} == {"outbound", "inbound"}
+
+
+def test_recent_messages_empty_when_no_match(tmp_path: Path) -> None:
+    history = _history(tmp_path)
+    _save_history(
+        history,
+        task_id="other",
+        metadata={
+            "sender": {"sender_id": "synapse-claude-8104"},
+            "target_agent_id": "synapse-gemini-8110",
+        },
+    )
+
+    messages = StatusCommand(MagicMock(), history_manager=history)._get_history(
+        {"agent_id": "synapse-codex-8121", "agent_type": "codex"}
+    )
+
+    assert messages == []


### PR DESCRIPTION
## Summary

- Add `SENDING_REPLY` short-lived sub-state surfaced via `synapse list` / `synapse status` while a child agent is mid-`synapse send` / `synapse reply`. `cmd_send` and `cmd_reply` toggle the registry status from READY/PROCESSING/WAITING/WAITING_FOR_INPUT to `SENDING_REPLY` for the duration of the HTTP POST and restore the original status in `finally` even on failure (so fallback paths like \`synapse send\` after a reply error stay correctly observable).
- Filter \`synapse status <agent>\` Recent Messages by the target agent's \`agent_id\` (sender or recipient) instead of the global A2A history. \`HistoryManager.list_observations()\` gains an additive \`agent_id\` parameter; existing \`agent_name\` callers stay compatible.
- Closes the focus part of #644 (sub-state surface). The watchdog / proactive parent monitoring half remains scoped to #646.

DONE / SHUTTING_DOWN / RATE_LIMITED are protected and never overwritten. \`_has_only_terminal_tasks()\` includes \`SENDING_REPLY\` in its READY-demote set since the state is short-lived by construction.

## Test plan

- [x] \`uv run pytest tests/test_sending_reply_status_644.py -q\` (8 functions / 10 parametrized cases — all green)
- [x] Adjacent suites: \`tests/test_status_sync_569.py tests/test_rate_limit_status_561.py\` — 27 passed total
- [x] \`uv run mypy synapse/\` — 114 sources clean
- [x] Manual: parent claude observed \`status=SENDING_REPLY\` mid-\`gh issue comment\` send during this PR's drafting (self-evidence)
- [ ] CI green on Python 3.10 / 3.11 / 3.12 / 3.13 / 3.14

## Notes

- post-impl-codex workflow stalled twice on this branch at the commit/PR step (same class of stall this PR is making observable). claude (parent) took over commit + push + PR creation manually. Observation logged in #644.
- Codex also surfaced the real cause behind the earlier "\`synapse reply\` 404" reports: the reply path itself succeeded; the codex sandbox then hit \`PermissionError\` while clearing \`~/.a2a/reply/<agent>.reply.json\`. Tracked as a separate bug in #644 comment for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * エージェントが A2A 送受信処理中に表示される新しい `SENDING_REPLY` ステータスを追加。処理完了後は自動的に前のステータスに戻ります。
  * `synapse status` のRecentメッセージを、選択したエージェントが関与したメッセージのみにフィルター処理するよう改善。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->