### PR TITLE
feat: surface input_required state in synapse list / status (#651)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Surface HTTP task `input_required` state in `synapse list` / `synapse status` so a parent operator sees the approve URL without an extra HTTP query (#651).
 - Surface LLM provider rate limits as `RATE_LIMITED` agent status (#561).
 - Delay sends to READY agents (#467).
 - **`/dev-issue <number>` slash command (skill):** bootstraps a new issue implementation in one step — fetches the issue and related closed PRs in parallel, greps the repo for code hotspots from the body, infers a branch prefix from labels and a slug from the title, generates a structured task brief at `/tmp/issue<num>-task.md` (mirroring the handwritten brief format used in recent issue → codex spawn flows like #467), creates a fresh branch from latest `origin/main`, and (by default) spawns a codex agent with `synapse spawn codex --task-file ... --notify`. Supports `--solo` (skip spawn) and `--dry-run` (brief only, no branch / no spawn). Canonical at `.agents/skills/dev-issue/SKILL.md`, mirrored as a symlink at `.claude/skills/dev-issue/` and as a copy at `plugins/synapse-a2a/skills/dev-issue/` for plugin distribution.

--- a/synapse/a2a_compat.py
+++ b/synapse/a2a_compat.py
@@ -397,6 +397,36 @@ _PERMISSION_CONTEXT_MIN_PRINTABLE = 10
 _WAITING_SOURCE_VALUES = frozenset({"regex", "heuristic", "none"})
 
 
+def _sync_registry_input_required_tasks(
+    *,
+    registry: Any,
+    agent_id: str | None,
+    task_store: Any,
+    port: int,
+) -> None:
+    """Mirror task_store input_required tasks into registry for `synapse list`.
+
+    Called whenever a task transitions to/from ``input_required`` so that
+    `synapse list` / `synapse status` can surface the approve URL to a
+    parent operator without having to query the agent's HTTP endpoint.
+    """
+    if registry is None or not agent_id:
+        return
+    summaries: list[dict[str, str]] = []
+    for task in task_store.list_tasks():
+        if task.status != "input_required":
+            continue
+        summaries.append(
+            {
+                "task_id": str(task.id),
+                "approve_url": (
+                    f"http://localhost:{port}/tasks/{task.id}/permission/approve"
+                ),
+            }
+        )
+    registry.update_input_required_tasks(agent_id, summaries)
+
+
 def _load_reply_artifacts(metadata: dict[str, Any]) -> list[Artifact] | None:
     """Deserialize structured reply artifacts from metadata."""
     raw_artifacts = metadata.get(_REPLY_ARTIFACTS_METADATA_KEY)
@@ -1150,6 +1180,15 @@ def create_a2a_router(
         def _sync_registry_input_wait_status(new_status: str) -> None:
             if registry is None or agent_id is None:
                 return
+            # Mirror task_store input_required tasks into the registry so
+            # `synapse list` / `synapse status` can surface the approve URL
+            # to a parent operator without an extra HTTP query (#651).
+            _sync_registry_input_required_tasks(
+                registry=registry,
+                agent_id=agent_id,
+                task_store=task_store,
+                port=port,
+            )
             if _is_permission_waiting_status(new_status):
                 registry.update_status(agent_id, WAITING)
                 return
@@ -1896,6 +1935,12 @@ def create_a2a_router(
             raise HTTPException(status_code=404, detail="Task not found")
 
         task_store.update_status(task_id, "working")
+        _sync_registry_input_required_tasks(
+            registry=registry,
+            agent_id=agent_id,
+            task_store=task_store,
+            port=port,
+        )
 
         if controller:
             approval_msg = (
@@ -1932,6 +1977,12 @@ def create_a2a_router(
 
         reason = request.reason if request else ""
         task_store.update_status(task_id, "input_required")
+        _sync_registry_input_required_tasks(
+            registry=registry,
+            agent_id=agent_id,
+            task_store=task_store,
+            port=port,
+        )
 
         if controller:
             rejection_msg = f"[A2A:PLAN_REJECTED:{task_id[:8]}] Your plan was rejected."
@@ -1983,6 +2034,12 @@ def create_a2a_router(
             ) from e
 
         task_store.update_status(task_id, "working")
+        _sync_registry_input_required_tasks(
+            registry=registry,
+            agent_id=agent_id,
+            task_store=task_store,
+            port=port,
+        )
         return {"status": label, "task_id": task_id}
 
     @router.post("/tasks/{task_id}/permission/approve")

--- a/synapse/commands/list.py
+++ b/synapse/commands/list.py
@@ -663,6 +663,7 @@ class ListCommand:
         "summary",
         "is_orphan",
         "spawned_by",
+        "input_required_tasks",
     )
 
     def _format_status(self, agent: dict[str, Any]) -> str:

--- a/synapse/commands/list.py
+++ b/synapse/commands/list.py
@@ -173,6 +173,7 @@ class ListCommand:
                 "summary": info.get("summary"),
                 "transport": registry.get_transport_display(agent_id) or "-",
                 "renderer_available": info.get("renderer_available"),
+                "input_required_tasks": info.get("input_required_tasks") or [],
             }
 
             if show_file_safety:

--- a/synapse/registry.py
+++ b/synapse/registry.py
@@ -407,6 +407,25 @@ class AgentRegistry:
 
         return self._atomic_update(agent_id, set_status, "status")
 
+    def update_input_required_tasks(
+        self, agent_id: str, tasks: list[dict[str, str]]
+    ) -> bool:
+        """Mirror the agent's input_required tasks for `synapse list` visibility.
+
+        Args:
+            agent_id: The unique agent identifier.
+            tasks: List of dicts with ``task_id`` and ``approve_url`` keys
+                (empty list clears the field).
+
+        Returns:
+            True if updated successfully, False otherwise.
+        """
+
+        def set_tasks(data: dict) -> None:
+            data["input_required_tasks"] = tasks
+
+        return self._atomic_update(agent_id, set_tasks, "input_required_tasks")
+
     def update_tty_device(self, agent_id: str, tty_device: str) -> bool:
         """Update the TTY device for an agent (for terminal jump feature).
 

--- a/tests/test_cmd_list_json.py
+++ b/tests/test_cmd_list_json.py
@@ -132,6 +132,7 @@ class TestListJson:
                 "summary": None,
                 "is_orphan": None,
                 "spawned_by": None,
+                "input_required_tasks": None,
                 "renderer_available": False,
             }
         ]
@@ -258,6 +259,7 @@ class TestListJson:
                 "summary": None,
                 "is_orphan": None,
                 "spawned_by": None,
+                "input_required_tasks": None,
                 "editing_file": "tests/test_cmd_list_json.py",
             }
         ]

--- a/tests/test_input_required_visibility_651.py
+++ b/tests/test_input_required_visibility_651.py
@@ -1,0 +1,204 @@
+"""Tests for #651 input_required task visibility in synapse list / status."""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from synapse.a2a_models import Message, TextPart
+from synapse.registry import AgentRegistry
+
+
+def _msg(text: str = "hi") -> Message:
+    return Message(role="user", parts=[TextPart(type="text", text=text)])
+
+
+@pytest.fixture
+def tmp_registry() -> AgentRegistry:
+    """Provide an AgentRegistry with an isolated temp directory."""
+    tmp = tempfile.mkdtemp(prefix="synapse-test-651-")
+    registry = AgentRegistry()
+    registry.registry_dir = Path(tmp)
+    registry.registry_dir.mkdir(parents=True, exist_ok=True)
+    registry.register("synapse-codex-8121", "codex", 8121)
+    try:
+        yield registry
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+class TestRegistryInputRequiredTasks:
+    def test_update_input_required_tasks_writes_field(
+        self, tmp_registry: AgentRegistry
+    ) -> None:
+        tasks = [
+            {
+                "task_id": "abc12345",
+                "approve_url": "http://localhost:8121/tasks/abc12345/permission/approve",
+            }
+        ]
+        assert (
+            tmp_registry.update_input_required_tasks("synapse-codex-8121", tasks)
+            is True
+        )
+        info = tmp_registry.get_agent("synapse-codex-8121")
+        assert info is not None
+        assert info.get("input_required_tasks") == tasks
+
+    def test_update_input_required_tasks_clears_with_empty_list(
+        self, tmp_registry: AgentRegistry
+    ) -> None:
+        tmp_registry.update_input_required_tasks(
+            "synapse-codex-8121",
+            [{"task_id": "x", "approve_url": "http://x"}],
+        )
+        tmp_registry.update_input_required_tasks("synapse-codex-8121", [])
+        info = tmp_registry.get_agent("synapse-codex-8121")
+        assert info is not None
+        assert info.get("input_required_tasks") == []
+
+    def test_update_input_required_tasks_unknown_agent_returns_false(
+        self, tmp_registry: AgentRegistry
+    ) -> None:
+        assert (
+            tmp_registry.update_input_required_tasks("nonexistent", [{"task_id": "x"}])
+            is False
+        )
+
+    def test_list_agents_includes_input_required_tasks(
+        self, tmp_registry: AgentRegistry
+    ) -> None:
+        tmp_registry.update_input_required_tasks(
+            "synapse-codex-8121",
+            [{"task_id": "abc", "approve_url": "http://x"}],
+        )
+        agents = tmp_registry.list_agents()
+        info = agents["synapse-codex-8121"]
+        assert info.get("input_required_tasks") == [
+            {"task_id": "abc", "approve_url": "http://x"}
+        ]
+
+
+class TestListCommandSurfacesInputRequired:
+    def test_get_agent_data_includes_input_required_tasks_field(
+        self, tmp_registry: AgentRegistry
+    ) -> None:
+        tmp_registry.update_input_required_tasks(
+            "synapse-codex-8121",
+            [
+                {
+                    "task_id": "abc12345",
+                    "approve_url": "http://localhost:8121/.../approve",
+                }
+            ],
+        )
+        from synapse.commands.list import ListCommand
+
+        list_cmd = ListCommand(
+            registry_factory=lambda: tmp_registry,
+            is_process_alive=lambda pid: True,
+            is_port_open=lambda *args, **kwargs: True,
+            clear_screen=lambda: None,
+            time_module=MagicMock(),
+            print_func=lambda s: None,
+        )
+        agents_list, _, _ = list_cmd._get_agent_data(tmp_registry)
+        assert len(agents_list) == 1
+        agent = agents_list[0]
+        assert agent.get("input_required_tasks") == [
+            {"task_id": "abc12345", "approve_url": "http://localhost:8121/.../approve"}
+        ]
+
+    def test_get_agent_data_empty_input_required_tasks_when_unset(
+        self, tmp_registry: AgentRegistry
+    ) -> None:
+        from synapse.commands.list import ListCommand
+
+        list_cmd = ListCommand(
+            registry_factory=lambda: tmp_registry,
+            is_process_alive=lambda pid: True,
+            is_port_open=lambda *args, **kwargs: True,
+            clear_screen=lambda: None,
+            time_module=MagicMock(),
+            print_func=lambda s: None,
+        )
+        agents_list, _, _ = list_cmd._get_agent_data(tmp_registry)
+        assert len(agents_list) == 1
+        assert agents_list[0].get("input_required_tasks", []) == []
+
+
+class TestSyncInputRequiredTasksHelper:
+    """Test the helper that pushes input_required state from task_store to registry."""
+
+    def test_sync_pushes_task_id_and_approve_url(
+        self, tmp_registry: AgentRegistry
+    ) -> None:
+        from synapse.a2a_compat import _sync_registry_input_required_tasks
+        from synapse.task_store import TaskStore
+
+        store = TaskStore()
+        task_a = store.create(_msg(), None)
+        store.update_status(task_a.id, "input_required")
+        task_b = store.create(_msg(), None)
+        store.update_status(task_b.id, "completed")
+
+        _sync_registry_input_required_tasks(
+            registry=tmp_registry,
+            agent_id="synapse-codex-8121",
+            task_store=store,
+            port=8121,
+        )
+        info = tmp_registry.get_agent("synapse-codex-8121")
+        assert info is not None
+        tasks = info.get("input_required_tasks") or []
+        assert len(tasks) == 1
+        assert tasks[0]["task_id"] == task_a.id
+        assert "approve" in tasks[0]["approve_url"]
+        assert str(task_a.id) in tasks[0]["approve_url"]
+
+    def test_sync_clears_when_no_input_required_tasks(
+        self, tmp_registry: AgentRegistry
+    ) -> None:
+        from synapse.a2a_compat import _sync_registry_input_required_tasks
+        from synapse.task_store import TaskStore
+
+        tmp_registry.update_input_required_tasks(
+            "synapse-codex-8121",
+            [{"task_id": "stale", "approve_url": "http://stale"}],
+        )
+        store = TaskStore()
+        store.create(_msg(), None)
+
+        _sync_registry_input_required_tasks(
+            registry=tmp_registry,
+            agent_id="synapse-codex-8121",
+            task_store=store,
+            port=8121,
+        )
+        info = tmp_registry.get_agent("synapse-codex-8121")
+        assert info is not None
+        assert info.get("input_required_tasks") == []
+
+    def test_sync_skips_when_registry_or_agent_id_missing(
+        self, tmp_registry: AgentRegistry
+    ) -> None:
+        from synapse.a2a_compat import _sync_registry_input_required_tasks
+        from synapse.task_store import TaskStore
+
+        store = TaskStore()
+        task = store.create(_msg(), None)
+        store.update_status(task.id, "input_required")
+
+        _sync_registry_input_required_tasks(
+            registry=None, agent_id="x", task_store=store, port=8121
+        )
+        _sync_registry_input_required_tasks(
+            registry=tmp_registry, agent_id=None, task_store=store, port=8121
+        )
+        info = tmp_registry.get_agent("synapse-codex-8121")
+        assert info is not None
+        assert info.get("input_required_tasks") in (None, [])

--- a/tests/test_input_required_visibility_651.py
+++ b/tests/test_input_required_visibility_651.py
@@ -130,6 +130,68 @@ class TestListCommandSurfacesInputRequired:
         assert len(agents_list) == 1
         assert agents_list[0].get("input_required_tasks", []) == []
 
+    def test_run_json_exposes_input_required_tasks(
+        self, tmp_registry: AgentRegistry
+    ) -> None:
+        """synapse list --json must include input_required_tasks for programmatic consumers."""
+        import argparse
+        import json
+
+        from synapse.commands.list import ListCommand
+
+        tmp_registry.update_input_required_tasks(
+            "synapse-codex-8121",
+            [
+                {
+                    "task_id": "abc12345",
+                    "approve_url": "http://localhost:8121/.../approve",
+                }
+            ],
+        )
+
+        captured: list[str] = []
+        list_cmd = ListCommand(
+            registry_factory=lambda: tmp_registry,
+            is_process_alive=lambda pid: True,
+            is_port_open=lambda *args, **kwargs: True,
+            clear_screen=lambda: None,
+            time_module=MagicMock(),
+            print_func=captured.append,
+        )
+
+        list_cmd.run_json(argparse.Namespace())
+
+        assert len(captured) == 1
+        payload = json.loads(captured[0])
+        assert len(payload) == 1
+        assert payload[0].get("input_required_tasks") == [
+            {"task_id": "abc12345", "approve_url": "http://localhost:8121/.../approve"}
+        ]
+
+    def test_run_json_empty_input_required_tasks_when_unset(
+        self, tmp_registry: AgentRegistry
+    ) -> None:
+        """synapse list --json should emit empty list when no input_required tasks."""
+        import argparse
+        import json
+
+        from synapse.commands.list import ListCommand
+
+        captured: list[str] = []
+        list_cmd = ListCommand(
+            registry_factory=lambda: tmp_registry,
+            is_process_alive=lambda pid: True,
+            is_port_open=lambda *args, **kwargs: True,
+            clear_screen=lambda: None,
+            time_module=MagicMock(),
+            print_func=captured.append,
+        )
+
+        list_cmd.run_json(argparse.Namespace())
+
+        payload = json.loads(captured[0])
+        assert payload[0].get("input_required_tasks", []) == []
+
 
 class TestSyncInputRequiredTasksHelper:
     """Test the helper that pushes input_required state from task_store to registry."""


### PR DESCRIPTION
## Summary

- Adds an \`input_required_tasks\` field to the registry so \`synapse list\` and \`synapse status\` (and their \`--json\` variants) can show pending permission/approval prompts with a ready-to-paste \`approve_url\`. Parent operators no longer need to query each agent's \`/tasks\` endpoint to discover that a workflow is stuck waiting for \`curl -X POST .../permission/approve\`.
- The mirror is piggy-backed on the existing \`_sync_registry_input_wait_status\` hook, so every \`task_store.update_status(..., \"input_required\")\` site plus the matching approve/deny/reject endpoints push fresh state in one place. Helper is a no-op when \`registry\` / \`agent_id\` is missing (so CLI tests with bare task_stores keep passing).
- Closes #651. The proactive parent notification half (auto-approve, watchdog) remains scoped to #646; this PR is observability only.

## Background — why this exists

Discovered during the PR #649 / PR #650 sessions: \`post-impl-codex\` workflow stalled at the \"create PR\" step because the underlying HTTP task moved to \`input_required\`, but \`synapse list\` displayed nothing actionable — the parent had to read \`tail bhxq94ktx.output\` to find the \`Approve: curl ...\` hint that the workflow runner had already emitted. With this PR, \`synapse list --json\` carries the same hint inline.

## Test plan

- [x] \`uv run pytest tests/test_input_required_visibility_651.py -q\` — 9 tests green
- [x] Adjacent suites: \`test_status_sync_569\`, \`test_rate_limit_status_561\`, \`test_a2a_compat\`, \`test_permission_api\` — 110 passed total, no regressions
- [x] \`uv run mypy synapse/\` — 114 sources clean
- [ ] CI green on Python 3.10 / 3.11 / 3.12 / 3.13 / 3.14
- [ ] Manual: spawn a codex, get it stuck on a permission prompt, verify \`synapse list --json | jq .[].input_required_tasks\` returns the expected dict

## Notes

- Implementation is by claude (parent) — codex was rate-limited at the time of this work.
- Renderer / rich UI annotation is intentionally **not** included here. \`synapse list\` text output and rich TUI continue to behave the same way; this PR is about wiring the data into the registry + \`--json\` payload first. A follow-up can decorate the TUI once the data shape stabilises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * `synapse list` と `synapse status` が承認待ち（input_required）タスクの approve URL を表示するようになりました。追加のHTTP問い合わせなしで親オペレータが承認リンクを確認できます。

* **テスト**
  * input_required タスクの表示・同期挙動を検証する包括的なエンドツーエンドテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->