### PR TITLE
fix: tolerate PermissionError/OSError in clear_reply_target() (#653)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `clear_reply_target()` now swallows cleanup `PermissionError`/`OSError` failures so sandbox unlink errors no longer mask successful reply sends (#653).
+
 ## [0.30.0] - 2026-04-27
 
 Minor release adding a true PTY-level cancellation path for stuck agents while preserving the existing SIGINT broadcast behavior for signal-mode callers. The cancel API can now choose `mode=pty`, `mode=signal`, or profile-driven `mode=auto`, with per-profile defaults for Claude, Codex, Gemini, Copilot, and OpenCode. This release also surfaces the `RATE_LIMITED` agent status (#561), the READY-send delay, the `/dev-issue` skill, the workflow target-resolution fix, and synchronized API/site documentation.

--- a/synapse/reply_target.py
+++ b/synapse/reply_target.py
@@ -76,5 +76,8 @@ def load_reply_target(agent_id: str) -> SenderInfo | None:
 
 def clear_reply_target(agent_id: str) -> None:
     """Delete persisted reply target sender information for an agent."""
-    reply_file = _get_reply_target_path(agent_id)
-    reply_file.unlink(missing_ok=True)
+    try:
+        reply_file = _get_reply_target_path(agent_id)
+        reply_file.unlink(missing_ok=True)
+    except (OSError, ValueError) as e:
+        logger.warning("Failed to clear reply target for %s: %s", agent_id, e)

--- a/tests/test_reply_persistence.py
+++ b/tests/test_reply_persistence.py
@@ -1,5 +1,6 @@
 """Tests for file-based reply target persistence."""
 
+import logging
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -44,6 +45,46 @@ def test_clear(tmp_path, monkeypatch) -> None:
     clear_reply_target(agent_id)
 
     assert not reply_file.exists()
+
+
+def test_clear_swallows_permission_error(tmp_path, monkeypatch, caplog) -> None:
+    """clear_reply_target should log and suppress PermissionError."""
+    monkeypatch.setenv("SYNAPSE_REPLY_TARGET_DIR", str(tmp_path))
+    caplog.set_level(logging.WARNING, logger="synapse.reply_target")
+
+    def raise_permission_error(self: Path, missing_ok: bool = False) -> None:
+        raise PermissionError("denied")
+
+    monkeypatch.setattr(Path, "unlink", raise_permission_error)
+
+    clear_reply_target("synapse-codex-8122")
+
+    assert "Failed to clear reply target" in caplog.text
+
+
+def test_clear_swallows_oserror(tmp_path, monkeypatch, caplog) -> None:
+    """clear_reply_target should log and suppress generic OSError."""
+    monkeypatch.setenv("SYNAPSE_REPLY_TARGET_DIR", str(tmp_path))
+    caplog.set_level(logging.WARNING, logger="synapse.reply_target")
+
+    def raise_oserror(self: Path, missing_ok: bool = False) -> None:
+        raise OSError(30, "Read-only file system")
+
+    monkeypatch.setattr(Path, "unlink", raise_oserror)
+
+    clear_reply_target("synapse-codex-8122")
+
+    assert "Failed to clear reply target" in caplog.text
+
+
+def test_clear_swallows_invalid_agent_id(tmp_path, monkeypatch, caplog) -> None:
+    """clear_reply_target should log and suppress invalid agent IDs."""
+    monkeypatch.setenv("SYNAPSE_REPLY_TARGET_DIR", str(tmp_path))
+    caplog.set_level(logging.WARNING, logger="synapse.reply_target")
+
+    clear_reply_target("../etc/passwd")
+
+    assert "Failed to clear reply target" in caplog.text
 
 
 def test_load_missing(tmp_path, monkeypatch) -> None:

--- a/tests/test_reply_persistence.py
+++ b/tests/test_reply_persistence.py
@@ -50,6 +50,7 @@ def test_clear(tmp_path, monkeypatch) -> None:
 def test_clear_swallows_permission_error(tmp_path, monkeypatch, caplog) -> None:
     """clear_reply_target should log and suppress PermissionError."""
     monkeypatch.setenv("SYNAPSE_REPLY_TARGET_DIR", str(tmp_path))
+    monkeypatch.setattr(logging.getLogger("synapse"), "propagate", True)
     caplog.set_level(logging.WARNING, logger="synapse.reply_target")
 
     def raise_permission_error(self: Path, missing_ok: bool = False) -> None:
@@ -65,6 +66,7 @@ def test_clear_swallows_permission_error(tmp_path, monkeypatch, caplog) -> None:
 def test_clear_swallows_oserror(tmp_path, monkeypatch, caplog) -> None:
     """clear_reply_target should log and suppress generic OSError."""
     monkeypatch.setenv("SYNAPSE_REPLY_TARGET_DIR", str(tmp_path))
+    monkeypatch.setattr(logging.getLogger("synapse"), "propagate", True)
     caplog.set_level(logging.WARNING, logger="synapse.reply_target")
 
     def raise_oserror(self: Path, missing_ok: bool = False) -> None:
@@ -80,6 +82,7 @@ def test_clear_swallows_oserror(tmp_path, monkeypatch, caplog) -> None:
 def test_clear_swallows_invalid_agent_id(tmp_path, monkeypatch, caplog) -> None:
     """clear_reply_target should log and suppress invalid agent IDs."""
     monkeypatch.setenv("SYNAPSE_REPLY_TARGET_DIR", str(tmp_path))
+    monkeypatch.setattr(logging.getLogger("synapse"), "propagate", True)
     caplog.set_level(logging.WARNING, logger="synapse.reply_target")
 
     clear_reply_target("../etc/passwd")


### PR DESCRIPTION
## Summary

- `clear_reply_target()` now swallows `PermissionError` / `OSError` (and `ValueError` from invalid agent_id paths), mirroring the existing defensive pattern in `load_reply_target()`
- Sandbox unlink failures no longer mask successful reply sends — the HTTP POST already delivered the reply by the time cleanup runs, so making cleanup best-effort eliminates the false-failure exit code
- Adds 3 focused tests (PermissionError / OSError / invalid agent_id) using `caplog` to verify warning logs and exception non-propagation
- Resolves #653

## Background

Observed during PR #650 (#644 SENDING_REPLY) implementation. Codex's `synapse reply` HTTP POST returned 200 (delivery succeeded), but the post-send cleanup at `synapse/tools/a2a.py:795` raised `PermissionError` from `unlink()`, causing a non-zero exit. The parent (Claude) interpreted this as failure and fell back to `synapse send`, resulting in duplicate notifications. This bug also reproduced in real time during the implementation of this very fix — codex hit it on its plan-reply send.

The asymmetry that masked this for so long: `load_reply_target()` already wrapped `OSError` defensively, but `clear_reply_target()` did not. Read tolerated errors; cleanup did not.

## Why best-effort cleanup is safe

Stale `<agent_id>.reply.json` files are reaped on the next `load_reply_target()` call via the existing 30-minute TTL check (`saved_at` field). There is no correctness invariant that requires immediate cleanup on the success path — the file is just a fallback target cache.

## Test plan

- [x] `uv run pytest tests/test_reply_persistence.py -q` — 10 passed (7 existing + 3 new)
- [x] `uv run mypy synapse/` — Success: no issues found in 114 source files
- [x] Pre-commit hooks (ruff, ruff format, mypy) all pass
- [x] CHANGELOG `[Unreleased]` `### Fixed` entry added

## Out of scope

- Investigation of *why* the sandbox triggered `PermissionError` (sandbox config / file ownership) — this PR makes the parent path tolerant; root-cause sandbox investigation is its own concern
- Reply-target TTL or schema changes
- Parent-side resilience to non-zero `synapse reply` exits (separate UX discussion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * リプライ送信後のクリーンアップエラーが適切に処理されるようになり、ファイルシステムエラーがリプライ送信の成功を妨げなくなりました。エラーはログに記録されます。

* **テスト**
  * クリーンアップエラー処理の新しいテストカバレッジを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->