### PR TITLE
feat: synapse watchdog check for one-shot stuck-agent detection (#646)

### DIFF
--- a/.agents/skills/synapse-a2a/SKILL.md
+++ b/.agents/skills/synapse-a2a/SKILL.md
@@ -43,6 +43,7 @@ Inter-agent communication framework via Google A2A Protocol.
 |------|---------|
 | List agents | `synapse list` for humans (auto-refresh, interactive: arrows/1-9 select, Enter jump, k kill, / filter). For AI/scripts use `synapse list --json`, `synapse list --plain`, or MCP `list_agents` |
 | Agent detail | `synapse status <target> [--json]` |
+| Stuck-agent watchdog (Stage 1) | `synapse watchdog check [--alarm-only] [--json]` (one-shot heuristic scan; #646) |
 | Send message | `synapse send <target> "<msg>"` (default: `--notify`; `--from` auto-detected) |
 | Broadcast | `synapse broadcast "<msg>"` |
 | Wait for reply | `synapse send <target> "<msg>" --wait` |

--- a/.agents/skills/synapse-a2a/references/commands.md
+++ b/.agents/skills/synapse-a2a/references/commands.md
@@ -338,6 +338,66 @@ synapse waiting-debug report --out /tmp/report.json    # write JSON to file (std
 
 **Schedule it** — there is no `synapse schedule` CLI for this. Use cron or launchd at a 5-minute cadence. See `docs/phase15-collection.md` for the canonical cron line and launchd plist.
 
+### Watchdog Stuck-Agent Check (`synapse watchdog check`)
+
+Stage 1 MVP (#646) one-shot CLI that scans every live agent and surfaces stuck-state suspicions via a heuristic table. Programmatic use cases (scripts, CI, monitors) should pass `--json`. Stage 2 (background daemon + A2A push notifications), Stage 3 (`synapse list --watch` integration), and Stage 4 (auto-recovery) are tracked for future PRs.
+
+```bash
+# Default: table of all live agents
+synapse watchdog check
+
+# Filter: only agents with an active alarm
+synapse watchdog check --alarm-only
+
+# JSON array (one object per agent) — for scripts / monitors
+synapse watchdog check --json
+synapse watchdog check --alarm-only --json
+```
+
+**Output columns** (table mode):
+
+- **ID**: Agent ID
+- **STATUS**: Current registry status (e.g., `READY`, `PROCESSING`, `RATE_LIMITED`, `SENDING_REPLY`)
+- **UPTIME**: Time since `registered_at`
+- **SAME_STATUS_FOR**: Time since the last `status` transition (`last_status_change_at`); `-` for legacy entries that predate the field
+- **LAST_OUTBOUND**: Time since the most recent outbound A2A observation for this agent, or `(none)`
+- **ALARM**: `⚠ <reason>` when a heuristic fires, otherwise `-`
+
+**Heuristics (priority order — first match wins):**
+
+| # | Condition | Alarm |
+|---|-----------|-------|
+| 1 | `RATE_LIMITED` for more than 30 min | `Rate-limited > 30m` |
+| 2 | `SENDING_REPLY` for more than 60 sec | `Send stuck > 60s` |
+| 3 | `PROCESSING` for more than 30 min AND no outbound A2A in the last 10 min | `Stuck-on-reply suspected` |
+| 4 | Spawn never reached READY (`registered_at` 60s–5m ago, status ≠ `READY`, `last_status_change_at` missing) | `Spawn never ready` |
+
+The 5-minute upper bound on heuristic 4 prevents misclassifying long-lived legacy agents that may not have populated `last_status_change_at`. Heuristics 1–3 require `last_status_change_at`, so they are silently skipped on pre-`last_status_change_at` registry entries; heuristic 4 only needs `registered_at` (which has always existed) and remains effective on legacy entries.
+
+**JSON schema** (`--json`): a top-level array; each element is one agent's `WatchdogReport`:
+
+```json
+[
+  {
+    "agent_id": "synapse-claude-8100",
+    "status": "PROCESSING",
+    "uptime_seconds": 4321.5,
+    "same_status_seconds": 2105.0,
+    "last_outbound_seconds_ago": 870.2,
+    "alarm": "Stuck-on-reply suspected"
+  }
+]
+```
+
+- `uptime_seconds`, `same_status_seconds`, `last_outbound_seconds_ago` are nullable floats (`null` when the underlying field is missing — e.g., `last_outbound_seconds_ago` is `null` when the agent has not produced an outbound observation).
+- `alarm` is `null` when no heuristic fires; otherwise it is the same short string used in the table's `ALARM` column.
+- `--alarm-only` and `--json` compose: passing both yields a JSON array containing only the agents whose `alarm` is non-null.
+
+**Use cases:**
+- Quickly scanning every live agent for a known stuck pattern without inspecting them one-by-one with `synapse status`.
+- Wiring stuck-agent detection into shell scripts, CI safety nets, or external monitors via `--json --alarm-only`.
+- Debugging spawn-never-ready regressions (heuristic 4) on freshly spawned agents.
+
 ### Saved Agent Definitions
 
 Manage reusable agent definitions that persist across sessions. Saved agents are stored as `.agent` files in project (`.synapse/agents/`) or user (`~/.synapse/agents/`) scope.

--- a/.agents/skills/synapse-manager/references/commands-quick-ref.md
+++ b/.agents/skills/synapse-manager/references/commands-quick-ref.md
@@ -3,6 +3,7 @@
 | Command | Purpose |
 |---------|---------|
 | `synapse list` | Check agent status (auto-updates; `--json` for JSON array) |
+| `synapse watchdog check [--alarm-only] [--json]` | Stage 1 stuck-agent heuristic scan (#646) |
 | `synapse spawn <type\|id> --name <n> --role "<r>"` | Start agent (ad-hoc or from saved definition) |
 | `synapse send <name> "<msg>" --silent` | Delegate task (fire-and-forget) |
 | `synapse send <name> "<msg>" --wait` | Request reply (blocking) |

--- a/.claude/skills/synapse-a2a/SKILL.md
+++ b/.claude/skills/synapse-a2a/SKILL.md
@@ -43,6 +43,7 @@ Inter-agent communication framework via Google A2A Protocol.
 |------|---------|
 | List agents | `synapse list` for humans (auto-refresh, interactive: arrows/1-9 select, Enter jump, k kill, / filter). For AI/scripts use `synapse list --json`, `synapse list --plain`, or MCP `list_agents` |
 | Agent detail | `synapse status <target> [--json]` |
+| Stuck-agent watchdog (Stage 1) | `synapse watchdog check [--alarm-only] [--json]` (one-shot heuristic scan; #646) |
 | Send message | `synapse send <target> "<msg>"` (default: `--notify`; `--from` auto-detected) |
 | Broadcast | `synapse broadcast "<msg>"` |
 | Wait for reply | `synapse send <target> "<msg>" --wait` |

--- a/.claude/skills/synapse-a2a/references/commands.md
+++ b/.claude/skills/synapse-a2a/references/commands.md
@@ -338,6 +338,66 @@ synapse waiting-debug report --out /tmp/report.json    # write JSON to file (std
 
 **Schedule it** — there is no `synapse schedule` CLI for this. Use cron or launchd at a 5-minute cadence. See `docs/phase15-collection.md` for the canonical cron line and launchd plist.
 
+### Watchdog Stuck-Agent Check (`synapse watchdog check`)
+
+Stage 1 MVP (#646) one-shot CLI that scans every live agent and surfaces stuck-state suspicions via a heuristic table. Programmatic use cases (scripts, CI, monitors) should pass `--json`. Stage 2 (background daemon + A2A push notifications), Stage 3 (`synapse list --watch` integration), and Stage 4 (auto-recovery) are tracked for future PRs.
+
+```bash
+# Default: table of all live agents
+synapse watchdog check
+
+# Filter: only agents with an active alarm
+synapse watchdog check --alarm-only
+
+# JSON array (one object per agent) — for scripts / monitors
+synapse watchdog check --json
+synapse watchdog check --alarm-only --json
+```
+
+**Output columns** (table mode):
+
+- **ID**: Agent ID
+- **STATUS**: Current registry status (e.g., `READY`, `PROCESSING`, `RATE_LIMITED`, `SENDING_REPLY`)
+- **UPTIME**: Time since `registered_at`
+- **SAME_STATUS_FOR**: Time since the last `status` transition (`last_status_change_at`); `-` for legacy entries that predate the field
+- **LAST_OUTBOUND**: Time since the most recent outbound A2A observation for this agent, or `(none)`
+- **ALARM**: `⚠ <reason>` when a heuristic fires, otherwise `-`
+
+**Heuristics (priority order — first match wins):**
+
+| # | Condition | Alarm |
+|---|-----------|-------|
+| 1 | `RATE_LIMITED` for more than 30 min | `Rate-limited > 30m` |
+| 2 | `SENDING_REPLY` for more than 60 sec | `Send stuck > 60s` |
+| 3 | `PROCESSING` for more than 30 min AND no outbound A2A in the last 10 min | `Stuck-on-reply suspected` |
+| 4 | Spawn never reached READY (`registered_at` 60s–5m ago, status ≠ `READY`, `last_status_change_at` missing) | `Spawn never ready` |
+
+The 5-minute upper bound on heuristic 4 prevents misclassifying long-lived legacy agents that may not have populated `last_status_change_at`. Heuristics 1–3 require `last_status_change_at`, so they are silently skipped on pre-`last_status_change_at` registry entries; heuristic 4 only needs `registered_at` (which has always existed) and remains effective on legacy entries.
+
+**JSON schema** (`--json`): a top-level array; each element is one agent's `WatchdogReport`:
+
+```json
+[
+  {
+    "agent_id": "synapse-claude-8100",
+    "status": "PROCESSING",
+    "uptime_seconds": 4321.5,
+    "same_status_seconds": 2105.0,
+    "last_outbound_seconds_ago": 870.2,
+    "alarm": "Stuck-on-reply suspected"
+  }
+]
+```
+
+- `uptime_seconds`, `same_status_seconds`, `last_outbound_seconds_ago` are nullable floats (`null` when the underlying field is missing — e.g., `last_outbound_seconds_ago` is `null` when the agent has not produced an outbound observation).
+- `alarm` is `null` when no heuristic fires; otherwise it is the same short string used in the table's `ALARM` column.
+- `--alarm-only` and `--json` compose: passing both yields a JSON array containing only the agents whose `alarm` is non-null.
+
+**Use cases:**
+- Quickly scanning every live agent for a known stuck pattern without inspecting them one-by-one with `synapse status`.
+- Wiring stuck-agent detection into shell scripts, CI safety nets, or external monitors via `--json --alarm-only`.
+- Debugging spawn-never-ready regressions (heuristic 4) on freshly spawned agents.
+
 ### Saved Agent Definitions
 
 Manage reusable agent definitions that persist across sessions. Saved agents are stored as `.agent` files in project (`.synapse/agents/`) or user (`~/.synapse/agents/`) scope.

--- a/.claude/skills/synapse-manager/references/commands-quick-ref.md
+++ b/.claude/skills/synapse-manager/references/commands-quick-ref.md
@@ -3,6 +3,7 @@
 | Command | Purpose |
 |---------|---------|
 | `synapse list` | Check agent status (auto-updates; `--json` for JSON array) |
+| `synapse watchdog check [--alarm-only] [--json]` | Stage 1 stuck-agent heuristic scan (#646) |
 | `synapse spawn <type\|id> --name <n> --role "<r>"` | Start agent (ad-hoc or from saved definition) |
 | `synapse send <name> "<msg>" --silent` | Delegate task (fire-and-forget) |
 | `synapse send <name> "<msg>" --wait` | Request reply (blocking) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `synapse watchdog check` command for one-shot stuck-agent detection (#646).
+
 ### Fixed
 
 - `clear_reply_target()` now swallows cleanup `PermissionError`/`OSError` failures so sandbox unlink errors no longer mask successful reply sends (#653).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,32 @@
 2. **Default base branch is `main`** for all PRs
 3. Do NOT change branches during active work without user confirmation (worktree agents are exempt)
 
+## Dogfooding policy — file an issue when synapse misbehaves
+
+This repo IS the synapse-a2a tool itself. We use it daily to develop it, so
+every odd / clunky / surprising behavior observed during real use is signal,
+not noise. **File a GitHub issue immediately** when you observe any of:
+
+- A `synapse` command exits non-zero despite the underlying operation
+  succeeding (e.g. delivery succeeded, cleanup failed)
+- An agent appears stuck (PROCESSING / WAITING / SENDING_REPLY) for longer
+  than its operation should take, with no clear cause from `synapse status`
+- Output is misleading or hard to interpret (status string, table column,
+  log line, error message)
+- A workflow / skill / slash command produces unexpected results, retries
+  needlessly, or leaves orphan state behind
+- Documentation describes behavior that no longer matches the code
+- Defaults that surprised you (timeout values, retry counts, fallback paths)
+
+When in doubt, **err on filing**. A duplicate or "wontfix" issue is cheap;
+a forgotten observation that would have improved the tool is expensive.
+The goal is a continuous improvement loop driven by lived usage.
+
+Use `gh issue create --label <bug|enhancement>` with a body that includes:
+the exact reproduction (commands run, expected vs. actual), what you were
+trying to do, and any session context that made the issue visible (e.g.
+"observed during PR #X work, codex agent on port Y").
+
 ## Commands
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -820,6 +820,7 @@ Save this agent definition for reuse? [y/N]:
 | `synapse file-safety debug` | Show debug info |
 | `synapse waiting-debug collect` | Append `/debug/waiting` snapshots from every running agent to `~/.synapse/waiting_debug.jsonl` (Phase 1.5 collection pipeline). `--out <path>` overrides the destination, `--agent <id>` filters to one agent, `--include-empty` records empty attempts, `--timeout <seconds>` sets the per-agent HTTP timeout (default 5.0, v0.28.2). See [`docs/phase15-collection.md`](docs/phase15-collection.md) |
 | `synapse waiting-debug report` | Summarise a `waiting_debug.jsonl` file: per-profile / `pattern_source` / `path_used` counts, confidence distribution, `idle_gate_drops`, `renderer_unavailable_agents`. Accepts `--since <iso>`, `--agent <id>`, `--json`, `--out <path>` (write JSON to file; stdout stays empty, safe for cron) |
+| `synapse watchdog check` | One-shot stuck-agent detection across all live agents (Stage 1 MVP, [#646](https://github.com/s-hiraoku/synapse-a2a/issues/646)). Prints a table with ID / STATUS / UPTIME / SAME_STATUS_FOR / LAST_OUTBOUND / ALARM. Heuristics: `RATE_LIMITED > 30m`, `SENDING_REPLY > 60s`, `PROCESSING > 30m` with no outbound A2A in the last 10m, and "spawn never ready" (registered > 60s ago, < 5m, status != READY). `--alarm-only` filters to alarm rows; `--json` emits an array of reports for programmatic consumers. Stage 2-4 (background daemon, push notifications, multi-watchdog locking, automatic recovery) are future work |
 | `synapse skills` | Skill Manager (interactive TUI) |
 | `synapse skills list` | List discovered skills |
 | `synapse skills show <name>` | Show skill details |
@@ -1682,6 +1683,25 @@ For Copilot specifically, bracketed paste is enabled because Copilot CLI 1.0.12+
 | **DONE** | Blue | Task completed (auto-transitions to READY after 10s) |
 
 The registry status is reconciled against `task_store` on every controller transition: WAITING (permission) wins over WAITING_FOR_INPUT, and a fully terminal `task_store` demotes a stale PROCESSING / WAITING_FOR_INPUT back to READY ([#569](https://github.com/s-hiraoku/synapse-a2a/pull/569)).
+
+### Stuck-Agent Watchdog
+
+`synapse watchdog check` is a one-shot, read-only command that scans every live agent in the registry and surfaces stuck-state suspicions in a table (Stage 1 MVP, [#646](https://github.com/s-hiraoku/synapse-a2a/issues/646)). It complements the status colours above: where `synapse list` shows the current state, the watchdog flags states that have lasted longer than expected.
+
+```bash
+synapse watchdog check               # table output
+synapse watchdog check --alarm-only  # only rows that tripped a heuristic
+synapse watchdog check --json        # JSON array for programmatic consumers
+```
+
+Heuristics (priority order):
+
+1. `RATE_LIMITED` for more than 30 minutes
+2. `SENDING_REPLY` for more than 60 seconds
+3. `PROCESSING` for more than 30 minutes with no outbound A2A send/reply in the last 10 minutes
+4. Spawn never ready: registered more than 60s ago (and within 5 minutes), status still not READY
+
+Each row reports `ID`, `STATUS`, `UPTIME`, `SAME_STATUS_FOR`, `LAST_OUTBOUND`, and `ALARM`. The `same_status_seconds` field is computed from `last_status_change_at`, which is written only on real registry status transitions; legacy registry entries that pre-date the field skip duration-based heuristics gracefully. Stage 2-4 (background daemon, A2A push notifications, multi-watchdog locking, `synapse list --watch` integration, automatic recovery) are future work.
 
 ### Interactive Controls
 

--- a/guides/references.md
+++ b/guides/references.md
@@ -52,6 +52,7 @@ flowchart TB
         auth["auth"]
         canvas["canvas"]
         multiagent["multiagent (map)"]
+        watchdog["watchdog"]
     end
 
     subgraph Memory["memory サブコマンド"]
@@ -2072,6 +2073,44 @@ synapse waiting-debug report
 - `report` は集計のみで副作用はありません。`idle_gate_drops` は「regex にマッチしたが idle gate を通らなかった」件数、`renderer_unavailable_agents` は `snapshot.renderer_available == false` だったエージェントの数です。`--out` を指定すると stdout には何も出力せず、指定ファイルに JSON 集計を書き出します（cron / scripting 向け）。`--out` と `--json` を同時に指定した場合は `--out` 優先（stdout は空）です。
 - `collected_at` が ISO-8601 としてパースできないレコードは、サイレント drop せず stderr に `Warning: record at line N has unparseable collected_at: 'value' (reason)` を 1 件出した上でその行をスキップします（v0.28.2）。JSONL が cron 出力と混ざった場合の早期検出に使えます。
 - cron / launchd で定期的に collect を回すための運用手順（ProgramArguments の絶対パス、PATH 継承問題、バージョン bump の必要性、`--timeout` / `--out` の使い分け）は [`docs/phase15-collection.md`](../docs/phase15-collection.md) を参照。
+
+---
+
+### 1.27 synapse watchdog
+
+スタックしたエージェントを heuristic で検知する one-shot コマンド (Stage 1 MVP, [#646](https://github.com/s-hiraoku/synapse-a2a/issues/646))。`synapse list` が「現在の STATUS」を表示するのに対し、`synapse watchdog check` は「その STATUS が想定より長く続いていないか」を判定して可視化します。
+
+```bash
+synapse watchdog check               # 全 live エージェントを table 形式でチェック（デフォルト）
+synapse watchdog check --alarm-only  # alarm が立った行だけ表示
+synapse watchdog check --json        # 各 report を JSON 配列で出力（programmatic consumer 向け）
+```
+
+**ヒューリスティック（優先順位順）**:
+
+| # | 条件 | アラーム文言 |
+|---|------|--------------|
+| 1 | `RATE_LIMITED` が 30 分超 | `Rate-limited > 30m` |
+| 2 | `SENDING_REPLY` が 60 秒超 | `Send stuck > 60s` |
+| 3 | `PROCESSING` が 30 分超で、直近 10 分の outbound A2A 送信が 0 件 | `Stuck-on-reply suspected` |
+| 4 | spawn から 60 秒〜5 分経過しても READY にならない | `Spawn never ready` |
+
+**出力カラム**:
+
+| 列 | 説明 |
+|----|------|
+| ID | エージェントID |
+| STATUS | 現在のステータス（`READY`, `PROCESSING`, `RATE_LIMITED`, `SENDING_REPLY` など） |
+| UPTIME | `registered_at` からの経過時間 |
+| SAME_STATUS_FOR | `last_status_change_at` からの経過時間（同じ STATUS が継続している時間） |
+| LAST_OUTBOUND | 直近の outbound A2A 送信からの経過時間（`(none)` は履歴なし） |
+| ALARM | ヒューリスティックに該当した場合のメッセージ（該当なしは `-`） |
+
+**JSON 出力**: 各 report は `agent_id` / `status` / `uptime_seconds` / `same_status_seconds` / `last_outbound_seconds_ago` / `alarm` を持つオブジェクト配列です。`alarm` は該当ヒューリスティックなしの場合 `null`。
+
+**後方互換**: `last_status_change_at` フィールドは本機能で導入されたもので、レジストリの実ステータス遷移時のみ書き込まれます（no-op rewrite では既存値を保持）。古いレジストリエントリ（フィールドが欠落）に対する duration ベースのヒューリスティックは silent に skip されます（false positive 防止）。
+
+**Stage 2-4（future work）**: バックグラウンドデーモン、A2A push 通知、通知の cooldown、マルチ watchdog のロック、`synapse list --watch` 統合、自動 recovery は本 PR の scope 外で、それぞれ別 PR として段階的に追加予定です。
 
 ---
 

--- a/guides/troubleshooting.md
+++ b/guides/troubleshooting.md
@@ -436,12 +436,17 @@ flowchart TB
 synapse status <agent-name>
 synapse status <agent-name> --json
 
+# 全 live エージェントをまとめてスタック判定（Stage 1 MVP, #646）
+synapse watchdog check --alarm-only
+
 # CLI を直接起動してプロンプトを確認
 claude
 
 # 表示されるプロンプト
 # > _
 ```
+
+`synapse watchdog check` は `PROCESSING` が 30 分以上続き、直近 10 分の outbound A2A 送信が 0 件のエージェントを `Stuck-on-reply suspected` としてフラグ立てします。`--json` で programmatic に取り出せるので、cron / launchd 経由の定期チェックにも使えます。詳細は [references.md §1.27](references.md)。
 
 **対処法**:
 

--- a/guides/usage.md
+++ b/guides/usage.md
@@ -374,6 +374,7 @@ flowchart TB
 | `synapse reset` | 設定をデフォルトに戻す（`--force` で確認スキップ） |
 | `synapse --version` | バージョン情報表示 |
 | `synapse list` | 実行中エージェント一覧 |
+| `synapse watchdog check` | スタックエージェントを heuristic で検知（Stage 1 MVP, [#646](https://github.com/s-hiraoku/synapse-a2a/issues/646)）。`--alarm-only` で alarm 行のみ filter、`--json` で programmatic 出力 |
 | `synapse send` | メッセージ送信 |
 | `synapse interrupt` | ソフト割り込み送信 |
 | `synapse broadcast` | カレントディレクトリの全エージェントにメッセージ送信 |
@@ -1789,6 +1790,11 @@ done
 別のエージェントを監視し、必要に応じて介入する。
 
 ```bash
+# 全 live エージェントをまとめてヒューリスティック判定（Stage 1 MVP, #646）
+synapse watchdog check                # table 出力
+synapse watchdog check --alarm-only   # alarm 行のみ
+synapse watchdog check --json         # JSON 配列（programmatic consumer 向け）
+
 # ステータス確認
 curl http://localhost:8120/status
 
@@ -1798,6 +1804,8 @@ synapse send codex "進捗を報告して" --priority 1
 # 応答がない場合は緊急介入
 synapse send codex "状況を報告して" --priority 5
 ```
+
+`synapse watchdog check` は `RATE_LIMITED > 30m` / `SENDING_REPLY > 60s` / `PROCESSING > 30m` で直近 10 分の outbound A2A 0 件 / spawn から 60s〜5m 経過しても READY 未到達、の 4 ヒューリスティックで stuck を判定します。詳細は [references.md §1.27](references.md)。Stage 2-4（バックグラウンドデーモン、push 通知、自動 recovery）は future work です。
 
 ---
 

--- a/plugins/synapse-a2a/skills/synapse-a2a/SKILL.md
+++ b/plugins/synapse-a2a/skills/synapse-a2a/SKILL.md
@@ -43,6 +43,7 @@ Inter-agent communication framework via Google A2A Protocol.
 |------|---------|
 | List agents | `synapse list` for humans (auto-refresh, interactive: arrows/1-9 select, Enter jump, k kill, / filter). For AI/scripts use `synapse list --json`, `synapse list --plain`, or MCP `list_agents` |
 | Agent detail | `synapse status <target> [--json]` |
+| Stuck-agent watchdog (Stage 1) | `synapse watchdog check [--alarm-only] [--json]` (one-shot heuristic scan; #646) |
 | Send message | `synapse send <target> "<msg>"` (default: `--notify`; `--from` auto-detected) |
 | Broadcast | `synapse broadcast "<msg>"` |
 | Wait for reply | `synapse send <target> "<msg>" --wait` |

--- a/plugins/synapse-a2a/skills/synapse-a2a/references/commands.md
+++ b/plugins/synapse-a2a/skills/synapse-a2a/references/commands.md
@@ -338,6 +338,66 @@ synapse waiting-debug report --out /tmp/report.json    # write JSON to file (std
 
 **Schedule it** — there is no `synapse schedule` CLI for this. Use cron or launchd at a 5-minute cadence. See `docs/phase15-collection.md` for the canonical cron line and launchd plist.
 
+### Watchdog Stuck-Agent Check (`synapse watchdog check`)
+
+Stage 1 MVP (#646) one-shot CLI that scans every live agent and surfaces stuck-state suspicions via a heuristic table. Programmatic use cases (scripts, CI, monitors) should pass `--json`. Stage 2 (background daemon + A2A push notifications), Stage 3 (`synapse list --watch` integration), and Stage 4 (auto-recovery) are tracked for future PRs.
+
+```bash
+# Default: table of all live agents
+synapse watchdog check
+
+# Filter: only agents with an active alarm
+synapse watchdog check --alarm-only
+
+# JSON array (one object per agent) — for scripts / monitors
+synapse watchdog check --json
+synapse watchdog check --alarm-only --json
+```
+
+**Output columns** (table mode):
+
+- **ID**: Agent ID
+- **STATUS**: Current registry status (e.g., `READY`, `PROCESSING`, `RATE_LIMITED`, `SENDING_REPLY`)
+- **UPTIME**: Time since `registered_at`
+- **SAME_STATUS_FOR**: Time since the last `status` transition (`last_status_change_at`); `-` for legacy entries that predate the field
+- **LAST_OUTBOUND**: Time since the most recent outbound A2A observation for this agent, or `(none)`
+- **ALARM**: `⚠ <reason>` when a heuristic fires, otherwise `-`
+
+**Heuristics (priority order — first match wins):**
+
+| # | Condition | Alarm |
+|---|-----------|-------|
+| 1 | `RATE_LIMITED` for more than 30 min | `Rate-limited > 30m` |
+| 2 | `SENDING_REPLY` for more than 60 sec | `Send stuck > 60s` |
+| 3 | `PROCESSING` for more than 30 min AND no outbound A2A in the last 10 min | `Stuck-on-reply suspected` |
+| 4 | Spawn never reached READY (`registered_at` 60s–5m ago, status ≠ `READY`, `last_status_change_at` missing) | `Spawn never ready` |
+
+The 5-minute upper bound on heuristic 4 prevents misclassifying long-lived legacy agents that may not have populated `last_status_change_at`. Heuristics 1–3 require `last_status_change_at`, so they are silently skipped on pre-`last_status_change_at` registry entries; heuristic 4 only needs `registered_at` (which has always existed) and remains effective on legacy entries.
+
+**JSON schema** (`--json`): a top-level array; each element is one agent's `WatchdogReport`:
+
+```json
+[
+  {
+    "agent_id": "synapse-claude-8100",
+    "status": "PROCESSING",
+    "uptime_seconds": 4321.5,
+    "same_status_seconds": 2105.0,
+    "last_outbound_seconds_ago": 870.2,
+    "alarm": "Stuck-on-reply suspected"
+  }
+]
+```
+
+- `uptime_seconds`, `same_status_seconds`, `last_outbound_seconds_ago` are nullable floats (`null` when the underlying field is missing — e.g., `last_outbound_seconds_ago` is `null` when the agent has not produced an outbound observation).
+- `alarm` is `null` when no heuristic fires; otherwise it is the same short string used in the table's `ALARM` column.
+- `--alarm-only` and `--json` compose: passing both yields a JSON array containing only the agents whose `alarm` is non-null.
+
+**Use cases:**
+- Quickly scanning every live agent for a known stuck pattern without inspecting them one-by-one with `synapse status`.
+- Wiring stuck-agent detection into shell scripts, CI safety nets, or external monitors via `--json --alarm-only`.
+- Debugging spawn-never-ready regressions (heuristic 4) on freshly spawned agents.
+
 ### Saved Agent Definitions
 
 Manage reusable agent definitions that persist across sessions. Saved agents are stored as `.agent` files in project (`.synapse/agents/`) or user (`~/.synapse/agents/`) scope.

--- a/plugins/synapse-a2a/skills/synapse-manager/references/commands-quick-ref.md
+++ b/plugins/synapse-a2a/skills/synapse-manager/references/commands-quick-ref.md
@@ -3,6 +3,7 @@
 | Command | Purpose |
 |---------|---------|
 | `synapse list` | Check agent status (auto-updates; `--json` for JSON array) |
+| `synapse watchdog check [--alarm-only] [--json]` | Stage 1 stuck-agent heuristic scan (#646) |
 | `synapse spawn <type\|id> --name <n> --role "<r>"` | Start agent (ad-hoc or from saved definition) |
 | `synapse send <name> "<msg>" --silent` | Delegate task (fire-and-forget) |
 | `synapse send <name> "<msg>" --wait` | Request reply (blocking) |

--- a/site-docs/changelog.md
+++ b/site-docs/changelog.md
@@ -4,6 +4,11 @@ For the complete changelog, see [CHANGELOG.md on GitHub](https://github.com/s-hi
 
 ## Recent Highlights
 
+### Unreleased
+
+- **Added**: `synapse watchdog check` (#646) — Stage 1 MVP one-shot CLI that scans every live agent and surfaces stuck-state suspicions via a heuristic table. Supports `--alarm-only` (only rows with an alarm) and `--json` (machine-readable output). Heuristics in priority order: (1) `RATE_LIMITED` for over 30 minutes, (2) `SENDING_REPLY` for over 60 seconds, (3) `PROCESSING` for over 30 minutes with no outbound A2A in the last 10 minutes, (4) spawn never reaching `READY` between 60 seconds and 5 minutes after registration. Stage 2-4 (background daemon, `synapse list --watch` integration, automatic recovery) ship in future PRs.
+- **Added**: `last_status_change_at` field on registry entries, written only on real status transitions so no-op rewrites preserve the timestamp. Pre-existing entries with the field absent are skipped by duration-based heuristics rather than counted from epoch.
+
 ### v0.30.0
 
 - **Added**: True PTY-level interrupt API (#647) — `POST /tasks/{id}/cancel` now accepts `mode=auto|pty|signal` and `repeat`, allowing stuck agents to receive Ctrl+C bytes through the PTY while preserving the legacy SIGINT path for `mode=signal`.

--- a/site-docs/guide/agent-management.md
+++ b/site-docs/guide/agent-management.md
@@ -410,3 +410,32 @@ crontab -e
 
 !!! info "Legacy agents return 404 (or 503 when capability-gated)"
     Agents that are still running with a pre-0.28.0 `synapse` binary do not expose `GET /debug/waiting`. The collector logs one `HTTP Error 404: Not Found` warning per legacy agent to stderr and continues. Agents on v0.28.0+ whose controller lacks the `waiting_debug_snapshot` capability (e.g., a non-PTY runtime) instead return `HTTP Error 503: Service Unavailable` with detail `waiting debug data not available` — also expected and non-fatal. Data accrues only for agents respawned after the CLI upgrade — stop and restart them with `synapse kill <id>` followed by the usual spawn when you want them in the dataset.
+
+### Stuck-Agent Watchdog (`watchdog check`)
+
+`synapse watchdog check` (added in #646, Stage 1 MVP) is a complementary observability layer focused on **stuck-state detection** rather than the WAITING-detection sampling that `--debug-waiting` and `waiting-debug` provide. It scans every live registry entry once and flags agents that match one of four duration- or outbound-history-based heuristics.
+
+```bash
+synapse watchdog check                 # Heuristic table for every live agent
+synapse watchdog check --alarm-only    # Only rows where a heuristic fired
+synapse watchdog check --json          # Machine-readable WatchdogReport[]
+```
+
+The table shows `ID`, `STATUS`, `UPTIME`, `SAME_STATUS_FOR`, `LAST_OUTBOUND`, and an `ALARM` column. The first matching rule (priority order) wins:
+
+| # | Trigger | Alarm |
+|---|---------|-------|
+| 1 | `RATE_LIMITED` for more than 30 min | `Rate-limited > 30m` |
+| 2 | `SENDING_REPLY` for more than 60 s | `Send stuck > 60s` |
+| 3 | `PROCESSING` for more than 30 min **and** no outbound A2A send in the last 10 min | `Stuck-on-reply suspected` |
+| 4 | Spawn never reached `READY` (uptime 60 s–5 min, no `last_status_change_at`) | `Spawn never ready` |
+
+Heuristic 3 cross-references the same `HistoryManager` that backs `synapse history`, filtered to outbound rows whose `metadata.sender_id` matches the agent — so a `PROCESSING` agent that is still actively replying to peers is **not** flagged.
+
+!!! tip "Stage 1 is operator-driven"
+    There is no background daemon yet. Run `synapse watchdog check --alarm-only` manually when an agent feels stuck, or schedule it from cron / launchd alongside `synapse waiting-debug collect`. Stage 2-4 (background daemon, `synapse list --watch` integration, A2A push notifications, automatic recovery) ship in follow-up PRs.
+
+!!! note "Duration heuristics need `last_status_change_at`"
+    Heuristics 1-3 read `last_status_change_at` (added in #646), which is written only on real status transitions. Pre-existing registry entries that lack the field are skipped rather than counted from epoch — restart older agents (`synapse kill <id>` then respawn) to include them.
+
+See [CLI Reference — Watchdog](../reference/cli.md#watchdog-stuck-agent-detection) for the full flag and JSON schema.

--- a/site-docs/reference/cli-cheatsheet.md
+++ b/site-docs/reference/cli-cheatsheet.md
@@ -21,6 +21,9 @@ Quick reference for the most commonly used Synapse A2A commands. For full detail
 | `synapse waiting-debug collect --timeout 10` | Override the per-agent HTTP timeout (default 5.0 s) for slow agents |
 | `synapse waiting-debug report` | Aggregate the collected WAITING snapshots (text or `--json`) |
 | `synapse waiting-debug report --out report.json` | Write JSON report to file (stdout stays empty — cron-safe) |
+| `synapse watchdog check` | One-shot stuck-agent heuristic table for every live agent (#646) |
+| `synapse watchdog check --alarm-only` | Same scan, but only rows with an alarm (cron-friendly) |
+| `synapse watchdog check --json` | Same scan as JSON (`WatchdogReport[]`) |
 | `synapse kill <target>` | Graceful shutdown (30 s timeout) |
 | `synapse kill <target> -f` | Force kill (immediate SIGKILL) |
 | `synapse cleanup` | Kill orphan child agents (parent PID dead) |
@@ -207,6 +210,11 @@ synapse status my-claude --debug-waiting     # Dump in-memory WAITING-detection 
 # Phase 1.5: persist /debug/waiting snapshots across all agents
 synapse waiting-debug collect                # Append to ~/.synapse/waiting_debug.jsonl
 synapse waiting-debug report --json          # Aggregate profile/pattern_source/confidence
+
+# Stuck-agent watchdog (Stage 1 MVP, #646)
+synapse watchdog check                       # Heuristic table for every live agent
+synapse watchdog check --alarm-only          # Cron-friendly: silent when nothing is stuck
+synapse watchdog check --json                # Machine-readable WatchdogReport[]
 
 # Jump to an agent's terminal
 synapse jump my-claude

--- a/site-docs/reference/cli.md
+++ b/site-docs/reference/cli.md
@@ -996,6 +996,40 @@ Persists `/debug/waiting` snapshots exposed by every running agent to `~/.synaps
 !!! note "Legacy agents"
     Agents still running a pre-0.28.0 `synapse` binary do not expose `GET /debug/waiting`. The collector logs one `HTTP Error 404: Not Found` warning per legacy agent and continues; respawn those agents to include them in the dataset.
 
+## Watchdog (Stuck-Agent Detection)
+
+```bash
+synapse watchdog check                 # Heuristic table for every live agent
+synapse watchdog check --alarm-only    # Only rows with an alarm
+synapse watchdog check --json          # Machine-readable JSON
+```
+
+Stage 1 MVP one-shot scan that flags potentially stuck agents using duration- and outbound-history-based heuristics. The table renders one row per live agent with `ID`, `STATUS`, `UPTIME`, `SAME_STATUS_FOR`, `LAST_OUTBOUND`, and an `ALARM` column (e.g., `⚠ Stuck-on-reply suspected`) or `-` when no heuristic fires. JSON output mirrors the `WatchdogReport` dataclass (`agent_id`, `status`, `uptime_seconds`, `same_status_seconds`, `last_outbound_seconds_ago`, `alarm`).
+
+| Flag | Description |
+|------|-------------|
+| `--alarm-only` | Restrict output to agents whose heuristics fired. Useful for cron / scripted polling so empty runs print nothing |
+| `--json` | Emit each report as a JSON array element instead of the Rich table. Combine with `--alarm-only` for alarm-only JSON |
+
+### Heuristics (priority order)
+
+| # | Trigger | Alarm |
+|---|---------|-------|
+| 1 | `RATE_LIMITED` for more than 30 min | `Rate-limited > 30m` |
+| 2 | `SENDING_REPLY` for more than 60 s | `Send stuck > 60s` |
+| 3 | `PROCESSING` for more than 30 min **and** no outbound A2A send in the last 10 min | `Stuck-on-reply suspected` |
+| 4 | Spawn never reached `READY` (uptime 60 s–5 min, no `last_status_change_at`) | `Spawn never ready` |
+
+The first matching rule wins. `last_outbound_seconds_ago` reads recent outbound entries from the same `HistoryManager` that backs `synapse history`, filtered to rows where the metadata `sender_id` matches the agent.
+
+!!! note "`last_status_change_at` is required for duration heuristics"
+    Heuristics 1-3 need `last_status_change_at` (#646) to compute `same_status_seconds`. Registry entries from agents started before this field was introduced are skipped by those heuristics rather than counted from epoch. Restart older agents to include them.
+
+!!! info "Stage 2-4 (future)"
+    The background daemon, `synapse list --watch` integration, A2A push notifications, multi-watchdog locking, and automatic recovery (e.g., auto-cancel + interrupt for stuck `SENDING_REPLY`) land in follow-up PRs. The Stage 1 MVP is operator-driven only — run it manually or from cron when you want a snapshot.
+
+See [Agent Management — Stuck-Agent Watchdog](../guide/agent-management.md#stuck-agent-watchdog-watchdog-check) for operator workflow.
+
 ## Low-Level A2A Tool
 
 ```bash

--- a/site-docs/troubleshooting.md
+++ b/site-docs/troubleshooting.md
@@ -497,6 +497,7 @@ synapse external add <new_url> --alias <alias>
 - Idle detection timeout may be too short -- increase in profile YAML
 - Send an interrupt: `synapse interrupt <agent> "Status?"`
 - Force kill and restart: `synapse kill <agent> -f`
+- Quickly triage with the watchdog: `synapse watchdog check --alarm-only` flags `PROCESSING` over 30 min with no outbound A2A in the last 10 min as `Stuck-on-reply suspected`, plus `RATE_LIMITED > 30m`, `Send stuck > 60s`, and `Spawn never ready` (#646). See [Agent Management — Stuck-Agent Watchdog](guide/agent-management.md#stuck-agent-watchdog-watchdog-check).
 
 ??? note "Understanding Idle Detection Strategies"
     Synapse supports three idle detection strategies, configured per agent type in YAML profiles:

--- a/synapse/cli.py
+++ b/synapse/cli.py
@@ -3191,6 +3191,7 @@ Status meanings:
         help="One-shot stuck-agent detection",
         description="Run watchdog checks for stuck or stalled live agents.",
     )
+    p_watchdog.set_defaults(func=lambda _args: p_watchdog.print_help())
     watchdog_subparsers = p_watchdog.add_subparsers(
         dest="watchdog_command", metavar="SUBCOMMAND"
     )

--- a/synapse/cli.py
+++ b/synapse/cli.py
@@ -99,6 +99,7 @@ from synapse.commands.spawn_cmd import (
 )
 from synapse.commands.start import StartCommand
 from synapse.commands.waiting_debug import cmd_waiting_debug, non_negative_float_arg
+from synapse.commands.watchdog import cmd_watchdog_check
 from synapse.commands.workflow import (
     cmd_workflow_create,
     cmd_workflow_delete,
@@ -3183,6 +3184,31 @@ Status meanings:
         help="Force one-shot plain-text output without the Rich TUI",
     )
     p_list.set_defaults(func=cmd_list)
+
+    # watchdog
+    p_watchdog = subparsers.add_parser(
+        "watchdog",
+        help="One-shot stuck-agent detection",
+        description="Run watchdog checks for stuck or stalled live agents.",
+    )
+    watchdog_subparsers = p_watchdog.add_subparsers(
+        dest="watchdog_command", metavar="SUBCOMMAND"
+    )
+    p_watchdog_check = watchdog_subparsers.add_parser(
+        "check",
+        help="Check live agents for stuck-state heuristics",
+    )
+    p_watchdog_check.add_argument(
+        "--alarm-only",
+        action="store_true",
+        help="Show only agents with watchdog alarms",
+    )
+    p_watchdog_check.add_argument(
+        "--json",
+        action="store_true",
+        help="Output watchdog reports as JSON",
+    )
+    p_watchdog_check.set_defaults(func=cmd_watchdog_check)
 
     # status
     p_status = subparsers.add_parser(

--- a/synapse/commands/watchdog.py
+++ b/synapse/commands/watchdog.py
@@ -1,0 +1,125 @@
+"""Watchdog command implementation for one-shot stuck-agent checks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from dataclasses import asdict
+from typing import Any
+
+from rich.console import Console
+from rich.table import Table
+
+from synapse.history import HistoryManager
+from synapse.paths import get_history_db_path
+from synapse.port_manager import is_process_alive
+from synapse.registry import AgentRegistry
+from synapse.watchdog import WatchdogReport, evaluate_agent
+
+
+def _format_duration(seconds: float | None) -> str:
+    if seconds is None:
+        return "-"
+    total_seconds = max(0, int(seconds))
+    hours, remainder = divmod(total_seconds, 3600)
+    minutes, secs = divmod(remainder, 60)
+    if hours:
+        return f"{hours}h {minutes:02d}m"
+    return f"{minutes}m {secs:02d}s"
+
+
+def _format_last_outbound(seconds: float | None) -> str:
+    if seconds is None:
+        return "(none)"
+    total_seconds = max(0, int(seconds))
+    if total_seconds < 60:
+        return f"{total_seconds}s ago"
+    minutes, secs = divmod(total_seconds, 60)
+    if minutes < 60:
+        return f"{minutes}m ago" if secs == 0 else f"{minutes}m {secs}s ago"
+    hours, minutes = divmod(minutes, 60)
+    return f"{hours}h {minutes:02d}m ago"
+
+
+def _metadata_sender_id(metadata: Any) -> str | None:
+    if not isinstance(metadata, dict):
+        return None
+    sender_id = metadata.get("sender_id")
+    if isinstance(sender_id, str):
+        return sender_id
+    sender = metadata.get("sender")
+    if isinstance(sender, dict):
+        nested_sender_id = sender.get("sender_id")
+        if isinstance(nested_sender_id, str):
+            return nested_sender_id
+    return None
+
+
+def _outbound_history_for_agent(
+    history_manager: HistoryManager,
+    agent_id: str,
+) -> list[dict[str, Any]]:
+    observations = history_manager.list_observations(limit=50, agent_id=agent_id)
+    return [
+        observation
+        for observation in observations
+        if _metadata_sender_id(observation.get("metadata")) == agent_id
+    ]
+
+
+def _live_agents(registry: AgentRegistry) -> dict[str, dict[str, Any]]:
+    live_agents: dict[str, dict[str, Any]] = {}
+    for agent_id, info in registry.list_agents().items():
+        pid = info.get("pid")
+        if isinstance(pid, int) and not is_process_alive(pid):
+            continue
+        live_agents[agent_id] = info
+    return live_agents
+
+
+def _collect_reports(now: float) -> list[WatchdogReport]:
+    registry = AgentRegistry()
+    history_manager = HistoryManager.from_env(db_path=get_history_db_path())
+    reports: list[WatchdogReport] = []
+
+    for agent_id, agent_info in sorted(_live_agents(registry).items()):
+        history = _outbound_history_for_agent(history_manager, agent_id)
+        reports.append(evaluate_agent(agent_info=agent_info, history=history, now=now))
+
+    return reports
+
+
+def _print_table(reports: list[WatchdogReport]) -> None:
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("ID")
+    table.add_column("STATUS")
+    table.add_column("UPTIME")
+    table.add_column("SAME_STATUS_FOR")
+    table.add_column("LAST_OUTBOUND")
+    table.add_column("ALARM", no_wrap=True)
+
+    for report in reports:
+        table.add_row(
+            report.agent_id,
+            report.status,
+            _format_duration(report.uptime_seconds),
+            _format_duration(report.same_status_seconds),
+            _format_last_outbound(report.last_outbound_seconds_ago),
+            f"⚠ {report.alarm}" if report.alarm else "-",
+        )
+
+    Console(width=200).print(table)
+
+
+def cmd_watchdog_check(args: argparse.Namespace) -> None:
+    """Run a one-shot stuck-agent watchdog check."""
+    reports = _collect_reports(now=time.time())
+    if getattr(args, "alarm_only", False):
+        reports = [report for report in reports if report.alarm]
+
+    if getattr(args, "json", False):
+        print(json.dumps([asdict(report) for report in reports], indent=2))
+        return
+
+    _print_table(reports)

--- a/synapse/commands/watchdog.py
+++ b/synapse/commands/watchdog.py
@@ -11,6 +11,7 @@ from typing import Any
 from rich.console import Console
 from rich.table import Table
 
+from synapse.commands.renderers.rich_renderer import format_elapsed
 from synapse.history import HistoryManager
 from synapse.paths import get_history_db_path
 from synapse.port_manager import is_process_alive
@@ -21,25 +22,13 @@ from synapse.watchdog import WatchdogReport, evaluate_agent
 def _format_duration(seconds: float | None) -> str:
     if seconds is None:
         return "-"
-    total_seconds = max(0, int(seconds))
-    hours, remainder = divmod(total_seconds, 3600)
-    minutes, secs = divmod(remainder, 60)
-    if hours:
-        return f"{hours}h {minutes:02d}m"
-    return f"{minutes}m {secs:02d}s"
+    return format_elapsed(max(0.0, seconds))
 
 
 def _format_last_outbound(seconds: float | None) -> str:
     if seconds is None:
         return "(none)"
-    total_seconds = max(0, int(seconds))
-    if total_seconds < 60:
-        return f"{total_seconds}s ago"
-    minutes, secs = divmod(total_seconds, 60)
-    if minutes < 60:
-        return f"{minutes}m ago" if secs == 0 else f"{minutes}m {secs}s ago"
-    hours, minutes = divmod(minutes, 60)
-    return f"{hours}h {minutes:02d}m ago"
+    return f"{format_elapsed(max(0.0, seconds))} ago"
 
 
 def _metadata_sender_id(metadata: Any) -> str | None:
@@ -60,7 +49,7 @@ def _outbound_history_for_agent(
     history_manager: HistoryManager,
     agent_id: str,
 ) -> list[dict[str, Any]]:
-    observations = history_manager.list_observations(limit=50, agent_id=agent_id)
+    observations = history_manager.list_observations(limit=10, agent_id=agent_id)
     return [
         observation
         for observation in observations

--- a/synapse/registry.py
+++ b/synapse/registry.py
@@ -218,6 +218,7 @@ class AgentRegistry:
             "port": port,
             "status": status,
             "status_updated_at": now,
+            "last_status_change_at": now,
             "registered_at": now,
             "pid": os.getpid(),
             "working_dir": os.getcwd(),
@@ -402,8 +403,12 @@ class AgentRegistry:
         """
 
         def set_status(data: dict) -> None:
+            previous_status = data.get("status")
+            now = time.time()
             data["status"] = status
-            data["status_updated_at"] = time.time()
+            data["status_updated_at"] = now
+            if previous_status != status:
+                data["last_status_change_at"] = now
 
         return self._atomic_update(agent_id, set_status, "status")
 

--- a/synapse/watchdog.py
+++ b/synapse/watchdog.py
@@ -1,0 +1,122 @@
+"""Pure watchdog evaluation logic for stuck-agent detection."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+from synapse.status import PROCESSING, RATE_LIMITED, READY, SENDING_REPLY
+
+RATE_LIMITED_SECONDS = 30 * 60
+SENDING_REPLY_SECONDS = 60
+PROCESSING_SECONDS = 30 * 60
+OUTBOUND_IDLE_SECONDS = 10 * 60
+SPAWN_READY_SECONDS = 60
+SPAWN_READY_MAX_SECONDS = 5 * 60
+
+
+@dataclass(frozen=True)
+class WatchdogReport:
+    agent_id: str
+    status: str
+    uptime_seconds: float | None
+    same_status_seconds: float | None
+    last_outbound_seconds_ago: float | None
+    alarm: str | None
+
+
+def _seconds_since(value: Any, now: float) -> float | None:
+    timestamp = _timestamp_to_epoch(value)
+    if timestamp is None:
+        return None
+    return max(0.0, now - timestamp)
+
+
+def _timestamp_to_epoch(value: Any) -> float | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, int | float):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            pass
+
+        normalized = value.strip()
+        if not normalized:
+            return None
+        if normalized.endswith("Z"):
+            normalized = f"{normalized[:-1]}+00:00"
+        for candidate in (normalized, normalized.replace(" ", "T", 1)):
+            try:
+                return datetime.fromisoformat(candidate).timestamp()
+            except ValueError:
+                continue
+    return None
+
+
+def _last_outbound_seconds_ago(
+    history: list[dict[str, Any]], now: float
+) -> float | None:
+    for row in history:
+        seconds_ago = _seconds_since(row.get("timestamp"), now)
+        if seconds_ago is not None:
+            return seconds_ago
+    return None
+
+
+def evaluate_agent(
+    *,
+    agent_info: dict[str, Any],
+    history: list[dict[str, Any]],
+    now: float,
+) -> WatchdogReport:
+    """Evaluate one agent against the Stage 1 watchdog heuristics."""
+    agent_id = str(agent_info.get("agent_id") or "")
+    status = str(agent_info.get("status") or "-")
+    uptime_seconds = _seconds_since(agent_info.get("registered_at"), now)
+    same_status_seconds = _seconds_since(agent_info.get("last_status_change_at"), now)
+    last_outbound_seconds_ago = _last_outbound_seconds_ago(history, now)
+
+    alarm: str | None = None
+    if (
+        status == RATE_LIMITED
+        and same_status_seconds is not None
+        and same_status_seconds > RATE_LIMITED_SECONDS
+    ):
+        alarm = "Rate-limited > 30m"
+    elif (
+        status == SENDING_REPLY
+        and same_status_seconds is not None
+        and same_status_seconds > SENDING_REPLY_SECONDS
+    ):
+        alarm = "Send stuck > 60s"
+    elif (
+        status == PROCESSING
+        and same_status_seconds is not None
+        and same_status_seconds > PROCESSING_SECONDS
+        and (
+            last_outbound_seconds_ago is None
+            or last_outbound_seconds_ago > OUTBOUND_IDLE_SECONDS
+        )
+    ):
+        alarm = "Stuck-on-reply suspected"
+    elif (
+        status != READY
+        and same_status_seconds is None
+        and uptime_seconds is not None
+        and uptime_seconds > SPAWN_READY_SECONDS
+        and uptime_seconds <= SPAWN_READY_MAX_SECONDS
+    ):
+        alarm = "Spawn never ready"
+
+    return WatchdogReport(
+        agent_id=agent_id,
+        status=status,
+        uptime_seconds=uptime_seconds,
+        same_status_seconds=same_status_seconds,
+        last_outbound_seconds_ago=last_outbound_seconds_ago,
+        alarm=alarm,
+    )

--- a/synapse/watchdog.py
+++ b/synapse/watchdog.py
@@ -8,12 +8,14 @@ from typing import Any
 
 from synapse.status import PROCESSING, RATE_LIMITED, READY, SENDING_REPLY
 
-RATE_LIMITED_SECONDS = 30 * 60
-SENDING_REPLY_SECONDS = 60
-PROCESSING_SECONDS = 30 * 60
+_THIRTY_MINUTES = 30 * 60
+
+RATE_LIMITED_ALARM_SECONDS = _THIRTY_MINUTES
+SENDING_REPLY_ALARM_SECONDS = 60
+PROCESSING_STALL_SECONDS = _THIRTY_MINUTES
 OUTBOUND_IDLE_SECONDS = 10 * 60
-SPAWN_READY_SECONDS = 60
-SPAWN_READY_MAX_SECONDS = 5 * 60
+SPAWN_READY_GRACE_SECONDS = 60
+SPAWN_READY_WINDOW_SECONDS = 5 * 60
 
 
 @dataclass(frozen=True)
@@ -67,6 +69,12 @@ def _last_outbound_seconds_ago(
     return None
 
 
+_DURATION_RULES: tuple[tuple[str, float, str], ...] = (
+    (RATE_LIMITED, RATE_LIMITED_ALARM_SECONDS, "Rate-limited > 30m"),
+    (SENDING_REPLY, SENDING_REPLY_ALARM_SECONDS, "Send stuck > 60s"),
+)
+
+
 def evaluate_agent(
     *,
     agent_info: dict[str, Any],
@@ -80,37 +88,12 @@ def evaluate_agent(
     same_status_seconds = _seconds_since(agent_info.get("last_status_change_at"), now)
     last_outbound_seconds_ago = _last_outbound_seconds_ago(history, now)
 
-    alarm: str | None = None
-    if (
-        status == RATE_LIMITED
-        and same_status_seconds is not None
-        and same_status_seconds > RATE_LIMITED_SECONDS
-    ):
-        alarm = "Rate-limited > 30m"
-    elif (
-        status == SENDING_REPLY
-        and same_status_seconds is not None
-        and same_status_seconds > SENDING_REPLY_SECONDS
-    ):
-        alarm = "Send stuck > 60s"
-    elif (
-        status == PROCESSING
-        and same_status_seconds is not None
-        and same_status_seconds > PROCESSING_SECONDS
-        and (
-            last_outbound_seconds_ago is None
-            or last_outbound_seconds_ago > OUTBOUND_IDLE_SECONDS
-        )
-    ):
-        alarm = "Stuck-on-reply suspected"
-    elif (
-        status != READY
-        and same_status_seconds is None
-        and uptime_seconds is not None
-        and uptime_seconds > SPAWN_READY_SECONDS
-        and uptime_seconds <= SPAWN_READY_MAX_SECONDS
-    ):
-        alarm = "Spawn never ready"
+    alarm = _evaluate_alarm(
+        status=status,
+        same_status_seconds=same_status_seconds,
+        uptime_seconds=uptime_seconds,
+        last_outbound_seconds_ago=last_outbound_seconds_ago,
+    )
 
     return WatchdogReport(
         agent_id=agent_id,
@@ -120,3 +103,40 @@ def evaluate_agent(
         last_outbound_seconds_ago=last_outbound_seconds_ago,
         alarm=alarm,
     )
+
+
+def _evaluate_alarm(
+    *,
+    status: str,
+    same_status_seconds: float | None,
+    uptime_seconds: float | None,
+    last_outbound_seconds_ago: float | None,
+) -> str | None:
+    for rule_status, threshold, message in _DURATION_RULES:
+        if (
+            status == rule_status
+            and same_status_seconds is not None
+            and same_status_seconds > threshold
+        ):
+            return message
+
+    if (
+        status == PROCESSING
+        and same_status_seconds is not None
+        and same_status_seconds > PROCESSING_STALL_SECONDS
+        and (
+            last_outbound_seconds_ago is None
+            or last_outbound_seconds_ago > OUTBOUND_IDLE_SECONDS
+        )
+    ):
+        return "Stuck-on-reply suspected"
+
+    if (
+        status != READY
+        and same_status_seconds is None
+        and uptime_seconds is not None
+        and SPAWN_READY_GRACE_SECONDS < uptime_seconds <= SPAWN_READY_WINDOW_SECONDS
+    ):
+        return "Spawn never ready"
+
+    return None

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 import textwrap
 import threading
+import time
 from contextlib import contextmanager
 from pathlib import Path
 
@@ -395,6 +396,27 @@ def test_update_status(registry):
 
     info = registry.get_agent(agent_id)
     assert info["status"] == "IDLE"
+
+
+def test_last_status_change_at_tracks_real_transitions(registry):
+    """last_status_change_at should not move on same-status rewrites."""
+    agent_id = "test_last_status_change_at"
+    registry.register(agent_id, "claude", 8100, status="STARTING")
+
+    registered_info = registry.get_agent(agent_id)
+    first_changed_at = registered_info["last_status_change_at"]
+    assert first_changed_at == registered_info["registered_at"]
+
+    time.sleep(0.01)
+    assert registry.update_status(agent_id, "READY") is True
+    transitioned_at = registry.get_agent(agent_id)["last_status_change_at"]
+    assert transitioned_at > first_changed_at
+
+    time.sleep(0.01)
+    assert registry.update_status(agent_id, "READY") is True
+    rewritten_info = registry.get_agent(agent_id)
+    assert rewritten_info["last_status_change_at"] == transitioned_at
+    assert rewritten_info["status_updated_at"] >= transitioned_at
 
 
 def test_update_status_nonexistent(registry):

--- a/tests/test_watchdog_646.py
+++ b/tests/test_watchdog_646.py
@@ -1,0 +1,212 @@
+"""Tests for one-shot agent watchdog stuck detection (#646)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Any
+from unittest.mock import patch
+
+from synapse.status import PROCESSING, RATE_LIMITED, READY, SENDING_REPLY, WAITING
+
+NOW = 1_776_800_000.0
+
+
+def _agent_info(
+    *,
+    agent_id: str = "synapse-codex-8122",
+    status: str = READY,
+    registered_delta: float = 120.0,
+    last_status_delta: float | None = 0.0,
+) -> dict[str, Any]:
+    info: dict[str, Any] = {
+        "agent_id": agent_id,
+        "status": status,
+        "registered_at": NOW - registered_delta,
+        "pid": 12345,
+        "port": 8122,
+    }
+    if last_status_delta is not None:
+        info["last_status_change_at"] = NOW - last_status_delta
+    return info
+
+
+def _history_row(*, timestamp_delta: float) -> dict[str, Any]:
+    return {
+        "task_id": "task-outbound",
+        "agent_name": "codex",
+        "timestamp": NOW - timestamp_delta,
+        "metadata": {"sender": {"sender_id": "synapse-codex-8122"}},
+    }
+
+
+def test_evaluate_processing_stuck_with_no_outbound() -> None:
+    from synapse.watchdog import evaluate_agent
+
+    report = evaluate_agent(
+        agent_info=_agent_info(status=PROCESSING, last_status_delta=31 * 60),
+        history=[],
+        now=NOW,
+    )
+
+    assert report.alarm == "Stuck-on-reply suspected"
+    assert report.same_status_seconds == 31 * 60
+    assert report.last_outbound_seconds_ago is None
+
+
+def test_evaluate_processing_stuck_but_recent_outbound() -> None:
+    from synapse.watchdog import evaluate_agent
+
+    report = evaluate_agent(
+        agent_info=_agent_info(status=PROCESSING, last_status_delta=31 * 60),
+        history=[_history_row(timestamp_delta=5 * 60)],
+        now=NOW,
+    )
+
+    assert report.alarm is None
+    assert report.last_outbound_seconds_ago == 5 * 60
+
+
+def test_evaluate_sending_reply_too_long() -> None:
+    from synapse.watchdog import evaluate_agent
+
+    report = evaluate_agent(
+        agent_info=_agent_info(status=SENDING_REPLY, last_status_delta=90),
+        history=[],
+        now=NOW,
+    )
+
+    assert report.alarm == "Send stuck > 60s"
+
+
+def test_evaluate_rate_limited_too_long() -> None:
+    from synapse.watchdog import evaluate_agent
+
+    report = evaluate_agent(
+        agent_info=_agent_info(status=RATE_LIMITED, last_status_delta=31 * 60),
+        history=[],
+        now=NOW,
+    )
+
+    assert report.alarm == "Rate-limited > 30m"
+
+
+def test_evaluate_spawn_never_ready() -> None:
+    from synapse.watchdog import evaluate_agent
+
+    report = evaluate_agent(
+        agent_info=_agent_info(
+            status=WAITING,
+            registered_delta=70,
+            last_status_delta=None,
+        ),
+        history=[],
+        now=NOW,
+    )
+
+    assert report.alarm == "Spawn never ready"
+    assert report.same_status_seconds is None
+
+
+def test_evaluate_healthy_processing() -> None:
+    from synapse.watchdog import evaluate_agent
+
+    report = evaluate_agent(
+        agent_info=_agent_info(status=PROCESSING, last_status_delta=5 * 60),
+        history=[_history_row(timestamp_delta=60)],
+        now=NOW,
+    )
+
+    assert report.alarm is None
+
+
+def test_evaluate_missing_last_status_change_at_skips_judgement() -> None:
+    from synapse.watchdog import evaluate_agent
+
+    report = evaluate_agent(
+        agent_info=_agent_info(
+            status=PROCESSING,
+            registered_delta=2 * 60 * 60,
+            last_status_delta=None,
+        ),
+        history=[],
+        now=NOW,
+    )
+
+    assert report.alarm is None
+    assert report.same_status_seconds is None
+
+
+def test_watchdog_check_alarm_only_filters_clean_agents(capsys) -> None:
+    from synapse.commands.watchdog import cmd_watchdog_check
+    from synapse.watchdog import WatchdogReport
+
+    agents = {
+        "clean": _agent_info(agent_id="clean", status=READY),
+        "stuck": _agent_info(agent_id="stuck", status=PROCESSING),
+    }
+
+    with (
+        patch("synapse.commands.watchdog.AgentRegistry") as registry_cls,
+        patch("synapse.commands.watchdog.HistoryManager") as history_cls,
+        patch("synapse.commands.watchdog.is_process_alive", return_value=True),
+        patch("synapse.commands.watchdog.evaluate_agent") as evaluate,
+    ):
+        registry_cls.return_value.list_agents.return_value = agents
+        history_cls.from_env.return_value.list_observations.return_value = []
+        evaluate.side_effect = [
+            WatchdogReport("clean", READY, 30.0, 30.0, None, None),
+            WatchdogReport(
+                "stuck",
+                PROCESSING,
+                3_600.0,
+                1_900.0,
+                None,
+                "Stuck-on-reply suspected",
+            ),
+        ]
+
+        cmd_watchdog_check(argparse.Namespace(alarm_only=True, json=False))
+
+    output = capsys.readouterr().out
+    assert "stuck" in output
+    assert "Stuck-on-reply suspected" in output
+    assert "clean" not in output
+
+
+def test_watchdog_check_json_output(capsys) -> None:
+    from synapse.commands.watchdog import cmd_watchdog_check
+    from synapse.watchdog import WatchdogReport
+
+    agents = {"stuck": _agent_info(agent_id="stuck", status=PROCESSING)}
+
+    with (
+        patch("synapse.commands.watchdog.AgentRegistry") as registry_cls,
+        patch("synapse.commands.watchdog.HistoryManager") as history_cls,
+        patch("synapse.commands.watchdog.is_process_alive", return_value=True),
+        patch("synapse.commands.watchdog.evaluate_agent") as evaluate,
+    ):
+        registry_cls.return_value.list_agents.return_value = agents
+        history_cls.from_env.return_value.list_observations.return_value = []
+        evaluate.return_value = WatchdogReport(
+            "stuck",
+            PROCESSING,
+            3_600.0,
+            1_900.0,
+            None,
+            "Stuck-on-reply suspected",
+        )
+
+        cmd_watchdog_check(argparse.Namespace(alarm_only=False, json=True))
+
+    rows = json.loads(capsys.readouterr().out)
+    assert rows == [
+        {
+            "agent_id": "stuck",
+            "status": PROCESSING,
+            "uptime_seconds": 3_600.0,
+            "same_status_seconds": 1_900.0,
+            "last_outbound_seconds_ago": None,
+            "alarm": "Stuck-on-reply suspected",
+        }
+    ]


### PR DESCRIPTION
## Summary

- **Stage 1 MVP** of the agent watchdog from #646 — a one-shot CLI that scans all live agents and surfaces stuck-state suspicions via a heuristic table
- Adds `synapse watchdog check` with `--alarm-only` and `--json` flags
- Adds `last_status_change_at` field to registry entries, written only on real status transitions (no-op rewrites preserve the timestamp)
- Resolves #646 (Stage 1 only — Stage 2/3/4 land in their own future PRs)
- Includes a CLAUDE.md docs commit codifying the dogfooding policy that drove this batch of issues

## Heuristics (priority order)

The first matching condition wins; the rest are short-circuited:

| # | Condition | Alarm |
|---|---|---|
| 1 | `RATE_LIMITED` > 30 min | `Rate-limited > 30m` |
| 2 | `SENDING_REPLY` > 60 sec | `Send stuck > 60s` |
| 3 | `PROCESSING` > 30 min AND no outbound A2A in last 10 min | `Stuck-on-reply suspected` |
| 4 | spawn never ready (`registered_at` 60s–5m ago, status ≠ READY) | `Spawn never ready` |

The 5m upper bound on heuristic 4 prevents misclassifying long-lived legacy agents that may not have populated `last_status_change_at`.

## Backward compatibility

`last_status_change_at` is optional. Old registry entries without the field are skipped by duration-based heuristics (1–3). Heuristic 4 (spawn never ready) only needs `registered_at`, which already existed, so it remains effective even on legacy entries.

## Files

- `synapse/watchdog.py` — pure heuristic layer (`evaluate_agent`, `WatchdogReport` dataclass)
- `synapse/commands/watchdog.py` — table / JSON / `--alarm-only` output
- `synapse/cli.py` — register `watchdog check` subcommand
- `synapse/registry.py` — `last_status_change_at` write semantics
- `tests/test_watchdog_646.py` — 9 tests (7 heuristic per-case + 2 CLI smoke)
- `tests/test_registry.py` — 1 regression for `last_status_change_at` semantics
- `CHANGELOG.md` — `[Unreleased]` Added entry
- `CLAUDE.md` — dogfooding policy (filed as `dc2b25f` for visibility; explains why this issue/PR cluster exists)

## Out of scope (future PRs)

| Stage | What | Tracking |
|---|---|---|
| 2 | Background daemon (`synapse watchdog start`) | future PR |
| 2 | A2A priority-4 push notifications | future PR |
| 2 | Notification cooldown / multi-watchdog locking | future PR |
| 3 | `synapse list --watch` integration | future PR |
| 4 | Automatic recovery (kill+respawn) | #646 vision |

## Test plan

- [x] `uv run pytest tests/test_watchdog_646.py -q` — 9 passed
- [x] `uv run pytest tests/test_watchdog_646.py tests/test_registry.py tests/test_cmd_list_json.py -q` — 55 passed
- [x] `uv run mypy synapse/` — no issues found in 116 source files
- [x] `uv run synapse watchdog check --json` — exit 0 with JSON array output
- [x] Pre-commit hooks (ruff, ruff format, mypy) all pass

## Related issues

- #644 / PR #650 (SENDING_REPLY) — sub-state input for heuristic 2
- #561 / PR #648 (RATE_LIMITED) — input for heuristic 1
- #538 / PR #640 (WAITING_FOR_INPUT) — adjacent status precision work
- #569 / PR #641 (registry status drift fix) — prerequisite for accurate timestamps
- #655 — observability bugs in `synapse status` `recent_messages` API surfaced during this PR's implementation; the watchdog itself partially addresses the same root concern (programmatic stuck-detection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ワンショット形式でスタック状態のエージェントを検出する `synapse watchdog check` コマンドを追加しました。`--alarm-only` および `--json` 出力オプションに対応しています。

* **ドキュメント**
  * Synapse の不正動作を報告するためのガイドラインを追加しました。誤った終了、スタック状態のエージェント、および誤解を招く出力など様々なケースをカバーしています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->