### PR TITLE
fix: include parent-side A2A sends in synapse status recent_messages (#659)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `clear_reply_target()` now swallows cleanup `PermissionError`/`OSError` failures so sandbox unlink errors no longer mask successful reply sends (#653).
+- `synapse status <agent> --json` recent messages now include parent-side A2A sends to the agent (#659).
 
 ## [0.30.0] - 2026-04-27
 

--- a/synapse/commands/status.py
+++ b/synapse/commands/status.py
@@ -248,10 +248,13 @@ class StatusCommand:
         if not self._history_manager:
             return []
         try:
-            agent_name = info.get("agent_type", "unknown")
             agent_id = info.get("agent_id")
+            if agent_id:
+                return self._history_manager.list_observations(
+                    agent_id=agent_id, limit=5
+                )
             return self._history_manager.list_observations(
-                agent_name=agent_name, agent_id=agent_id, limit=5
+                agent_name=info.get("agent_type", "unknown"), limit=5
             )
         except Exception:  # broad catch: history lookup is optional status info
             return []

--- a/tests/test_status_history_659.py
+++ b/tests/test_status_history_659.py
@@ -1,0 +1,152 @@
+"""Regression tests for status recent message history (#659)."""
+
+from pathlib import Path
+
+import pytest
+
+from synapse.commands.status import StatusCommand
+from synapse.history import HistoryManager
+
+TARGET_AGENT_ID = "synapse-codex-8121"
+
+
+@pytest.fixture
+def history_manager(tmp_path: Path) -> HistoryManager:
+    return HistoryManager(db_path=str(tmp_path / "history.db"))
+
+
+@pytest.fixture
+def status_command(history_manager: HistoryManager) -> StatusCommand:
+    return StatusCommand(registry=None, history_manager=history_manager)  # type: ignore[arg-type]
+
+
+def _save_observation(
+    history_manager: HistoryManager,
+    *,
+    task_id: str,
+    agent_name: str,
+    input_text: str,
+    metadata: dict[str, object] | None = None,
+) -> None:
+    history_manager.save_observation(
+        task_id=task_id,
+        agent_name=agent_name,
+        session_id=f"session-{task_id}",
+        input_text=input_text,
+        output_text="done",
+        status="completed",
+        metadata=metadata,
+    )
+
+
+def _task_ids(observations: list[dict[str, object]]) -> set[str]:
+    return {str(observation["task_id"]) for observation in observations}
+
+
+def test_get_history_includes_parent_side_send_observation(
+    history_manager: HistoryManager, status_command: StatusCommand
+) -> None:
+    _save_observation(
+        history_manager,
+        task_id="parent-send",
+        agent_name="claude",
+        input_text="synapse send codex fix bug",
+        metadata={"target_agent_id": TARGET_AGENT_ID},
+    )
+    _save_observation(
+        history_manager,
+        task_id="child-task",
+        agent_name="codex",
+        input_text="fix bug",
+        metadata={"recipient_agent_id": TARGET_AGENT_ID},
+    )
+
+    observations = status_command._get_history(
+        {"agent_id": TARGET_AGENT_ID, "agent_type": "codex"}
+    )
+
+    assert _task_ids(observations) == {"parent-send", "child-task"}
+
+
+def test_get_history_includes_child_reply_observation(
+    history_manager: HistoryManager, status_command: StatusCommand
+) -> None:
+    _save_observation(
+        history_manager,
+        task_id="child-reply",
+        agent_name="codex",
+        input_text="reply complete",
+        metadata={"sender": {"sender_id": TARGET_AGENT_ID}},
+    )
+
+    observations = status_command._get_history(
+        {"agent_id": TARGET_AGENT_ID, "agent_type": "codex"}
+    )
+
+    assert _task_ids(observations) == {"child-reply"}
+
+
+def test_get_history_excludes_unrelated_agents(
+    history_manager: HistoryManager, status_command: StatusCommand
+) -> None:
+    _save_observation(
+        history_manager,
+        task_id="target-send",
+        agent_name="claude",
+        input_text="targeted send",
+        metadata={"target_agent_id": TARGET_AGENT_ID},
+    )
+    _save_observation(
+        history_manager,
+        task_id="other-send",
+        agent_name="claude",
+        input_text="unrelated send",
+        metadata={"target_agent_id": "synapse-codex-8122"},
+    )
+    _save_observation(
+        history_manager,
+        task_id="probe-leftover",
+        agent_name="hello",
+        input_text="hello",
+        metadata={"sender_id": "synapse-codex-8122"},
+    )
+
+    observations = status_command._get_history(
+        {"agent_id": TARGET_AGENT_ID, "agent_type": "codex"}
+    )
+
+    assert _task_ids(observations) == {"target-send"}
+
+
+def test_get_history_falls_back_to_agent_name_when_no_agent_id(
+    history_manager: HistoryManager, status_command: StatusCommand
+) -> None:
+    _save_observation(
+        history_manager,
+        task_id="legacy-codex",
+        agent_name="codex",
+        input_text="legacy codex message",
+        metadata={"target_agent_id": "synapse-codex-8122"},
+    )
+    _save_observation(
+        history_manager,
+        task_id="parent-send",
+        agent_name="claude",
+        input_text="parent side send",
+        metadata={"target_agent_id": TARGET_AGENT_ID},
+    )
+
+    observations = status_command._get_history({"agent_type": "codex"})
+
+    assert _task_ids(observations) == {"legacy-codex"}
+
+
+def test_get_history_handles_empty_history_gracefully(
+    status_command: StatusCommand,
+) -> None:
+    assert (
+        status_command._get_history(
+            {"agent_id": TARGET_AGENT_ID, "agent_type": "codex"}
+        )
+        == []
+    )


### PR DESCRIPTION
## Summary

- Drop the `agent_name` SQL filter in `status._get_history` when an `agent_id` is available, so that **parent-side** `synapse send` observations (saved with `agent_name=parent_type`) are no longer dropped before the `agent_id` post-filter runs
- Resolves #659 (Bug B from the #655 observability tracker)
- Legacy callers without `agent_id` fall back to the original `agent_name`-based query

## The bug

`synapse/commands/status.py:_get_history` previously called:

```python
self._history_manager.list_observations(
    agent_name=info.get("agent_type"),  # e.g. "codex"
    agent_id=info.get("agent_id"),
    limit=5,
)
```

`history.list_observations` applies `agent_name` as a **SQL WHERE** filter, then runs the `agent_id` filter in Python afterwards (`history.py:356-378`). So observations saved by `synapse/tools/a2a_helpers.py:228` (parent-side `synapse send`, `agent_name=parent_type`) were eliminated at the SQL stage before the metadata-based `agent_id` match could rescue them. From the child agent's `synapse status --json`, the parent's send history was invisible — only child-side task observations (`agent_name=child_type` from `a2a_compat.py:350`) survived.

This made `synapse status <child> --json` useless for parent-side observation, which directly caused the Bug A misdiagnosis recorded in #655: a child waiting for parent approval looked indistinguishable from a stalled child, because the parent couldn't see its own previous sends in the child's history.

## The fix

When `agent_id` is present, query by `agent_id` only. `history._observation_matches_agent_id` already walks `sender_id`, `recipient_agent_id`, `target_agent_id`, nested `sender.sender_id`, `recipient.recipient_id`, etc., so a single `agent_id` filter captures both directions of the A2A conversation. Minimal call-site change; no `list_observations` API or SQL changes.

```python
agent_id = info.get("agent_id")
if agent_id:
    return self._history_manager.list_observations(agent_id=agent_id, limit=5)
return self._history_manager.list_observations(
    agent_name=info.get("agent_type", "unknown"), limit=5,
)
```

## Test plan

- [x] `uv run pytest tests/test_status_history_659.py -q` — 5 passed (new regression tests)
- [x] `uv run pytest tests/test_status*.py tests/test_history*.py -q` — 85 passed (no adjacent regressions)
- [x] `uv run mypy synapse/` — no issues across 116 source files
- [x] Pre-commit hooks (ruff, ruff format, mypy) all pass

## Files

- `synapse/commands/status.py` — `_get_history` filter logic (+5/-2)
- `tests/test_status_history_659.py` — 5 new regression tests (+153)
- `CHANGELOG.md` — `[Unreleased]` `### Fixed` entry (+1)

## Out of scope (#655 sibling issues, future PRs)

- **#660** — PTY screen scrape residue leaking into `output` field
- **#661** — `recent_messages` timestamps all sharing identical value (carry-over / bulk overwrite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * `synapse status --json` コマンドの「最近のメッセージ」セクションに、エージェント向けの親側A2A送信が表示されるようになりました。これにより、エージェント間の通信をより詳しく追跡できます。

* **テスト**
  * ステータス履歴フィルタリング動作の回帰テストが追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->