### PR TITLE
fix: stop overwriting output_text with send placeholder (#660 route A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Parent-side `synapse send` observations no longer write placeholder text into `output_text`, keeping recent message output reserved for agent responses (#660).
 - `clear_reply_target()` now swallows cleanup `PermissionError`/`OSError` failures so sandbox unlink errors no longer mask successful reply sends (#653).
 
 ## [0.30.0] - 2026-04-27

--- a/synapse/tools/a2a_helpers.py
+++ b/synapse/tools/a2a_helpers.py
@@ -220,6 +220,7 @@ def _record_sent_message(
             "direction": "sent",
             "target_agent_id": target_agent.get("agent_id"),
             "target_agent_type": target_agent.get("agent_type"),
+            "output_kind": "send_placeholder",
             "priority": priority,
         }
         if sender_info:
@@ -230,7 +231,7 @@ def _record_sent_message(
             agent_name=sender_name,
             session_id="a2a-send",
             input_text=f"@{target_agent.get('agent_type')} {message}",
-            output_text=f"Task sent to {target_agent.get('agent_id')}",
+            output_text="",
             status="sent",
             metadata=metadata,
         )

--- a/tests/test_a2a_helpers_660.py
+++ b/tests/test_a2a_helpers_660.py
@@ -1,0 +1,66 @@
+"""Regression tests for parent-side sent-message history output (#660)."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+from synapse.a2a_compat import Artifact, _format_artifact_text
+from synapse.history import HistoryManager
+from synapse.tools.a2a_helpers import _record_sent_message
+
+
+def _history_manager(tmp_path: Path) -> HistoryManager:
+    return HistoryManager(db_path=str(tmp_path / "history.db"))
+
+
+def _record_parent_send(history: HistoryManager) -> dict:
+    target_agent = {
+        "agent_id": "synapse-codex-8124",
+        "agent_type": "codex",
+    }
+
+    with patch("synapse.tools.a2a_helpers._get_history_manager", return_value=history):
+        _record_sent_message(
+            task_id="task-660",
+            target_agent=target_agent,
+            message="implement issue 660",
+            priority=3,
+            sender_info={
+                "sender_id": "synapse-claude-8104",
+                "sender_type": "claude",
+                "sender_endpoint": "http://localhost:8104",
+            },
+        )
+
+    observations = history.list_observations(limit=1)
+    assert len(observations) == 1
+    return observations[0]
+
+
+def test_send_observation_uses_empty_output_text(tmp_path: Path):
+    observation = _record_parent_send(_history_manager(tmp_path))
+
+    assert observation["output"] == ""
+
+
+def test_send_observation_metadata_marks_send_placeholder(tmp_path: Path):
+    observation = _record_parent_send(_history_manager(tmp_path))
+
+    assert observation["metadata"]["output_kind"] == "send_placeholder"
+
+
+def test_send_observation_preserves_input_text_format(tmp_path: Path):
+    observation = _record_parent_send(_history_manager(tmp_path))
+
+    assert observation["input"] == "@codex implement issue 660"
+
+
+def test_send_observation_preserves_target_agent_id_in_metadata(tmp_path: Path):
+    observation = _record_parent_send(_history_manager(tmp_path))
+
+    assert observation["metadata"]["target_agent_id"] == "synapse-codex-8124"
+
+
+def test_task_artifact_output_formatting_remains_unchanged():
+    artifact = Artifact(type="text", data={"content": "raw PTY remnant"})
+
+    assert _format_artifact_text(artifact) == "raw PTY remnant"


### PR DESCRIPTION
## Summary

- Replace the `output_text=f"Task sent to {agent_id}"` placeholder string with an empty string and a `metadata.output_kind="send_placeholder"` flag in the parent-side `synapse send` audit observation
- Resolves #660 **route A only** (the placeholder-text path). Route B (`_format_artifact_text` raw PTY leakage) is out of scope and will be filed as a follow-up issue
- New sends adopt the cleaner format; past DB rows are left untouched

## The bug (route A)

`synapse/tools/a2a_helpers.py:_record_sent_message_to_history` previously did:

```python
history.save_observation(
    ...,
    input_text=f"@{target_type} {message}",
    output_text=f"Task sent to {target_agent_id}",  # ← placeholder
    status="sent",
    metadata=metadata,
)
```

`output_text` was used to store an audit acknowledgement, but the field's downstream consumers (e.g. `synapse status <child> --json` `recent_messages`) display it as if it were the child agent's actual output. From the child's perspective, the parent's audit trail looked like `"Task sent to <self>"` masquerading as the child's own emission.

## The fix

Empty string + metadata flag:

```python
metadata["output_kind"] = "send_placeholder"
history.save_observation(
    ...,
    input_text=f"@{target_type} {message}",
    output_text="",
    status="sent",
    metadata=metadata,
)
```

`metadata.output_kind="send_placeholder"` lets a consumer that needs to distinguish "send audit" from "real task observation" do so without parsing a magic string. The empty `output_text` displays cleanly in `recent_messages` (no garbage); `metadata.direction="sent"` already conveys the audit intent for richer renderers.

## Test plan

- [x] `uv run pytest tests/test_a2a_helpers_660.py -q` — 5 passed (new regression tests)
- [x] `uv run pytest tests/test_a2a*.py tests/test_history*.py -q` — 209 passed (no adjacent regressions)
- [x] `uv run mypy synapse/` — no issues across 116 source files
- [x] Pre-commit hooks (ruff, ruff format, mypy) all pass

## Files

- `synapse/tools/a2a_helpers.py` — `output_text=""` + metadata flag (+2/-1)
- `tests/test_a2a_helpers_660.py` — 5 new regression tests
- `CHANGELOG.md` — `[Unreleased]` `### Fixed` entry

## Out of scope (will be filed as follow-up)

**Route B**: `_format_artifact_text` in `synapse/a2a_compat.py` can still leak raw PTY screen content (e.g. `"prompt cleared"`, `"Some old text with › 1. Yes, proceed remnant"`) when an agent emits a task artifact whose text was not sanitized. That is a sanitization-layer concern that warrants its own issue rather than expanding this PR's scope.

## Related (#655 family)

- **PR #662** — #659 Bug B (recent_messages drops parent-side sends): in-flight, complementary fix on the read path
- **#661** — Bug D: timestamp uniformity (independent, future PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)