### PR TITLE
fix: millisecond-precision history timestamps (#661)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `recent_messages` timestamps now use millisecond precision so rapid history writes within the same second can still be ordered distinctly (#661).
 - `clear_reply_target()` now swallows cleanup `PermissionError`/`OSError` failures so sandbox unlink errors no longer mask successful reply sends (#653).
 
 ## [0.30.0] - 2026-04-27

--- a/synapse/history.py
+++ b/synapse/history.py
@@ -148,7 +148,9 @@ class HistoryManager:
                             input TEXT NOT NULL,
                             output TEXT NOT NULL,
                             status TEXT NOT NULL,
-                            timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+                            timestamp DATETIME DEFAULT (
+                                strftime('%Y-%m-%d %H:%M:%f', 'now')
+                            ),
                             metadata TEXT
                         )
                         """
@@ -314,7 +316,9 @@ class HistoryManager:
                         set_clauses.append("metadata = ?")
                         params.append(metadata_json)
 
-                    set_clauses.append("timestamp = CURRENT_TIMESTAMP")
+                    set_clauses.append(
+                        "timestamp = strftime('%Y-%m-%d %H:%M:%f', 'now')"
+                    )
                     params.append(task_id)
                     cursor.execute(
                         f"UPDATE observations SET {', '.join(set_clauses)}"

--- a/tests/test_history_timestamp_661.py
+++ b/tests/test_history_timestamp_661.py
@@ -1,0 +1,109 @@
+"""Regression tests for millisecond history timestamps (#661)."""
+
+import re
+import sqlite3
+import time
+from pathlib import Path
+
+from synapse.history import HistoryManager
+
+MILLISECOND_TIMESTAMP = re.compile(r"\.\d{3}$")
+
+
+def _history_manager(tmp_path: Path) -> HistoryManager:
+    return HistoryManager(db_path=str(tmp_path / "history.db"))
+
+
+def _save_observation(
+    history: HistoryManager,
+    task_id: str,
+    input_text: str = "input",
+) -> None:
+    history.save_observation(
+        task_id=task_id,
+        agent_name="claude",
+        session_id="session-661",
+        input_text=input_text,
+        output_text="output",
+        status="completed",
+    )
+
+
+def _insert_legacy_observation(db_path: str, task_id: str, timestamp: str) -> None:
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO observations
+            (session_id, agent_name, task_id, input, output, status, timestamp)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "legacy-session",
+                "claude",
+                task_id,
+                "legacy input",
+                "legacy output",
+                "completed",
+                timestamp,
+            ),
+        )
+
+
+def test_save_observation_uses_millisecond_timestamp(tmp_path: Path):
+    history = _history_manager(tmp_path)
+
+    _save_observation(history, "task-661")
+
+    observation = history.list_observations(limit=1)[0]
+    assert MILLISECOND_TIMESTAMP.search(observation["timestamp"])
+
+
+def test_consecutive_save_observations_have_distinct_timestamps(tmp_path: Path):
+    history = _history_manager(tmp_path)
+
+    _save_observation(history, "task-661-a")
+    time.sleep(0.002)
+    _save_observation(history, "task-661-b")
+
+    observations = history.list_observations(limit=2)
+    timestamps = {obs["timestamp"] for obs in observations}
+    assert len(timestamps) == 2
+
+
+def test_update_observation_status_uses_millisecond_timestamp(tmp_path: Path):
+    history = _history_manager(tmp_path)
+    _save_observation(history, "task-661-update")
+
+    assert history.update_observation_status("task-661-update", "failed")
+
+    observation = history.get_observation("task-661-update")
+    assert observation is not None
+    assert MILLISECOND_TIMESTAMP.search(observation["timestamp"])
+
+
+def test_order_by_timestamp_handles_mixed_precision(tmp_path: Path):
+    history = _history_manager(tmp_path)
+    _insert_legacy_observation(
+        history.db_path,
+        task_id="task-661-legacy",
+        timestamp="2026-04-27 11:37:06",
+    )
+
+    _save_observation(history, "task-661-new")
+
+    observations = history.list_observations(limit=2)
+    assert observations[0]["task_id"] == "task-661-new"
+    assert observations[1]["task_id"] == "task-661-legacy"
+
+
+def test_existing_legacy_rows_still_returned(tmp_path: Path):
+    history = _history_manager(tmp_path)
+    _insert_legacy_observation(
+        history.db_path,
+        task_id="task-661-legacy",
+        timestamp="2026-04-27 11:37:06",
+    )
+
+    observations = history.list_observations(limit=1)
+    assert observations[0]["task_id"] == "task-661-legacy"
+    assert observations[0]["timestamp"] == "2026-04-27 11:37:06"


### PR DESCRIPTION
## Summary

- Replace SQLite's second-precision `CURRENT_TIMESTAMP` with `strftime('%Y-%m-%d %H:%M:%f', 'now')` (millisecond precision) in both the table DDL default and `update_observation_status`
- Resolves #661 (Bug D from the #655 observability tracker)
- No migration: legacy second-precision rows continue to sort correctly alongside new millisecond rows

## The bug (real root cause)

The original #661 issue speculated about agent carry-over. Investigation showed the real cause was simpler: **`CURRENT_TIMESTAMP` produces `'YYYY-MM-DD HH:MM:SS'` (no fractional seconds)**. When `save_observation` inserts or `update_observation_status` writes happened multiple times within the same second — common during rapid status transitions or batch-style task lifecycle events — every affected row received an identical timestamp string. The "all five `recent_messages` share timestamp `2026-04-27 11:37:06`" symptom was this collision.

## The fix

Both the DDL default and the `UPDATE` clause now use:

```python
strftime('%Y-%m-%d %H:%M:%f', 'now')
```

`%f` yields seconds with three-digit fractional resolution (`'2026-04-27 11:37:06.123'`), so back-to-back writes in the same second produce distinct values.

## Why no migration is needed

SQLite stores DATETIME values as TEXT (the column is type-affinity, not strict). Lexicographic ordering on the new format is consistent with both legacy and new rows: `'2026-04-27 11:37:06'` (legacy) precedes `'2026-04-27 11:37:06.001'` (new) under string comparison, so `ORDER BY timestamp DESC LIMIT n` continues to work correctly without backfilling old rows.

## Test plan

- [x] `uv run pytest tests/test_history_timestamp_661.py -q` — 5 passed
- [x] `uv run pytest tests/test_history*.py tests/test_a2a*.py -q` — all green (no adjacent regressions)
- [x] `uv run mypy synapse/` — no issues across 116 source files
- [x] Pre-commit hooks pass

## Files

- `synapse/history.py` — DDL default + `update_observation_status` timestamp write (+5/-2)
- `tests/test_history_timestamp_661.py` — 5 new regression tests:
  - `save_observation` produces millisecond-suffixed timestamps
  - consecutive saves within the same second yield distinct timestamps
  - `update_observation_status` produces millisecond-suffixed timestamps
  - mixed legacy/new rows order correctly via `list_observations`
  - legacy second-precision rows still surface in `list_observations`
- `CHANGELOG.md` — `[Unreleased]` `### Fixed` entry

## Out of scope

- Sub-millisecond precision (μs / ns): #661 explicitly out-of-scope
- Timestamp column type change (DATETIME → INTEGER epoch): would require migration, separate PR
- Bug B (#659): handled in PR #662 (in-flight)
- Bug C route A (#660): handled in PR #663 (in-flight)
- Bug C route B (#664): future PR

## Related

This completes the #655 observability sub-bug split:

| Bug | Issue | PR | Status |
|---|---|---|---|
| Bug B (recent_messages drops A2A) | #659 | #662 | in-flight |
| Bug C route A (placeholder text) | #660 | #663 | in-flight |
| Bug C route B (PTY scrape) | #664 | future | filed |
| **Bug D (timestamp uniformity)** | **#661** | **this PR** | **opening** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)