### PR TITLE
fix: strip PTY control bytes from artifact text in history (#664)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Artifact text formatting now strips PTY control bytes before persisting or returning A2A output, preventing raw terminal redraw content from leaking into `recent_messages` (#664).
+
 ## [0.31.0] - 2026-04-28
 
 This release rolls up a "status precision" family that sharpens what `synapse list` / `synapse status` show during long-running and rate-limited work, plus a new one-shot `synapse watchdog check` command for surfacing stuck agents. Status precision now covers `RATE_LIMITED` (#561), the `SENDING_REPLY` sub-state (#644), HTTP `input_required` (#651), and a true PTY-level interrupt path with `mode=pty|signal|auto` (#647). Observability of recent messages is hardened by including parent-side A2A sends (#659), keeping `output_text` reserved for agent responses (#660), and using millisecond-precision history timestamps (#661). The default agent instructions also now describe `synapse memory` as legacy in favor of LLM Wiki (#527). Includes the previously unreleased READY-send delay (#467), the workflow target-resolution fix (#568), and the `/dev-issue` skill that were staged on `main` after the 0.29.0 tag but never shipped.

--- a/synapse/a2a_compat.py
+++ b/synapse/a2a_compat.py
@@ -298,14 +298,14 @@ def _format_artifact_text(artifact: "Artifact", use_markdown: bool = False) -> s
         content = code_data.get("content", str(artifact.data))
         prefix = f"```{language}\n" if use_markdown else f"[Code: {language}]\n"
         suffix = "\n```" if use_markdown else ""
-        return f"{prefix}{content}{suffix}"
+        return strip_control_bytes(f"{prefix}{content}{suffix}")
 
     if artifact.type == "text":
         if isinstance(artifact.data, str):
-            return artifact.data
-        return str(artifact.data.get("content", artifact.data))
+            return strip_control_bytes(artifact.data)
+        return strip_control_bytes(str(artifact.data.get("content", artifact.data)))
 
-    return f"[{artifact.type}] {artifact.data}"
+    return strip_control_bytes(f"[{artifact.type}] {artifact.data}")
 
 
 def _save_task_to_history(

--- a/tests/test_a2a_compat_sanitize_664.py
+++ b/tests/test_a2a_compat_sanitize_664.py
@@ -1,0 +1,54 @@
+"""Regression tests for artifact text sanitization (#664)."""
+
+from synapse.a2a_compat import Artifact, _format_artifact_text
+
+
+def test_text_artifact_strips_csi():
+    artifact = Artifact(type="text", data="hello\x1b[Kworld")
+
+    output = _format_artifact_text(artifact)
+
+    assert "\x1b[K" not in output
+    assert output == "helloworld"
+
+
+def test_text_artifact_dict_strips_control():
+    artifact = Artifact(type="text", data={"content": "ok\x07bell"})
+
+    output = _format_artifact_text(artifact)
+
+    assert "\x07" not in output
+    assert output == "okbell"
+
+
+def test_code_artifact_strips_within_content():
+    artifact = Artifact(
+        type="code",
+        data={
+            "content": "print(\x1b[31m'red'\x1b[0m)",
+            "metadata": {"language": "python"},
+        },
+    )
+
+    output = _format_artifact_text(artifact)
+
+    assert "\x1b[31m" not in output
+    assert "\x1b[0m" not in output
+    assert output == "[Code: python]\nprint('red')"
+
+
+def test_unknown_artifact_strips_control():
+    artifact = Artifact(type="unknown_type", data="raw\x1b]1337;foo\x07payload")
+
+    output = _format_artifact_text(artifact)
+
+    assert "\x1b]1337;foo\x07" not in output
+    assert output == "[unknown_type] rawpayload"
+
+
+def test_plain_text_unchanged():
+    artifact = Artifact(type="text", data="multi\nline\ttab content")
+
+    output = _format_artifact_text(artifact)
+
+    assert output == "multi\nline\ttab content"


### PR DESCRIPTION
## Summary

- **Bug C route B fix.** `_format_artifact_text` was passing agent-side raw `artifact.data` straight into `output_text`, leaving CSI escapes (`\x1b[K`), OSC sequences, BEL, and other C0/C1 control bytes in `recent_messages[].output`.
- **Reuse first.** Applies the existing `strip_control_bytes` helper from `synapse/_pty_sanitize` (originally introduced for permission notifications via #582/#586) at each return path of `_format_artifact_text`. No new sanitizer or regex; the issue body's draft approach was superseded after verifying the helper already exists.
- **Symmetric to PR #663.** That PR fixed route A (parent-side placeholder text); this PR closes the remaining route from #655 / #660.

## Files

- `synapse/a2a_compat.py` — 4 `strip_control_bytes(...)` wrappings in `_format_artifact_text` (code / text-str / text-dict / unknown)
- `tests/test_a2a_compat_sanitize_664.py` — 5 regression tests (CSI, BEL, OSC, code-block content, plain-text-unchanged)
- `CHANGELOG.md` — `[Unreleased] ### Fixed` entry

## Test plan

- [x] `uv run pytest tests/test_a2a_compat_sanitize_664.py -q` → 5 passed
- [x] `uv run pytest tests/test_a2a_compat.py tests/test_a2a_helpers_660.py tests/test_history_timestamp_661.py tests/test_status_history_659.py -q` → 100 passed (no regressions in #659/#660/#661 family)
- [x] `uv run pytest -q` (full suite) → 4365 passed, 6 pre-existing failures unrelated to this change (file_safety env, learning_mode, send_ready_delay_467, settings instruction paths)
- [x] `uv run mypy synapse/` → no issues, 116 source files
- [x] Red-phase verified: 4 failed / 1 passed before fix, demonstrating tests bind to bug paths

Closes #664.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* アーティファクトテキストの出力から制御バイトを除去するようにしました。

## テスト
* アーティファクトテキスト形式の制御バイト除去動作を検証する回帰テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->