### PR TITLE
feat(dev-issue): suggest post-impl skill in summary, branched by mode (#665)

### DIFF
--- a/.agents/skills/dev-issue/SKILL.md
+++ b/.agents/skills/dev-issue/SKILL.md
@@ -168,7 +168,7 @@ Depending on the flag:
   /dev-issue: branch and brief ready. Begin implementation in this session.
   ```
 
-- **`--dry-run`**: skip branch creation (step 9) and spawn. Print:
+- **`--dry-run`**: skip branch creation (step 9) and skip spawn (step 10). Print:
   ```
   /dev-issue: dry run. Brief written to /tmp/issue<num>-task.md.
   Review and re-run without --dry-run to create the branch and spawn.

--- a/.agents/skills/dev-issue/SKILL.md
+++ b/.agents/skills/dev-issue/SKILL.md
@@ -177,16 +177,65 @@ Depending on the flag:
 ### 11. Output a summary
 
 Print a concise summary to stdout (not a synapse send — this is for the
-human user invoking the slash):
+human user invoking the slash). The `Next:` line must point to the
+appropriate **post-implementation skill** so the docs/skills/site-sync
+chain isn't silently dropped after the implementation lands.
+
+**default mode** (codex spawned — implementing agent is codex):
 
 ```
 ✓ /dev-issue <num> ready
   Title:   <issue title>
   Branch:  <prefix>/<slug>-<num>   (created from origin/main @ <sha>)
   Brief:   /tmp/issue<num>-task.md
-  Spawned: <codex agent name>      (omit if --solo or --dry-run)
-  Next:    Wait for codex plan reply, or begin implementation.
+  Spawned: <codex agent name>
+  Next:    Wait for codex plan reply, then approve.
+           After implementation completes, run /post-impl-codex to sync
+           docs/skills/site, commit, create PR, and start pr-guardian.
 ```
+
+**`--solo` mode** (parent implements — implementing agent is the caller):
+
+```
+✓ /dev-issue <num> ready (--solo)
+  Title:   <issue title>
+  Branch:  <prefix>/<slug>-<num>   (created from origin/main @ <sha>)
+  Brief:   /tmp/issue<num>-task.md
+  Next:    Begin implementation in this session.
+           After implementation, run /post-impl-claude (Claude Code) or
+           /post-impl (target: self) to sync docs/skills/site, commit,
+           create PR, and start pr-guardian.
+```
+
+**`--dry-run` mode** (no branch, no implementation, no post-impl needed):
+
+```
+✓ /dev-issue <num> dry-run ready
+  Title:   <issue title>
+  Brief:   /tmp/issue<num>-task.md
+  Next:    Review the brief, then re-run without --dry-run to create
+           the branch and spawn (or pass --solo to implement yourself).
+```
+
+#### Post-impl skill selection by implementing agent
+
+| `/dev-issue` mode | Implementing agent     | Post-impl skill                     |
+|-------------------|------------------------|-------------------------------------|
+| **default**       | spawned codex          | `/post-impl-codex`                  |
+| **`--solo`**      | parent (Claude Code)   | `/post-impl-claude` *or* `/post-impl` (target: self) |
+| **`--dry-run`**   | (none)                 | (not applicable)                    |
+
+`/post-impl-codex` calls the workflow runner with codex-optimized steps
+(`/code-simplifier` as a subagent). `/post-impl-claude` uses the built-in
+`/simplify`. `/post-impl` (target: self) injects the sequence back into
+the caller's PTY so it stays in-process — useful when the caller is itself
+a long-lived agent (claude or codex). Pick `/post-impl-claude` over
+`/post-impl` when the caller is a one-shot Claude Code session and you
+want explicit phase boundaries.
+
+The `Next:` line is **a suggestion, not a guarantee** — `/dev-issue` does
+not invoke the post-impl skill itself. The user (or parent agent) decides
+when implementation is "done enough" to run it.
 
 ## Brief Template
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `/dev-issue` summary now suggests the appropriate post-implementation skill based on mode: `/post-impl-codex` for default (codex spawn), `/post-impl-claude` or `/post-impl` (target: self) for `--solo`. Surfaces the docs/skills/site-sync chain so it isn't silently dropped after implementation (#665).
+- `/dev-issue` summary now suggests the appropriate post-implementation skill based on mode: `/post-impl-codex` for default (codex spawn), `/post-impl-claude` or `/post-impl` (target: self) for `--solo`, and none for `--dry-run` (brief only — no post-impl proposed). Surfaces the docs/skills/site-sync chain so it isn't silently dropped after implementation (#665).
 ### Fixed
 
 - Artifact text formatting now strips PTY control bytes before persisting or returning A2A output, preventing raw terminal redraw content from leaking into `recent_messages` (#664).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `/dev-issue` summary now suggests the appropriate post-implementation skill based on mode: `/post-impl-codex` for default (codex spawn), `/post-impl-claude` or `/post-impl` (target: self) for `--solo`. Surfaces the docs/skills/site-sync chain so it isn't silently dropped after implementation (#665).
+
 ## [0.31.0] - 2026-04-28
 
 This release rolls up a "status precision" family that sharpens what `synapse list` / `synapse status` show during long-running and rate-limited work, plus a new one-shot `synapse watchdog check` command for surfacing stuck agents. Status precision now covers `RATE_LIMITED` (#561), the `SENDING_REPLY` sub-state (#644), HTTP `input_required` (#651), and a true PTY-level interrupt path with `mode=pty|signal|auto` (#647). Observability of recent messages is hardened by including parent-side A2A sends (#659), keeping `output_text` reserved for agent responses (#660), and using millisecond-precision history timestamps (#661). The default agent instructions also now describe `synapse memory` as legacy in favor of LLM Wiki (#527). Includes the previously unreleased READY-send delay (#467), the workflow target-resolution fix (#568), and the `/dev-issue` skill that were staged on `main` after the 0.29.0 tag but never shipped.

--- a/plugins/synapse-a2a/skills/dev-issue/SKILL.md
+++ b/plugins/synapse-a2a/skills/dev-issue/SKILL.md
@@ -168,7 +168,7 @@ Depending on the flag:
   /dev-issue: branch and brief ready. Begin implementation in this session.
   ```
 
-- **`--dry-run`**: skip branch creation (step 9) and spawn. Print:
+- **`--dry-run`**: skip branch creation (step 9) and skip spawn (step 10). Print:
   ```
   /dev-issue: dry run. Brief written to /tmp/issue<num>-task.md.
   Review and re-run without --dry-run to create the branch and spawn.

--- a/plugins/synapse-a2a/skills/dev-issue/SKILL.md
+++ b/plugins/synapse-a2a/skills/dev-issue/SKILL.md
@@ -177,16 +177,65 @@ Depending on the flag:
 ### 11. Output a summary
 
 Print a concise summary to stdout (not a synapse send — this is for the
-human user invoking the slash):
+human user invoking the slash). The `Next:` line must point to the
+appropriate **post-implementation skill** so the docs/skills/site-sync
+chain isn't silently dropped after the implementation lands.
+
+**default mode** (codex spawned — implementing agent is codex):
 
 ```
 ✓ /dev-issue <num> ready
   Title:   <issue title>
   Branch:  <prefix>/<slug>-<num>   (created from origin/main @ <sha>)
   Brief:   /tmp/issue<num>-task.md
-  Spawned: <codex agent name>      (omit if --solo or --dry-run)
-  Next:    Wait for codex plan reply, or begin implementation.
+  Spawned: <codex agent name>
+  Next:    Wait for codex plan reply, then approve.
+           After implementation completes, run /post-impl-codex to sync
+           docs/skills/site, commit, create PR, and start pr-guardian.
 ```
+
+**`--solo` mode** (parent implements — implementing agent is the caller):
+
+```
+✓ /dev-issue <num> ready (--solo)
+  Title:   <issue title>
+  Branch:  <prefix>/<slug>-<num>   (created from origin/main @ <sha>)
+  Brief:   /tmp/issue<num>-task.md
+  Next:    Begin implementation in this session.
+           After implementation, run /post-impl-claude (Claude Code) or
+           /post-impl (target: self) to sync docs/skills/site, commit,
+           create PR, and start pr-guardian.
+```
+
+**`--dry-run` mode** (no branch, no implementation, no post-impl needed):
+
+```
+✓ /dev-issue <num> dry-run ready
+  Title:   <issue title>
+  Brief:   /tmp/issue<num>-task.md
+  Next:    Review the brief, then re-run without --dry-run to create
+           the branch and spawn (or pass --solo to implement yourself).
+```
+
+#### Post-impl skill selection by implementing agent
+
+| `/dev-issue` mode | Implementing agent     | Post-impl skill                     |
+|-------------------|------------------------|-------------------------------------|
+| **default**       | spawned codex          | `/post-impl-codex`                  |
+| **`--solo`**      | parent (Claude Code)   | `/post-impl-claude` *or* `/post-impl` (target: self) |
+| **`--dry-run`**   | (none)                 | (not applicable)                    |
+
+`/post-impl-codex` calls the workflow runner with codex-optimized steps
+(`/code-simplifier` as a subagent). `/post-impl-claude` uses the built-in
+`/simplify`. `/post-impl` (target: self) injects the sequence back into
+the caller's PTY so it stays in-process — useful when the caller is itself
+a long-lived agent (claude or codex). Pick `/post-impl-claude` over
+`/post-impl` when the caller is a one-shot Claude Code session and you
+want explicit phase boundaries.
+
+The `Next:` line is **a suggestion, not a guarantee** — `/dev-issue` does
+not invoke the post-impl skill itself. The user (or parent agent) decides
+when implementation is "done enough" to run it.
 
 ## Brief Template
 


### PR DESCRIPTION
## Summary

- **`/dev-issue` step 11 (Output a summary)** now branches by mode and points to the appropriate post-implementation skill, surfacing the docs / skills / site-sync chain that was previously left implicit and frequently skipped.
- **Mode → skill table** added inline in the SKILL.md so future readers see the selection logic (codex → `/post-impl-codex`; claude solo → `/post-impl-claude` or `/post-impl`; dry-run → none).
- **Solo implementation** by the parent (Claude Code) — this is a doc-only change to a single skill mirrored across `plugins/synapse-a2a/skills/dev-issue/` (canonical) and `.agents/skills/dev-issue/` (tracked mirror). `.claude/skills/dev-issue/` is gitignored as a per-developer local copy.

## Why

Recent dev sessions showed that after `/dev-issue → codex implementation`, the user manually had to remember which post-impl skill to invoke (4 variants exist: `/post-impl-codex`, `/post-impl-claude`, `/post-impl`, `/parallel-docs-simplify-sync`). The chain was usually skipped, producing PRs where the code merged but docs / `site-docs/` / skill mirrors drifted out of sync. Making the suggestion discoverable in the slash output closes that loop.

## Changes

- `plugins/synapse-a2a/skills/dev-issue/SKILL.md` — step 11 rewritten with three mode-specific summary blocks + post-impl selection table
- `.agents/skills/dev-issue/SKILL.md` — synced from canonical (byte-identical)
- `CHANGELOG.md` — `[Unreleased] ### Changed` entry

## Test plan

- [x] All 3 mirrors byte-identical: `diff plugins/synapse-a2a/skills/dev-issue/SKILL.md .agents/skills/dev-issue/SKILL.md` clean
- [x] `.claude/` mirror also synced locally (gitignored, regenerated by `sync-plugin-skills` skill)
- [x] No code change → no pytest/mypy run needed (pre-commit hooks: ruff/ruff-format/mypy all skipped, "no files to check")
- [x] Manual readthrough: skill structure (step 1-11) intact, only step 11 expanded; brief template (step 8) unchanged

Closes #665.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

**ドキュメンテーション**
- `/dev-issue`コマンドの出力サマリーセクションを更新し、実装後のステップについてより詳細な指示を提供するようになりました
- 実行モード（デフォルト、solo、dry-run）に応じた異なるの次ステップ指示が明確化されました
- ドキュメンテーション同期とコミット、プルリクエスト作成のフローが詳しく説明されるようになりました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->