### PR TITLE
refactor: status string literals → synapse.status constants + dogfooding cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `/dev-issue` summary now suggests the appropriate post-implementation skill based on mode: `/post-impl-codex` for default (codex spawn), `/post-impl-claude` or `/post-impl` (target: self) for `--solo`, and none for `--dry-run` (brief only — no post-impl proposed). Surfaces the docs/skills/site-sync chain so it isn't silently dropped after implementation (#665).
+
+### Refactored
+
+- All status WRITE sites in `synapse/cli.py` and `synapse/controller.py` now use the `synapse.status` constants instead of string literals (`"PROCESSING"`, `"DONE"`, `"SHUTTING_DOWN"`, `"WAITING"`, `"READY"`). Read-only status comparisons in `tools/a2a.py` and `commands/*.py` are intentionally left as literals; expanding scope there would not improve write-side state machine review.
+
 ### Fixed
 
 - Artifact text formatting now strips PTY control bytes before persisting or returning A2A output, preventing raw terminal redraw content from leaking into `recent_messages` (#664).

--- a/synapse/cli.py
+++ b/synapse/cli.py
@@ -117,6 +117,7 @@ from synapse.port_manager import (
     is_process_alive,
 )
 from synapse.registry import AgentRegistry, NameConflictError, is_port_open
+from synapse.status import SHUTTING_DOWN
 from synapse.utils import resolve_command_path
 
 # Known profiles (for shortcut detection)
@@ -430,7 +431,7 @@ def cmd_kill(args: argparse.Namespace) -> None:
         escalation_wait = max(remaining - grace_period, 0)
 
         # 1. Set status to SHUTTING_DOWN
-        registry.update_status(agent_id, "SHUTTING_DOWN")
+        registry.update_status(agent_id, SHUTTING_DOWN)
 
         # 2. Send graceful shutdown request via A2A
         logger.info(

--- a/synapse/controller.py
+++ b/synapse/controller.py
@@ -45,7 +45,7 @@ from synapse.pty_renderer import PtyRenderer
 from synapse.registry import AgentRegistry
 from synapse.settings import get_settings
 from synapse.skills import load_skill_sets
-from synapse.status import PROCESSING
+from synapse.status import DONE, PROCESSING, READY, SHUTTING_DOWN, WAITING
 from synapse.terminal_writer import TerminalWriter
 from synapse.utils import (
     RoleFileNotFoundError,
@@ -209,7 +209,7 @@ class TerminalController(StatusObserverMixin):
         self._pending_cr = False
         self._max_buffer = OUTPUT_BUFFER_MAX
         self._decoder = codecs.getincrementaldecoder("utf-8")("replace")
-        self.status = "PROCESSING"
+        self.status = PROCESSING
         self.lock = threading.Lock()
         self._write_lock = threading.RLock()
         self.running = False
@@ -457,7 +457,7 @@ class TerminalController(StatusObserverMixin):
         All mutable state is guarded by _auto_approve_lock.
         """
         with self._auto_approve_lock:
-            if new_status != "WAITING":
+            if new_status != WAITING:
                 return
 
             if self._auto_approve_stopped:
@@ -558,7 +558,7 @@ class TerminalController(StatusObserverMixin):
         self.thread = threading.Thread(target=self._monitor_output)
         self.thread.daemon = True
         self.thread.start()
-        self.status = "PROCESSING"
+        self.status = PROCESSING
 
         # Initialize last output time for timeout-based idle detection
         with self.lock:
@@ -711,9 +711,9 @@ class TerminalController(StatusObserverMixin):
                     self.agent_id,
                     exc_info=True,
                 )
-                if new_data and self.status not in {"PROCESSING", "SHUTTING_DOWN"}:
+                if new_data and self.status not in {PROCESSING, SHUTTING_DOWN}:
                     old_status = self.status
-                    self.status = "PROCESSING"
+                    self.status = PROCESSING
                     if self.agent_id:
                         self.registry.update_status(self.agent_id, self.status)
                     self._dispatch_status_callbacks(old_status, self.status)
@@ -760,7 +760,7 @@ class TerminalController(StatusObserverMixin):
             # Send initial instructions on first READY (agent is idle)
             if (
                 is_idle
-                and self.status == "READY"
+                and self.status == READY
                 and not self._identity_sent
                 and not self._identity_sending
                 and self.agent_id
@@ -1288,10 +1288,10 @@ class TerminalController(StatusObserverMixin):
         """
         with self.lock:
             old_status = self.status
-            self.status = "DONE"
+            self.status = DONE
             self._done_time = time.time()
 
-            logger.debug(f"[{self.agent_id}] Status: {old_status} -> DONE")
+            logger.debug(f"[{self.agent_id}] Status: {old_status} -> {DONE}")
 
             # Sync to registry
             if self.agent_id:
@@ -1308,7 +1308,7 @@ class TerminalController(StatusObserverMixin):
         """
         self.running = False
         with self.lock:
-            self.status = "SHUTTING_DOWN"
+            self.status = SHUTTING_DOWN
 
         proc = self.process
         pgid = getattr(self, "_pgid", None)


### PR DESCRIPTION
## Summary

Pre-refactor backlog cleanup + a narrow status-write refactor that emerged from it.

**Backlog cleanup (no code change)** — 6 orphan issues found and closed in this session:
- #311 (synapse status command spec) — already shipped
- #356 (PTY noise in A2A replies) — already covered by multi-layer filter chain in `output_parser.py` + #664 sanitize fix
- #604 (Golden Path docs) — already shipped via PR #615
- #647 (PTY-level interrupt) — already shipped via PR #649
- #644 (SENDING_REPLY surfacing) — A/B criteria met via PR #650/#662
- #655 (Bug A/B/C/D meta-tracker) — all 4 sub-bugs shipped (#646/#656, #659/#662, #660/#663, #664/#668, #661/#666)

**Refactor (the actual code change)**:
- All status WRITE sites in `synapse/cli.py` and `synapse/controller.py` now use the `synapse.status` constants instead of string literals
- 6 sites in `controller.py`: \_\_init\_\_, start, monitor-loop new\_data path, set\_done, stop, auto-approve trigger
- 1 site in `cli.py`: graceful shutdown sequence
- READ-only comparisons in `tools/a2a.py` / `commands/cleanup.py` / `commands/list.py` left untouched — expanding scope there would not improve write-side state machine review

**Process improvement filed**:
- Issue #670 — PR template should require `Closes #N` keyword (the orphan-issue root cause)

## Why

Started from "コードが複雑になっている気がする" → audit. Investigation showed the actual smell wasn't the state machine shape (8 statuses, transitions are fine), but the **mix of string literals and constants for the same value**. Refactoring the broader transition surface (e.g. extracting `status_transitions.py` with named functions) was rejected after analyzing 4 sync sites in controller.py and finding 3 distinct patterns — single-helper extraction would have changed behavior on at least one site.

Narrow refactor scope is the right size: behavior-preserving, mypy clean, full status test suite (213) green.

## Files

- `synapse/cli.py` — import `SHUTTING_DOWN`; 1 literal → constant
- `synapse/controller.py` — import `DONE`/`READY`/`SHUTTING_DOWN`/`WAITING` (already had `PROCESSING`); 6 literals → constants
- `CHANGELOG.md` — `[Unreleased] ### Refactored` entry

## Test plan

- [x] `uv run pytest tests/test_controller.py tests/test_a2a_compat.py tests/test_status*.py -q` → 213 passed in 73s
- [x] `uv run mypy synapse/` → no issues, 116 source files
- [x] pre-commit hooks: ruff (legacy alias) + ruff format + mypy all passed

Refs #670.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **リファクタリング**
  * ステータス更新処理をハードコードされた文字列から定数参照に統一しました。これにより、ステータス管理の一貫性と保守性が向上します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->