### PR TITLE
feat(reply): add --message-file/--stdin flag parity with synapse send (#673)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `synapse reply` now accepts `--message-file` / `-F` and `--stdin` flags, matching `synapse send`. This lets long replies (or replies containing backticks / `$()` / `${}` shell metacharacters) be passed via file or pipe instead of as a positional argument that the shell may try to expand. Reply still uses fixed `priority=3` and `silent` response mode — other `send` flags were intentionally not mirrored because they conflict with reply semantics (#673).
+
 ### Changed
 
 - `/dev-issue` summary now suggests the appropriate post-implementation skill based on mode: `/post-impl-codex` for default (codex spawn), `/post-impl-claude` or `/post-impl` (target: self) for `--solo`, and none for `--dry-run` (brief only — no post-impl proposed). Surfaces the docs/skills/site-sync chain so it isn't silently dropped after implementation (#665).

--- a/synapse/cli.py
+++ b/synapse/cli.py
@@ -3470,6 +3470,18 @@ Priority levels:
         default=False,
         help="List available reply targets and exit",
     )
+    p_reply.add_argument(
+        "--message-file",
+        "-F",
+        dest="message_file",
+        help="Read reply message from file (use '-' for stdin)",
+    )
+    p_reply.add_argument(
+        "--stdin",
+        action="store_true",
+        default=False,
+        help="Read reply message from stdin",
+    )
     p_reply.add_argument("message", nargs="?", default="", help="Reply message content")
     p_reply.set_defaults(func=cmd_reply)
 

--- a/synapse/commands/messaging.py
+++ b/synapse/commands/messaging.py
@@ -204,10 +204,11 @@ def cmd_broadcast(args: argparse.Namespace) -> None:
 
 def cmd_reply(args: argparse.Namespace) -> None:
     """Reply to the last received A2A message using reply tracking."""
-    message = args.message
     sender = getattr(args, "sender", None)
     to_sender = getattr(args, "to", None)
     list_targets = getattr(args, "list_targets", False)
+    message_file = getattr(args, "message_file", None)
+    use_stdin = getattr(args, "stdin", False)
 
     cmd = [sys.executable, str(_get_a2a_tool_path()), "reply"]
     if sender:
@@ -216,7 +217,11 @@ def cmd_reply(args: argparse.Namespace) -> None:
         cmd.extend(["--to", to_sender])
     if list_targets:
         cmd.append("--list-targets")
-    if message:
-        cmd.append(message)
+    if message_file:
+        cmd.extend(["--message-file", message_file])
+    if use_stdin:
+        cmd.append("--stdin")
+    if args.message:
+        cmd.append(args.message)
 
     _run_a2a_command(cmd, exit_on_error=True)

--- a/synapse/tools/a2a.py
+++ b/synapse/tools/a2a.py
@@ -690,8 +690,41 @@ def cmd_reply(args: argparse.Namespace) -> None:
             sys.exit(1)
         return
 
-    message = getattr(args, "message", "").strip()
     fail_reason = getattr(args, "fail", None)
+    message_file = getattr(args, "message_file", None)
+    use_stdin = getattr(args, "stdin", False)
+    positional_message = getattr(args, "message", "")
+
+    sources_used: list[str] = []
+    if positional_message:
+        sources_used.append("positional")
+    if message_file:
+        sources_used.append("--message-file")
+    if use_stdin:
+        sources_used.append("--stdin")
+
+    if len(sources_used) > 1:
+        print(
+            f"Error: Multiple message sources specified: {', '.join(sources_used)}. "
+            "Use exactly one of: positional argument, --message-file, or --stdin.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    if use_stdin:
+        message = sys.stdin.read().strip()
+    elif message_file:
+        if message_file == "-":
+            message = sys.stdin.read().strip()
+        else:
+            path = Path(message_file)
+            if not path.exists():
+                print(f"Error: Message file not found: {message_file}", file=sys.stderr)
+                sys.exit(1)
+            message = path.read_text(encoding="utf-8").strip()
+    else:
+        message = positional_message.strip()
+
     if fail_reason and message:
         print(
             "Error: Use either a reply message or --fail, not both.",
@@ -957,6 +990,18 @@ def main() -> None:
         "--fail",
         dest="fail",
         help="Send a failed reply with the given reason instead of a normal text reply",
+    )
+    p_reply.add_argument(
+        "--message-file",
+        "-F",
+        dest="message_file",
+        help="Read reply message from file (use '-' for stdin)",
+    )
+    p_reply.add_argument(
+        "--stdin",
+        action="store_true",
+        default=False,
+        help="Read reply message from stdin",
     )
     p_reply.add_argument("message", nargs="?", default="", help="Reply message content")
 

--- a/tests/test_reply_flag_parity_673.py
+++ b/tests/test_reply_flag_parity_673.py
@@ -1,0 +1,208 @@
+"""Regression tests for `synapse reply` flag parity with `synapse send` (#673)."""
+
+import argparse
+from unittest.mock import MagicMock, patch
+
+
+class TestReplyFlagParity673:
+    """Verify --message-file / --stdin reach send_to_local with file content."""
+
+    def _setup_mocks(
+        self, mock_sender: MagicMock, mock_get: MagicMock, mock_post: MagicMock
+    ) -> MagicMock:
+        mock_sender.return_value = {
+            "sender_id": "synapse-claude-8100",
+            "sender_endpoint": "http://localhost:8100",
+        }
+
+        list_response = MagicMock()
+        list_response.status_code = 200
+        list_response.json.return_value = {
+            "sender_ids": ["synapse-claude-8100"],
+            "targets": [{"sender_id": "synapse-claude-8100"}],
+        }
+        get_response = MagicMock()
+        get_response.status_code = 200
+        get_response.json.return_value = {
+            "sender_endpoint": "http://localhost:8110",
+            "sender_task_id": "abc",
+            "receiver_task_id": "local-task",
+        }
+        pop_response = MagicMock()
+        pop_response.status_code = 200
+        mock_get.side_effect = [list_response, get_response, pop_response]
+
+        local_reply_response = MagicMock()
+        local_reply_response.status_code = 200
+        mock_post.return_value = local_reply_response
+        return MagicMock()
+
+    @patch("synapse.tools.a2a.A2AClient")
+    @patch("synapse.tools.a2a.build_sender_info")
+    @patch("requests.get")
+    @patch("requests.post")
+    def test_message_file_loads_content(
+        self,
+        mock_post: MagicMock,
+        mock_get: MagicMock,
+        mock_sender: MagicMock,
+        mock_client_cls: MagicMock,
+        tmp_path,
+    ):
+        from synapse.tools.a2a import cmd_reply
+
+        self._setup_mocks(mock_sender, mock_get, mock_post)
+        mock_client = MagicMock()
+        mock_client.send_to_local.return_value = MagicMock(
+            id="task-1", status="completed"
+        )
+        mock_client_cls.return_value = mock_client
+
+        msg_path = tmp_path / "reply.txt"
+        msg_path.write_text("Long reply with `backticks` that would warn\n")
+
+        args = argparse.Namespace(
+            message="",
+            message_file=str(msg_path),
+            stdin=False,
+            fail=None,
+            to=None,
+            list_targets=False,
+            sender=None,
+        )
+        cmd_reply(args)
+
+        sent_message = mock_client.send_to_local.call_args.kwargs["message"]
+        assert sent_message == "Long reply with `backticks` that would warn"
+
+    @patch("synapse.tools.a2a.A2AClient")
+    @patch("synapse.tools.a2a.build_sender_info")
+    @patch("requests.get")
+    @patch("requests.post")
+    def test_stdin_reads_content(
+        self,
+        mock_post: MagicMock,
+        mock_get: MagicMock,
+        mock_sender: MagicMock,
+        mock_client_cls: MagicMock,
+        monkeypatch,
+    ):
+        import io
+
+        from synapse.tools.a2a import cmd_reply
+
+        self._setup_mocks(mock_sender, mock_get, mock_post)
+        mock_client = MagicMock()
+        mock_client.send_to_local.return_value = MagicMock(
+            id="task-1", status="completed"
+        )
+        mock_client_cls.return_value = mock_client
+
+        monkeypatch.setattr("sys.stdin", io.StringIO("piped reply\n"))
+
+        args = argparse.Namespace(
+            message="",
+            message_file=None,
+            stdin=True,
+            fail=None,
+            to=None,
+            list_targets=False,
+            sender=None,
+        )
+        cmd_reply(args)
+
+        sent_message = mock_client.send_to_local.call_args.kwargs["message"]
+        assert sent_message == "piped reply"
+
+    @patch("synapse.tools.a2a.build_sender_info")
+    def test_multiple_sources_rejected(self, mock_sender: MagicMock, capsys, tmp_path):
+        from synapse.tools.a2a import cmd_reply
+
+        mock_sender.return_value = {
+            "sender_id": "synapse-claude-8100",
+            "sender_endpoint": "http://localhost:8100",
+        }
+
+        msg_path = tmp_path / "reply.txt"
+        msg_path.write_text("from file")
+
+        args = argparse.Namespace(
+            message="positional",
+            message_file=str(msg_path),
+            stdin=False,
+            fail=None,
+            to=None,
+            list_targets=False,
+            sender=None,
+        )
+        try:
+            cmd_reply(args)
+            raised = False
+        except SystemExit as exc:
+            raised = exc.code != 0
+
+        assert raised
+        err = capsys.readouterr().err
+        assert "Multiple message sources specified" in err
+
+    @patch("synapse.tools.a2a.build_sender_info")
+    def test_message_file_not_found_errors(self, mock_sender: MagicMock, capsys):
+        from synapse.tools.a2a import cmd_reply
+
+        mock_sender.return_value = {
+            "sender_id": "synapse-claude-8100",
+            "sender_endpoint": "http://localhost:8100",
+        }
+
+        args = argparse.Namespace(
+            message="",
+            message_file="/nonexistent/reply.txt",
+            stdin=False,
+            fail=None,
+            to=None,
+            list_targets=False,
+            sender=None,
+        )
+        try:
+            cmd_reply(args)
+            raised = False
+        except SystemExit as exc:
+            raised = exc.code != 0
+
+        assert raised
+        err = capsys.readouterr().err
+        assert "Message file not found" in err
+
+    @patch("synapse.tools.a2a.A2AClient")
+    @patch("synapse.tools.a2a.build_sender_info")
+    @patch("requests.get")
+    @patch("requests.post")
+    def test_positional_still_works(
+        self,
+        mock_post: MagicMock,
+        mock_get: MagicMock,
+        mock_sender: MagicMock,
+        mock_client_cls: MagicMock,
+    ):
+        from synapse.tools.a2a import cmd_reply
+
+        self._setup_mocks(mock_sender, mock_get, mock_post)
+        mock_client = MagicMock()
+        mock_client.send_to_local.return_value = MagicMock(
+            id="task-1", status="completed"
+        )
+        mock_client_cls.return_value = mock_client
+
+        args = argparse.Namespace(
+            message="positional reply",
+            message_file=None,
+            stdin=False,
+            fail=None,
+            to=None,
+            list_targets=False,
+            sender=None,
+        )
+        cmd_reply(args)
+
+        sent_message = mock_client.send_to_local.call_args.kwargs["message"]
+        assert sent_message == "positional reply"


### PR DESCRIPTION
## Summary

- \`synapse reply\` now accepts \`--message-file\` / \`-F\` and \`--stdin\` — the same two flags \`synapse send\` already exposes for handling long messages, pipes, or content that contains shell-expandable characters (backticks, \`\$()\`, \`\${}\`)
- Discovered during this very session: every time the parent agent tried to reply with a long message containing inline code blocks, the positional path triggered \"WARNING: Message contains backtick command substitution\" and we had to fall back to \`synapse send\` — defeating the reply-tracking semantics

## Linked Issues

- Closes #673

## Why scope is narrow (2 flags, not 6)

Issue #673 originally proposed mirroring all of \`send\`'s flags. After looking at the actual \`reply\` send path:

- **\`--priority\`**: \`cmd_reply\` hardcodes \`priority=3\`. Reply priority has no real effect — the receiver's queue is filtered by content, not arbitrary numeric weight set by the replier.
- **\`--wait\` / \`--notify\` / \`--silent\`**: \`cmd_reply\` hardcodes \`response_mode=\"silent\"\` with the comment \`# Reply doesn't expect a reply back\`. Adding the flag would silently no-op.
- **\`--attach\`**: \`cmd_reply\`'s \`send_to_local\` call passes no \`file_parts\` argument; threading attachments through requires touching the reply-stack contract.
- **\`--force\`**: Reply target is determined by reply tracking (sender ID), not target working dir. The working-dir mismatch check that \`--force\` overrides doesn't run for replies.

Mirroring those 4 flags would be **misleading**, not helpful — agents would see a \`--notify\` flag, set it, and silently get fire-and-forget anyway. Better to add only what works.

This is the \`feedback_no_silent_scope_cuts.md\` policy in action: scope narrowing surfaced explicitly with reasoning.

## Files

- \`synapse/cli.py\` — \`p_reply\` argparse parser gains \`--message-file\`/\`-F\` and \`--stdin\`
- \`synapse/commands/messaging.py\` — \`cmd_reply\` forwards both flags to \`a2a.py\`
- \`synapse/tools/a2a.py\` — \`p_reply\` parser + \`cmd_reply\` message resolution logic mirroring \`_resolve_message\` semantics, with reply-specific message-vs-\`--fail\` conflict handling
- \`tests/test_reply_flag_parity_673.py\` — 5 regression tests
- \`CHANGELOG.md\` — \`[Unreleased] ### Added\` entry

## Test plan

- [x] \`uv run pytest tests/test_reply_flag_parity_673.py -q\` → 5 passed
- [x] \`uv run pytest tests/test_tools_a2a.py tests/test_reply_*.py tests/test_reply_flag_parity_673.py -q\` → 120 passed (no regression in adjacent suites)
- [x] \`uv run mypy synapse/\` → no issues, 116 source files
- [x] Pre-commit hooks: ruff (legacy alias) + ruff format + mypy all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)