### PR TITLE
refactor: status state machine read-side constants migration (Phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Refactored
 
-- All status WRITE sites in `synapse/cli.py` and `synapse/controller.py` now use the `synapse.status` constants instead of string literals (`"PROCESSING"`, `"DONE"`, `"SHUTTING_DOWN"`, `"WAITING"`, `"READY"`). Read-only status comparisons in `tools/a2a.py` and `commands/*.py` are intentionally left as literals; expanding scope there would not improve write-side state machine review.
+- All status WRITE sites in `synapse/cli.py` and `synapse/controller.py` now use the `synapse.status` constants instead of string literals (`"PROCESSING"`, `"DONE"`, `"SHUTTING_DOWN"`, `"WAITING"`, `"READY"`).
+- Status READ-only comparisons in `synapse/tools/a2a.py`, `synapse/commands/cleanup.py`, and `synapse/commands/list.py` now use the same `synapse.status` constants. Combined with the WRITE-side migration above, the status state machine no longer mixes literals and constants — the entire surface is greppable through the constants module.
 
 ### Fixed
 

--- a/synapse/commands/cleanup.py
+++ b/synapse/commands/cleanup.py
@@ -21,6 +21,7 @@ import time
 from typing import Any
 
 from synapse.registry import AgentRegistry, is_process_running
+from synapse.status import READY
 
 logger = logging.getLogger(__name__)
 
@@ -150,7 +151,7 @@ def opportunistic_cleanup_idle_orphans(
 
     now = time.time()
     for agent_id, info in orphans.items():
-        if info.get("status") != "READY":
+        if info.get("status") != READY:
             continue
         changed_at = info.get("status_changed_at")
         if not isinstance(changed_at, (int, float)):

--- a/synapse/commands/list.py
+++ b/synapse/commands/list.py
@@ -16,6 +16,7 @@ from synapse.commands.cleanup import opportunistic_cleanup_idle_orphans
 from synapse.file_safety import FileSafetyManager
 from synapse.port_manager import PORT_RANGES
 from synapse.registry import AgentRegistry
+from synapse.status import PROCESSING
 from synapse.utils import format_renderer_suffix
 
 if TYPE_CHECKING:
@@ -81,7 +82,7 @@ class ListCommand:
 
         # Check 2: Port must be open (agent server responding)
         # Skip port check for PROCESSING agents (server may still be starting)
-        is_starting = info.get("status", "-") == "PROCESSING"
+        is_starting = info.get("status", "-") == PROCESSING
         if is_starting or not port:
             return True
 

--- a/synapse/tools/a2a.py
+++ b/synapse/tools/a2a.py
@@ -295,7 +295,7 @@ def cmd_send(args: argparse.Namespace) -> None:
     # Wait for target to leave PROCESSING unless bypassed.
     if not delay_bypassed:
         status = target_agent.get("status", "")
-        if status == "PROCESSING":
+        if status == PROCESSING:
             display_name = target_agent.get("name") or agent_id
             try:
                 wait_timeout = int(os.environ.get("SYNAPSE_SEND_WAIT_TIMEOUT", "30"))
@@ -304,7 +304,7 @@ def cmd_send(args: argparse.Namespace) -> None:
             wait_timeout = max(wait_timeout, 0)
 
             waited = 0
-            while waited < wait_timeout and status == "PROCESSING":
+            while waited < wait_timeout and status == PROCESSING:
                 print(
                     f"\rWaiting for {display_name} to become READY... ({waited}s)",
                     end="",
@@ -322,7 +322,7 @@ def cmd_send(args: argparse.Namespace) -> None:
 
             if waited > 0:
                 print("", file=sys.stderr)
-            if status == "PROCESSING":
+            if status == PROCESSING:
                 print(
                     f"Warning: Timed out waiting for {display_name} to become READY. Continuing send.",
                     file=sys.stderr,
@@ -330,7 +330,7 @@ def cmd_send(args: argparse.Namespace) -> None:
 
     # Give READY targets a short window to flip to PROCESSING before injecting
     # a message, which avoids interrupting a user who is still typing at prompt.
-    if not delay_bypassed and target_agent.get("status", "") == "READY":
+    if not delay_bypassed and target_agent.get("status", "") == READY:
         try:
             ready_delay = float(os.environ.get("SYNAPSE_SEND_READY_DELAY", "2"))
         except ValueError:
@@ -349,7 +349,7 @@ def cmd_send(args: argparse.Namespace) -> None:
                 refreshed = _refresh_target_agent()
                 if refreshed:
                     target_agent = refreshed
-                    if refreshed.get("status", "") == "PROCESSING":
+                    if refreshed.get("status", "") == PROCESSING:
                         break
                 else:
                     break


### PR DESCRIPTION
## Summary

- Phase 1 of a 3-phase refactor cleanup that emerged from the user observation \"コードが複雑になっている気がする\"
- PR #671 migrated the WRITE side (status assignment sites in \`cli.py\` / \`controller.py\`); this PR migrates the symmetric READ side (status comparison sites in \`tools/a2a.py\` / \`commands/cleanup.py\` / \`commands/list.py\`)
- After this PR, the \`synapse.status\` constants are the single grep target for the entire state machine surface

## Linked Issues

- Refs #671 (the WRITE-side companion that intentionally left these for a separate PR)

## Changes

- \`synapse/tools/a2a.py\` — 5 sites: cmd_send wait/delay logic
- \`synapse/commands/cleanup.py\` — 1 site: \`opportunistic_cleanup_idle_orphans\`
- \`synapse/commands/list.py\` — 1 site: \`is_starting\` check

Total: +11 / -8 lines.

## Test plan

- [x] \`uv run pytest tests/test_tools_a2a.py tests/test_cmd_list_*.py tests/test_commands_cleanup.py -q\` → 108 passed
- [x] \`uv run mypy synapse/\` → no issues, 116 source files
- [x] Pre-commit hooks: ruff (legacy alias) + ruff format + mypy all passed

## Refactor cadence (this is Phase 1 of 3)

Phase 1 (this PR): status literals → constants in 3 read-side files
Phase 2 (next, codex spawn via /dev-issue 515): \`send_to_local()\` 235-line flatten + silent-skip fix
Phase 3 (after 0.32.0 release lull): \`cli.py\` (5179 lines) and \`a2a_compat.py\` (2916 lines) module splits — multi-PR series

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **リファクタリング**
  * ステータス値の参照方法をシステム全体で統一し、コードの一貫性と保守性が向上しました。

* **ドキュメンテーション**
  * 変更ログを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->