### PR TITLE
refactor(a2a_client): flatten send_to_local wait polling, fix silent skip (#515)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Refactored
 
+- `send_to_local()` wait mode now resolves a single polling endpoint before waiting, falling back to target polling instead of silently skipping when sender polling is unavailable (#515).
 - All status WRITE sites in `synapse/cli.py` and `synapse/controller.py` now use the `synapse.status` constants instead of string literals (`"PROCESSING"`, `"DONE"`, `"SHUTTING_DOWN"`, `"WAITING"`, `"READY"`). Read-only status comparisons in `tools/a2a.py` and `commands/*.py` are intentionally left as literals; expanding scope there would not improve write-side state machine review.
 
 ### Fixed

--- a/synapse/a2a_client.py
+++ b/synapse/a2a_client.py
@@ -32,6 +32,24 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+
+def _resolve_polling_endpoint(
+    sender_task_id: str | None,
+    sender_info: dict[str, str] | None,
+    target_endpoint: str,
+    target_uds_path: str | None,
+    target_task_id: str,
+) -> tuple[str, str | None, str]:
+    """Return the endpoint, UDS path, and task ID to poll for wait mode."""
+    if sender_task_id and sender_info:
+        sender_endpoint = sender_info.get("sender_endpoint")
+        sender_uds_path = sender_info.get("sender_uds_path")
+        if sender_endpoint:
+            return sender_endpoint, sender_uds_path, sender_task_id
+
+    return target_endpoint, target_uds_path, target_task_id
+
+
 # ============================================================
 # Data Classes
 # ============================================================
@@ -507,40 +525,28 @@ class A2AClient:
             task = A2ATask.from_dict(task_data)
 
             if wait_for_completion and response_mode == "wait":
-                if sender_task_id:
-                    # Poll SENDER's server for the sender_task_id (where reply will arrive)
-                    # not the target's server
-                    sender_endpoint = (
-                        sender_info.get("sender_endpoint") if sender_info else None
-                    )
-                    sender_uds = (
-                        sender_info.get("sender_uds_path") if sender_info else None
-                    )
-                    if sender_endpoint:
-                        completed_task = self._wait_for_local_completion(
-                            sender_endpoint,
-                            sender_task_id,
-                            timeout,
-                            uds_path=sender_uds if sender_uds else None,
-                        )
-                        if completed_task is not None:
-                            task = completed_task
+                poll_endpoint, poll_uds_path, poll_task_id = _resolve_polling_endpoint(
+                    sender_task_id,
+                    sender_info,
+                    endpoint,
+                    uds_path,
+                    task.id,
+                )
+                completed_task = self._wait_for_local_completion(
+                    poll_endpoint,
+                    poll_task_id,
+                    timeout,
+                    uds_path=poll_uds_path,
+                )
+                if completed_task is not None:
+                    task = completed_task
                 else:
-                    # No sender server (e.g. workflow subprocess).
-                    # Fall back to polling the TARGET's task directly.
-                    logger.debug(
-                        "No sender_task_id; polling target task %s at %s",
-                        task.id,
-                        endpoint,
+                    logger.warning(
+                        "wait_for_completion=True but polling timed out at "
+                        "%s/tasks/%s; returning unfinished task",
+                        poll_endpoint,
+                        poll_task_id,
                     )
-                    completed_task = self._wait_for_local_completion(
-                        endpoint,
-                        task.id,
-                        timeout,
-                        uds_path=uds_path,
-                    )
-                    if completed_task is not None:
-                        task = completed_task
 
             # Clear transport status after communication completes
             _update_transport(None)

--- a/tests/test_send_to_local_wait_strategy_515.py
+++ b/tests/test_send_to_local_wait_strategy_515.py
@@ -1,0 +1,184 @@
+"""Regression tests for send_to_local wait polling selection (#515)."""
+
+from unittest.mock import patch
+
+from synapse.a2a_client import A2AClient, A2ATask
+
+
+class DummyResponse:
+    def __init__(self, payload: dict):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        return None
+
+
+def _task_payload(task_id: str, status: str = "working") -> dict:
+    return {"task": {"id": task_id, "status": status, "artifacts": []}}
+
+
+def _completed_task(task_id: str = "completed-task") -> A2ATask:
+    return A2ATask(id=task_id, status="completed", artifacts=[])
+
+
+def test_polls_sender_when_sender_task_and_endpoint_present():
+    client = A2AClient()
+    sender_info = {
+        "sender_endpoint": "http://localhost:8100",
+        "sender_uds_path": "/tmp/sender.sock",
+    }
+
+    with (
+        patch("synapse.a2a_client.Path.exists", return_value=False),
+        patch("synapse.a2a_client.requests.post") as mock_post,
+        patch.object(
+            client,
+            "_wait_for_local_completion",
+            return_value=_completed_task("sender-task"),
+        ) as mock_wait,
+    ):
+        mock_post.side_effect = [
+            DummyResponse(_task_payload("sender-task")),
+            DummyResponse(_task_payload("target-task")),
+        ]
+
+        task = client.send_to_local(
+            endpoint="http://localhost:8124",
+            message="hello",
+            wait_for_completion=True,
+            response_mode="wait",
+            sender_info=sender_info,
+        )
+
+    assert task is not None
+    assert task.id == "sender-task"
+    mock_wait.assert_called_once_with(
+        "http://localhost:8100",
+        "sender-task",
+        60,
+        uds_path="/tmp/sender.sock",
+    )
+
+
+def test_polls_target_when_sender_endpoint_missing():
+    client = A2AClient()
+    sender_info = {
+        "sender_endpoint": "http://localhost:8100",
+        "sender_uds_path": "/tmp/sender.sock",
+    }
+
+    def post_side_effect(url, json=None, timeout=None):
+        if url == "http://localhost:8100/tasks/create":
+            sender_info["sender_endpoint"] = None
+            return DummyResponse(_task_payload("sender-task"))
+        return DummyResponse(_task_payload("target-task"))
+
+    with (
+        patch("synapse.a2a_client.Path.exists", return_value=False),
+        patch("synapse.a2a_client.requests.post", side_effect=post_side_effect),
+        patch.object(
+            client,
+            "_wait_for_local_completion",
+            return_value=_completed_task("target-task"),
+        ) as mock_wait,
+    ):
+        task = client.send_to_local(
+            endpoint="http://localhost:8124",
+            message="hello",
+            wait_for_completion=True,
+            response_mode="wait",
+            sender_info=sender_info,
+            uds_path="/tmp/target.sock",
+        )
+
+    assert task is not None
+    assert task.id == "target-task"
+    mock_wait.assert_called_once_with(
+        "http://localhost:8124",
+        "target-task",
+        60,
+        uds_path="/tmp/target.sock",
+    )
+
+
+def test_polls_target_when_no_sender_task_id():
+    client = A2AClient()
+
+    with (
+        patch("synapse.a2a_client.requests.post") as mock_post,
+        patch.object(
+            client,
+            "_wait_for_local_completion",
+            return_value=_completed_task("target-task"),
+        ) as mock_wait,
+    ):
+        mock_post.return_value = DummyResponse(_task_payload("target-task"))
+
+        task = client.send_to_local(
+            endpoint="http://localhost:8124",
+            message="hello",
+            wait_for_completion=True,
+            response_mode="wait",
+            sender_info=None,
+        )
+
+    assert task is not None
+    assert task.id == "target-task"
+    mock_wait.assert_called_once_with(
+        "http://localhost:8124",
+        "target-task",
+        60,
+        uds_path=None,
+    )
+
+
+def test_skip_polling_when_wait_disabled():
+    client = A2AClient()
+
+    with (
+        patch("synapse.a2a_client.requests.post") as mock_post,
+        patch.object(client, "_wait_for_local_completion") as mock_wait,
+    ):
+        mock_post.return_value = DummyResponse(_task_payload("target-task"))
+
+        task = client.send_to_local(
+            endpoint="http://localhost:8124",
+            message="hello",
+            wait_for_completion=False,
+            response_mode="wait",
+        )
+
+    assert task is not None
+    assert task.id == "target-task"
+    mock_wait.assert_not_called()
+
+
+def test_warning_logged_on_polling_timeout():
+    client = A2AClient()
+
+    with (
+        patch("synapse.a2a_client.requests.post") as mock_post,
+        patch.object(client, "_wait_for_local_completion", return_value=None),
+        patch("synapse.a2a_client.logger.warning") as mock_warning,
+    ):
+        mock_post.return_value = DummyResponse(_task_payload("target-task"))
+
+        task = client.send_to_local(
+            endpoint="http://localhost:8124",
+            message="hello",
+            wait_for_completion=True,
+            response_mode="wait",
+            timeout=3,
+        )
+
+    assert task is not None
+    assert task.id == "target-task"
+    mock_warning.assert_called_once_with(
+        "wait_for_completion=True but polling timed out at %s/tasks/%s; "
+        "returning unfinished task",
+        "http://localhost:8124",
+        "target-task",
+    )


### PR DESCRIPTION
## Summary

- **Phase 2** of the state-machine cleanup that emerged from \"コードが複雑になっている気がする\". Phase 1 (PR #671 + PR #675) settled status constants; Phase 2 fixes the silent-skip in \`send_to_local()\` wait polling
- Replaced a nested if/else that mixed sender-polling and target-polling strategies (15 lines of branching) with a single \`_resolve_polling_endpoint()\` helper + one polling call (4 lines)
- Added a \`logger.warning\` when polling actually executes but returns None (timeout), so callers no longer get silently-incomplete tasks back
- **Strategy pattern from the issue body explicitly rejected** in favor of flatten + helper. Reasoning in PR body below

## Linked Issues

- Closes #515
- Refs #513 (PR that added the target-polling fallback this PR formalizes)
- Refs #671, #675 (Phase 1 of the same cleanup)

## Why not Strategy pattern (despite the issue's proposal)

Issue #515 proposed \`SenderPollingStrategy\` / \`TargetPollingStrategy\` classes. Looking at the actual code:

\`\`\`python
# Both branches called the SAME function:
self._wait_for_local_completion(endpoint, task_id, timeout, uds_path=...)
# Only endpoint/task_id selection differed.
\`\`\`

A Strategy class makes sense when the **algorithm** differs. Here only the **input selection** differs. Strategy would have introduced two classes-without-state to wrap what is now 13 lines of pure-function endpoint resolution. Per \`feedback_no_silent_scope_cuts.md\` (note in the brief), this scope reduction was raised explicitly with the user before implementation, not silently cut.

## Changes

- \`synapse/a2a_client.py\`:
  - Added \`_resolve_polling_endpoint()\` module-level helper (13 lines, pure function)
  - Flattened wait branch in \`send_to_local()\` from 35 lines to 18 lines
  - \`logger.warning\` on polling timeout (was silent)
- \`tests/test_send_to_local_wait_strategy_515.py\`: 5 regression tests covering
  - sender polling when sender_task_id + sender_endpoint both present
  - target fallback when sender_endpoint is missing (the silent-skip case)
  - target fallback when sender_task_id was never created (workflow subprocess case)
  - wait-disabled no-op (regression net)
  - warning logged on polling timeout
- \`CHANGELOG.md\`: \`[Unreleased] ### Refactored\` entry

Total: +223 / -32

## Test plan

- [x] **Red phase**: 2 failed / 3 passed — silent skip + missing warning fail as expected; the 3 already-correct paths pass as a regression net
- [x] \`uv run pytest tests/test_send_to_local_wait_strategy_515.py -q\` → 5 passed
- [x] \`uv run pytest tests/test_a2a_client.py tests/test_send*.py -q\` → 155 passed (no regression in adjacent suites)
- [x] \`uv run mypy synapse/\` → no issues, 116 source files
- [x] Pre-commit hooks: ruff (legacy alias) + ruff format + mypy all passed
- [x] Public API unchanged: \`send_to_local()\` signature (16 params) and \`_wait_for_local_completion\` both untouched — 8 call sites work without change

## Refactor cadence

- Phase 1 (✅ shipped: PR #671 + PR #675): status constants migration
- **Phase 2 (this PR)**: \`send_to_local()\` flatten + silent-skip fix
- Phase 3 (deferred to 0.32.0 release lull): \`cli.py\` (5179 lines) and \`a2a_compat.py\` (2916 lines) module splits — multi-PR series

🤖 Generated with [Claude Code](https://claude.com/claude-code)