### PR TITLE
fix(long_message): strip PTY control bytes from long-message files (#677, Bug C route C)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Refactored
 
 - `send_to_local()` wait mode now resolves a single polling endpoint before waiting, falling back to target polling instead of silently skipping when sender polling is unavailable (#515).
-- All status WRITE sites in `synapse/cli.py` and `synapse/controller.py` now use the `synapse.status` constants instead of string literals (`"PROCESSING"`, `"DONE"`, `"SHUTTING_DOWN"`, `"WAITING"`, `"READY"`). Read-only status comparisons in `tools/a2a.py` and `commands/*.py` are intentionally left as literals; expanding scope there would not improve write-side state machine review.
 - All status WRITE sites in `synapse/cli.py` and `synapse/controller.py` now use the `synapse.status` constants instead of string literals (`"PROCESSING"`, `"DONE"`, `"SHUTTING_DOWN"`, `"WAITING"`, `"READY"`).
 - Status READ-only comparisons in `synapse/tools/a2a.py`, `synapse/commands/cleanup.py`, and `synapse/commands/list.py` now use the same `synapse.status` constants. Combined with the WRITE-side migration above, the status state machine no longer mixes literals and constants — the entire surface is greppable through the constants module.
 
 ### Fixed
 
+- `LongMessageStore.store_message()` now strips PTY control bytes before persisting content, preventing raw ANSI escapes and status-bar fragments from leaking into A2A long-message files (`/var/folders/.../synapse-a2a/messages/*.txt`). Symmetric to PR #663 (Bug C route A) and PR #668 (Bug C route B); this is route C of the same family (#677).
 - Artifact text formatting now strips PTY control bytes before persisting or returning A2A output, preventing raw terminal redraw content from leaking into `recent_messages` (#664).
 
 ## [0.31.0] - 2026-04-28

--- a/synapse/long_message.py
+++ b/synapse/long_message.py
@@ -15,6 +15,7 @@ import tempfile
 import time
 from pathlib import Path
 
+from synapse._pty_sanitize import strip_control_bytes
 from synapse.utils import build_sender_prefix
 
 logger = logging.getLogger(__name__)
@@ -84,6 +85,11 @@ class LongMessageStore:
         Uses atomic write (temp file + rename) to ensure file integrity.
         The file is named with the task_id for easy identification.
 
+        Content is passed through ``strip_control_bytes`` before persisting
+        so PTY scrape residue (ANSI escapes, status-bar fragments,
+        partial-render bytes) cannot leak into the long-message file path
+        — symmetric to PR #663/#668 (Bug C routes A/B). See issue #677.
+
         Args:
             task_id: The task ID associated with this message.
             content: The message content to store.
@@ -91,6 +97,8 @@ class LongMessageStore:
         Returns:
             Path to the created file.
         """
+        content = strip_control_bytes(content)
+
         # Generate unique filename using task_id and timestamp
         timestamp = int(time.time() * 1000)
         filename = f"{task_id[:8]}-{timestamp}.txt"

--- a/tests/test_long_message_sanitize_677.py
+++ b/tests/test_long_message_sanitize_677.py
@@ -1,0 +1,86 @@
+"""Regression tests for long-message file sanitization (#677).
+
+Bug C route C: ``LongMessageStore.store_message`` was writing raw content
+to ``/var/folders/.../synapse-a2a/messages/<id>-<ts>.txt`` without any
+sanitization, so PTY scrape residue (ANSI escapes, status-bar fragments,
+partial-render bytes) could leak into the long-message file path.
+
+PRs #663 (route A) and #668 (route B) already apply ``strip_control_bytes``
+at the parent placeholder and artifact persistence boundaries. This is
+the symmetric fix at the long-message file boundary.
+"""
+
+from pathlib import Path
+
+from synapse.long_message import LongMessageStore
+
+
+def _store(tmp_path: Path) -> LongMessageStore:
+    return LongMessageStore(message_dir=tmp_path / "messages", threshold=10)
+
+
+def test_strips_csi_escape(tmp_path: Path) -> None:
+    """ANSI CSI escapes (\\x1b[...m) must not appear in the stored file."""
+    store = _store(tmp_path)
+    file_path = store.store_message("task-001", "hello\x1b[31mred\x1b[0m world")
+
+    written = file_path.read_text(encoding="utf-8")
+    assert "\x1b" not in written
+    assert written == "hellored world"
+
+
+def test_strips_status_bar_residue(tmp_path: Path) -> None:
+    """Codex status-bar / autosuggestion bytes must not survive."""
+    store = _store(tmp_path)
+    # Real-world residue observed in 2026-04-29 session: leading SGR fragment
+    # plus a ``Ptmux;\\`` envelope wrapping a status-bar suggestion.
+    raw = (
+        "8;49mg\x07orking5\n"
+        "Real reply content here.\n"
+        "\x1bPtmux;\\ \xe2\x80\xba Run /review"
+    )
+    file_path = store.store_message("task-002", raw)
+
+    written = file_path.read_text(encoding="utf-8")
+    assert "\x07" not in written  # BEL stripped
+    assert "\x1b" not in written  # ESC stripped
+    assert "Real reply content here." in written
+
+
+def test_preserves_normal_text(tmp_path: Path) -> None:
+    """Plain text with newlines, tabs, and multibyte chars survives."""
+    store = _store(tmp_path)
+    raw = "multi\nline\ttext\n日本語の説明\n"
+    file_path = store.store_message("task-003", raw)
+
+    written = file_path.read_text(encoding="utf-8")
+    assert written == raw
+
+
+def test_strips_c0_control_bytes(tmp_path: Path) -> None:
+    """C0 control bytes (NUL, BEL, etc) are stripped except TAB/LF."""
+    store = _store(tmp_path)
+    raw = "before\x00null\x07bell\tafter\nline2"
+    file_path = store.store_message("task-004", raw)
+
+    written = file_path.read_text(encoding="utf-8")
+    assert "\x00" not in written
+    assert "\x07" not in written
+    assert "\t" in written  # TAB preserved
+    assert "\n" in written  # LF preserved
+    assert written == "beforenullbell\tafter\nline2"
+
+
+def test_threshold_check_uses_original_length(tmp_path: Path) -> None:
+    """needs_file_storage checks pre-sanitization length; sanitization
+    happens only inside store_message. This test guards against accidentally
+    short-circuiting needs_file_storage on already-stripped content (which
+    would change the file-vs-inline decision)."""
+    store = _store(tmp_path)
+    raw_with_ansi = "x\x1b[31m" * 30  # ~150 chars; sanitized would be much shorter
+    assert store.needs_file_storage(raw_with_ansi) is True
+
+    file_path = store.store_message("task-005", raw_with_ansi)
+    written = file_path.read_text(encoding="utf-8")
+    assert "\x1b" not in written
+    assert written == "x" * 30


### PR DESCRIPTION
## Summary

- Closes Bug C **route C** — the third and final route of the same family that PR #663 (route A: parent placeholder) and PR #668 (route B: artifact path) already fixed
- Applies existing \`strip_control_bytes\` (from \`synapse._pty_sanitize\`) at \`LongMessageStore.store_message()\` entry point — same one-liner pattern as the previous routes
- Bonus: drops a CHANGELOG.md duplicate \`### Refactored\` line that landed in the PR #671/#675 merge race (the auto-resolve workflow kept both versions; one was rendered false by the read-side migration)

## Linked Issues

- Closes #677

## Why

Observed in the 2026-04-29 dev session: a codex agent's reply file at \`/var/folders/.../synapse-a2a/messages/9847de5e-1777426589952.txt\` contained \`8;49mg•rking•king•ingngg5\` (ANSI SGR fragment + partial-render of \"working\") and \`Ptmux;\\ › Run /review on my current changes   gpt-5.5 medium · /Volumes/...\` (codex status-bar / autosuggestion). Neither of these are real reply content; both are PTY scrape leakage.

Tracing the path: \`LongMessageStore.store_message()\` was using \`temp_path.write_text(content, encoding=\"utf-8\")\` with no sanitization. The two previous routes had the same shape:

| Route | Boundary | Fix PR |
|---|---|---|
| A (parent placeholder text) | \`output_text\` write in parent-side send | #663 |
| B (artifact path) | \`_format_artifact_text\` in \`a2a_compat.py\` | #668 |
| **C (long-message file)** | **\`LongMessageStore.store_message()\`** | **this PR** |

Same fix pattern — apply \`strip_control_bytes\` at the boundary. The \`feedback_pty_residue_routes.md\` memory now documents these three routes for future triage.

## Files

- \`synapse/long_message.py\` — import \`strip_control_bytes\`; apply at top of \`store_message()\` with a 3-line WHY comment pointing at #663/#668/#677
- \`tests/test_long_message_sanitize_677.py\` — 5 regression cases (CSI escape, status-bar residue with the actual session payload, plain text preserved, C0 control bytes including BEL/NUL, threshold check uses pre-sanitization length so the file-vs-inline decision doesn't shift)
- \`CHANGELOG.md\` — \`[Unreleased] ### Fixed\` entry; remove duplicate \`### Refactored\` line that became false after PR #675

## Test plan

- [x] \`uv run pytest tests/test_long_message_sanitize_677.py -q\` → 5 passed
- [x] \`uv run pytest tests/test_long_message.py tests/test_long_message_sanitize_677.py -q\` → 33 passed (no regression in existing suite)
- [x] \`uv run mypy synapse/\` → no issues, 116 source files
- [x] Pre-commit hooks: ruff (legacy alias) + ruff format + mypy all passed

## Test design note

\`test_threshold_check_uses_original_length\` exists specifically to guard against an easy mistake: applying \`strip_control_bytes\` inside \`needs_file_storage\` would change the file-vs-inline decision (sanitized content might be under the threshold even when the original was over it). The fix is correctly placed inside \`store_message\` only — the decision boundary stays unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)