### PR TITLE
refactor: status state machine literals — final pre-existing cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `send_to_local()` wait mode now resolves a single polling endpoint before waiting, falling back to target polling instead of silently skipping when sender polling is unavailable (#515).
 - All status WRITE sites in `synapse/cli.py` and `synapse/controller.py` now use the `synapse.status` constants instead of string literals (`"PROCESSING"`, `"DONE"`, `"SHUTTING_DOWN"`, `"WAITING"`, `"READY"`).
 - Status READ-only comparisons in `synapse/tools/a2a.py`, `synapse/commands/cleanup.py`, and `synapse/commands/list.py` now use the same `synapse.status` constants. Combined with the WRITE-side migration above, the status state machine no longer mixes literals and constants — the entire surface is greppable through the constants module.
+- Remaining pre-existing status string literals in `synapse/server.py`, `synapse/registry.py` (register() default arg), `synapse/terminal_writer.py`, `synapse/idle_detector.py`, and `synapse/tools/a2a_helpers.py` now use the same `synapse.status` constants. After this PR, the only remaining status literal in `synapse/` is `error_detector.py:35` which uses `RATE_LIMITED` as an error-category label (a separate namespace from agent registry status, intentionally not coupled).
 
 ### Fixed
 

--- a/synapse/idle_detector.py
+++ b/synapse/idle_detector.py
@@ -10,7 +10,14 @@ from typing import Any
 
 from synapse.config import WAITING_EXPIRY_SECONDS
 from synapse.pty_renderer import PtyRenderer
-from synapse.status import DONE_TIMEOUT_SECONDS
+from synapse.status import (
+    DONE,
+    DONE_TIMEOUT_SECONDS,
+    PROCESSING,
+    READY,
+    SHUTTING_DOWN,
+    WAITING,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -198,27 +205,27 @@ class IdleDetector:
         task_protection_active: bool,
         has_file_locks: bool,
     ) -> StatusDecision:
-        if current_status == "SHUTTING_DOWN":
-            return StatusDecision("SHUTTING_DOWN")
+        if current_status == SHUTTING_DOWN:
+            return StatusDecision(SHUTTING_DOWN)
 
         if is_waiting:
-            base_status = "WAITING"
+            base_status = WAITING
         elif is_idle:
-            base_status = "READY"
+            base_status = READY
         else:
-            base_status = "PROCESSING"
+            base_status = PROCESSING
 
-        if base_status == "READY" and (task_protection_active or has_file_locks):
-            base_status = "PROCESSING"
+        if base_status == READY and (task_protection_active or has_file_locks):
+            base_status = PROCESSING
 
-        if current_status != "DONE":
+        if current_status != DONE:
             return StatusDecision(base_status)
 
         if not is_idle and not is_waiting:
-            return StatusDecision("PROCESSING", clear_done_time=True)
+            return StatusDecision(PROCESSING, clear_done_time=True)
 
         if is_waiting:
-            return StatusDecision("WAITING", clear_done_time=True)
+            return StatusDecision(WAITING, clear_done_time=True)
 
         done_timeout_expired = done_time and (
             time.time() - done_time >= DONE_TIMEOUT_SECONDS
@@ -226,7 +233,7 @@ class IdleDetector:
         if done_timeout_expired:
             return StatusDecision(base_status, clear_done_time=True)
 
-        return StatusDecision("DONE")
+        return StatusDecision(DONE)
 
     def check_waiting_state(
         self,

--- a/synapse/registry.py
+++ b/synapse/registry.py
@@ -11,6 +11,7 @@ from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from pathlib import Path
 
+from synapse.status import PROCESSING
 from synapse.utils import is_role_file_reference, resolve_role_value
 
 logger = logging.getLogger(__name__)
@@ -182,7 +183,7 @@ class AgentRegistry:
         agent_id: str,
         agent_type: str,
         port: int,
-        status: str = "PROCESSING",
+        status: str = PROCESSING,
         tty_device: str | None = None,
         name: str | None = None,
         role: str | None = None,

--- a/synapse/server.py
+++ b/synapse/server.py
@@ -15,6 +15,7 @@ from synapse.a2a_compat import create_a2a_router
 from synapse.controller import TerminalController
 from synapse.logging_config import setup_logging
 from synapse.registry import AgentRegistry, resolve_uds_path
+from synapse.status import PROCESSING
 from synapse.utils import resolve_command_path
 
 # Global controller and registry instances (for standalone mode)
@@ -203,7 +204,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     controller.start()
 
     register_kwargs: dict[str, Any] = {
-        "status": "PROCESSING",
+        "status": PROCESSING,
         "spawned_by": os.environ.get("SYNAPSE_SPAWNED_BY") or None,
     }
     renderer_available = getattr(controller, "renderer_available", None)

--- a/synapse/terminal_writer.py
+++ b/synapse/terminal_writer.py
@@ -10,6 +10,8 @@ from collections.abc import Callable
 from re import Pattern
 from typing import Any
 
+from synapse.status import DONE, PROCESSING, READY, WAITING
+
 
 class TerminalWriter:
     """Handle PTY input injection and submit confirmation."""
@@ -262,7 +264,7 @@ class TerminalWriter:
 
         with self._status_lock:
             previous_status = self.owner.status
-            self.owner.status = "PROCESSING"
+            self.owner.status = PROCESSING
 
         with self._write_lock:
             try:
@@ -375,11 +377,11 @@ class TerminalWriter:
             pending = self.owner._has_copilot_pending_placeholder(current_tail)
 
         current_status = self.owner.status
-        if initial_status == "READY" and current_status != "READY":
+        if initial_status == READY and current_status != READY:
             return not pending
-        if current_status in {"PROCESSING", "DONE"}:
+        if current_status in {PROCESSING, DONE}:
             return not pending
-        if current_status == "WAITING" and initial_status != "WAITING":
+        if current_status == WAITING and initial_status != WAITING:
             return not pending
 
         if not markers:

--- a/synapse/tools/a2a_helpers.py
+++ b/synapse/tools/a2a_helpers.py
@@ -12,6 +12,7 @@ from synapse.history import HistoryManager
 from synapse.paths import get_history_db_path
 from synapse.registry import AgentRegistry
 from synapse.settings import get_settings
+from synapse.status import READY
 
 logger = logging.getLogger(__name__)
 _SELF_TARGET_ERROR = "Cannot send to self (use target: self in workflows)"
@@ -251,7 +252,7 @@ def _pick_best_agent(matches: list[dict]) -> dict:
 
     def _sort_key(a: dict) -> tuple[int, int]:
         status = a.get("status") or ""
-        ready = 0 if status.upper() == "READY" else 1
+        ready = 0 if status.upper() == READY else 1
         port = a.get("port") or 99999
         return (ready, int(port))
 


### PR DESCRIPTION
## Summary

Final completion of the status string literal migration started in PR #671 (write side in cli.py/controller.py) and PR #675 (read side in tools/a2a.py + commands/cleanup.py + commands/list.py). This PR migrates the remaining pre-existing literals — these were the ones intentionally left out of the earlier scoped PRs as \"existing code, beyond the PR scope\" and surfaced by the post-impl simplify sweep (#679 PR body's \"Findings intentionally NOT applied\" section).

After this lands, the only remaining status literal in \`synapse/\` is \`error_detector.py:35\` (\`\"RATE_LIMITED\"\`) which uses the value as an error-category label — a separate namespace from agent registry status, intentionally not coupled.

## Linked Issues

- Refs #671 (write-side migration)
- Refs #675 (read-side migration)
- Refs #679 (sweep that surfaced these as scope-outside)

(No \`Closes\` — this is a follow-up refactor, not a bug fix.)

## Files migrated (5 files, ~17 sites)

| File | Sites | Notes |
|------|-------|-------|
| \`synapse/server.py:206\` | 1 | \`register_kwargs[\"status\"]\` default for registered agents |
| \`synapse/registry.py:185\` | 1 | \`register()\` default arg \`status: str = PROCESSING\` |
| \`synapse/terminal_writer.py\` | 4 | submit-confirmation logic (L265 write, L378-382 reads) |
| \`synapse/idle_detector.py\` | 10 | \`determine_new_status\` decision tree (SHUTTING_DOWN/WAITING/READY/PROCESSING/DONE) |
| \`synapse/tools/a2a_helpers.py:254\` | 1 | sort-key \`READY\` comparison |

Each file gains a single \`from synapse.status import …\` line; \`idle_detector.py\` extends its existing \`DONE_TIMEOUT_SECONDS\` import to a multi-symbol block.

## Test plan

- [x] \`uv run pytest tests/test_idle_detector.py tests/test_registry.py tests/test_registry_extended.py tests/test_server.py tests/test_server_extended.py tests/test_controller.py tests/test_controller_registry_sync.py -q\` → 202 passed (1 flaky failure was test-isolation related, not the refactor — single-file run of test_controller.py is 113/113 green)
- [x] \`uv run mypy synapse/\` → no issues, 116 source files
- [x] Pre-commit hooks: ruff (legacy alias) + ruff format + mypy all passed

## Skipped (still intentional)

- \`synapse/error_detector.py:35\`: \`(r\"rate limit|too many requests\", \"RATE_LIMITED\", \"Rate limit exceeded\")\` — \`RATE_LIMITED\` here is an **error category label** (output of regex matching), not the agent registry status. The two namespaces happen to share the same value but their coupling is conceptual, not structural. Converting to \`status.RATE_LIMITED\` would falsely suggest the data table imports state-machine semantics; it doesn't. Leave as a literal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **リファクタリング**
  * ステータス定義の一元化により、コード内のハードコードされたステータス文字列を共通定数に統一しました。複数のモジュール間でのステータス処理の一貫性を改善しています。

* **その他**
  * 内部的なコード品質の向上で、ユーザー向け機能への影響はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->