### PR TITLE
refactor(cli): decompose _add_message_source_flags into narrower helpers (#681)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Refactored
 
+- Split message source argparse flags into narrow text input, task-file, and attachment helpers while preserving the legacy bundle for callers that need all four flags (#681).
 - `send_to_local()` wait mode now resolves a single polling endpoint before waiting, falling back to target polling instead of silently skipping when sender polling is unavailable (#515).
 - All status WRITE sites in `synapse/cli.py` and `synapse/controller.py` now use the `synapse.status` constants instead of string literals (`"PROCESSING"`, `"DONE"`, `"SHUTTING_DOWN"`, `"WAITING"`, `"READY"`).
 - Status READ-only comparisons in `synapse/tools/a2a.py`, `synapse/commands/cleanup.py`, and `synapse/commands/list.py` now use the same `synapse.status` constants. Combined with the WRITE-side migration above, the status state machine no longer mixes literals and constants — the entire surface is greppable through the constants module.

--- a/synapse/cli.py
+++ b/synapse/cli.py
@@ -118,6 +118,7 @@ from synapse.port_manager import (
 )
 from synapse.registry import AgentRegistry, NameConflictError, is_port_open
 from synapse.status import PROCESSING, SHUTTING_DOWN
+from synapse.tools.a2a_helpers import _add_attachments_flag, _add_text_input_flags
 from synapse.utils import resolve_command_path
 
 # Known profiles (for shortcut detection)
@@ -3343,31 +3344,14 @@ Priority levels:
     )
     p_send.add_argument("target", help="Target agent (claude, codex, gemini)")
     p_send.add_argument("message", nargs="?", default=None, help="Message to send")
-    p_send.add_argument(
-        "--message-file",
-        "-F",
-        dest="message_file",
-        help="Read message from file (use '-' for stdin)",
-    )
-    p_send.add_argument(
-        "--stdin",
-        action="store_true",
-        default=False,
-        help="Read message from stdin",
-    )
+    _add_text_input_flags(p_send)
     p_send.add_argument(
         "--priority", "-p", type=int, default=3, help="Priority level 1-5 (default: 3)"
     )
     p_send.add_argument(
         "--from", "-f", dest="sender", help="Sender agent ID (for reply identification)"
     )
-    p_send.add_argument(
-        "--attach",
-        "-a",
-        action="append",
-        dest="attach",
-        help="Attach a file to the message (repeatable)",
-    )
+    _add_attachments_flag(p_send)
     _add_response_mode_flags(p_send)
     p_send.add_argument(
         "--force",
@@ -3414,31 +3398,14 @@ Priority levels:
     p_broadcast.add_argument(
         "message", nargs="?", default=None, help="Message to broadcast"
     )
-    p_broadcast.add_argument(
-        "--message-file",
-        "-F",
-        dest="message_file",
-        help="Read message from file (use '-' for stdin)",
-    )
-    p_broadcast.add_argument(
-        "--stdin",
-        action="store_true",
-        default=False,
-        help="Read message from stdin",
-    )
+    _add_text_input_flags(p_broadcast)
     p_broadcast.add_argument(
         "--priority", "-p", type=int, default=1, help="Priority level 1-5 (default: 1)"
     )
     p_broadcast.add_argument(
         "--from", "-f", dest="sender", help="Sender agent ID (for reply identification)"
     )
-    p_broadcast.add_argument(
-        "--attach",
-        "-a",
-        action="append",
-        dest="attach",
-        help="Attach a file to the message (repeatable)",
-    )
+    _add_attachments_flag(p_broadcast)
     _add_response_mode_flags(p_broadcast)
     p_broadcast.set_defaults(func=cmd_broadcast)
 
@@ -3470,18 +3437,7 @@ Priority levels:
         default=False,
         help="List available reply targets and exit",
     )
-    p_reply.add_argument(
-        "--message-file",
-        "-F",
-        dest="message_file",
-        help="Read reply message from file (use '-' for stdin)",
-    )
-    p_reply.add_argument(
-        "--stdin",
-        action="store_true",
-        default=False,
-        help="Read reply message from stdin",
-    )
+    _add_text_input_flags(p_reply)
     p_reply.add_argument("message", nargs="?", default="", help="Reply message content")
     p_reply.set_defaults(func=cmd_reply)
 

--- a/synapse/tools/a2a.py
+++ b/synapse/tools/a2a.py
@@ -41,8 +41,10 @@ from synapse.status import (
     WAITING_FOR_INPUT,
 )
 from synapse.tools.a2a_helpers import (  # noqa: F401 -- re-export
+    _add_attachments_flag,
     _add_message_source_flags,
     _add_response_mode_flags,
+    _add_text_input_flags,
     _agents_in_current_working_dir,
     _are_worktree_related,
     _artifact_display_text,
@@ -930,7 +932,8 @@ def main() -> None:
     p_send.add_argument(
         "message", nargs="?", default=None, help="Content of the message"
     )
-    _add_message_source_flags(p_send)
+    _add_text_input_flags(p_send)
+    _add_attachments_flag(p_send)
     p_send.add_argument(
         "--force",
         action="store_true",
@@ -966,7 +969,8 @@ def main() -> None:
     p_broadcast.add_argument(
         "message", nargs="?", default=None, help="Content of the message"
     )
-    _add_message_source_flags(p_broadcast)
+    _add_text_input_flags(p_broadcast)
+    _add_attachments_flag(p_broadcast)
 
     # reply command - simplified reply to last message
     p_reply = subparsers.add_parser("reply", help="Reply to the last received message")
@@ -991,18 +995,7 @@ def main() -> None:
         dest="fail",
         help="Send a failed reply with the given reason instead of a normal text reply",
     )
-    p_reply.add_argument(
-        "--message-file",
-        "-F",
-        dest="message_file",
-        help="Read reply message from file (use '-' for stdin)",
-    )
-    p_reply.add_argument(
-        "--stdin",
-        action="store_true",
-        default=False,
-        help="Read reply message from stdin",
-    )
+    _add_text_input_flags(p_reply)
     p_reply.add_argument("message", nargs="?", default="", help="Reply message content")
 
     args = parser.parse_args()

--- a/synapse/tools/a2a_helpers.py
+++ b/synapse/tools/a2a_helpers.py
@@ -640,8 +640,8 @@ def _add_response_mode_flags(parser: argparse.ArgumentParser) -> None:
     )
 
 
-def _add_message_source_flags(parser: argparse.ArgumentParser) -> None:
-    """Add --message-file, --stdin, and --attach flags to a parser."""
+def _add_text_input_flags(parser: argparse.ArgumentParser) -> None:
+    """Add universal text input flags to a parser."""
     parser.add_argument(
         "--message-file",
         "-F",
@@ -649,17 +649,25 @@ def _add_message_source_flags(parser: argparse.ArgumentParser) -> None:
         help="Read message from file (use '-' for stdin)",
     )
     parser.add_argument(
-        "--task-file",
-        "-T",
-        dest="task_file",
-        help="Read message from task file (use '-' for stdin)",
-    )
-    parser.add_argument(
         "--stdin",
         action="store_true",
         default=False,
         help="Read message from stdin",
     )
+
+
+def _add_task_file_flag(parser: argparse.ArgumentParser) -> None:
+    """Add the spawn-only task file input flag to a parser."""
+    parser.add_argument(
+        "--task-file",
+        "-T",
+        dest="task_file",
+        help="Read message from task file (use '-' for stdin)",
+    )
+
+
+def _add_attachments_flag(parser: argparse.ArgumentParser) -> None:
+    """Add the repeatable attachment flag to a parser."""
     parser.add_argument(
         "--attach",
         "-a",
@@ -667,3 +675,10 @@ def _add_message_source_flags(parser: argparse.ArgumentParser) -> None:
         dest="attach",
         help="Attach a file to the message (repeatable)",
     )
+
+
+def _add_message_source_flags(parser: argparse.ArgumentParser) -> None:
+    """Add the legacy bundle of text, task-file, stdin, and attachment flags."""
+    _add_text_input_flags(parser)
+    _add_task_file_flag(parser)
+    _add_attachments_flag(parser)

--- a/tests/test_message_source_flag_helpers_681.py
+++ b/tests/test_message_source_flag_helpers_681.py
@@ -1,0 +1,83 @@
+"""Regression tests for narrow message source flag helpers (#681)."""
+
+import argparse
+
+import pytest
+
+
+def test_add_text_input_flags_adds_message_file_and_stdin():
+    from synapse.tools.a2a_helpers import _add_text_input_flags
+
+    parser = argparse.ArgumentParser()
+    _add_text_input_flags(parser)
+
+    args = parser.parse_args(["--message-file", "/tmp/a.txt"])
+    assert args.message_file == "/tmp/a.txt"
+
+    args = parser.parse_args(["--stdin"])
+    assert args.stdin is True
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--attach", "x"])
+
+
+def test_add_attachments_flag_adds_attach_only():
+    from synapse.tools.a2a_helpers import _add_attachments_flag
+
+    parser = argparse.ArgumentParser()
+    _add_attachments_flag(parser)
+
+    args = parser.parse_args(["-a", "f1", "-a", "f2"])
+    assert args.attach == ["f1", "f2"]
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--message-file", "/tmp/a.txt"])
+
+
+def test_add_task_file_flag_adds_task_file_only():
+    from synapse.tools.a2a_helpers import _add_task_file_flag
+
+    parser = argparse.ArgumentParser()
+    _add_task_file_flag(parser)
+
+    args = parser.parse_args(["-T", "/tmp/t.md"])
+    assert args.task_file == "/tmp/t.md"
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--message-file", "/tmp/a.txt"])
+
+
+def test_legacy_add_message_source_flags_still_bundles_all_four():
+    from synapse.tools.a2a_helpers import _add_message_source_flags
+
+    parser = argparse.ArgumentParser()
+    _add_message_source_flags(parser)
+
+    args = parser.parse_args(
+        [
+            "--message-file",
+            "/tmp/a.txt",
+            "--task-file",
+            "/tmp/t.md",
+            "--stdin",
+            "--attach",
+            "f1",
+            "--attach",
+            "f2",
+        ]
+    )
+
+    assert args.message_file == "/tmp/a.txt"
+    assert args.task_file == "/tmp/t.md"
+    assert args.stdin is True
+    assert args.attach == ["f1", "f2"]
+
+
+@pytest.mark.parametrize("rejected_flag", ["--attach", "--task-file"])
+def test_p_reply_rejects_attach_and_task_file(rejected_flag, monkeypatch):
+    from synapse.tools import a2a
+
+    monkeypatch.setattr("sys.argv", ["synapse", "reply", rejected_flag, "x"])
+
+    with pytest.raises(SystemExit):
+        a2a.main()


### PR DESCRIPTION
## Summary

PR #674 inlined \`--message-file\` / \`--stdin\` into \`p_reply\` argparse because the existing \`_add_message_source_flags\` helper also bundled \`--task-file\` (spawn-only) and \`--attach\` (send/broadcast-only) — neither of which reply supports. That left **two ~12-line argparse blocks duplicated** across \`cli.py\` and \`tools/a2a.py\`. PR #679's simplify sweep flagged this as scope-outside; this PR is the dedicated follow-up.

The fix decomposes the wide helper into three single-responsibility narrow helpers, with the legacy 4-flag bundle preserved as a thin compose for wide callers (e.g. \`p_spawn\`) so backward-compatible code paths stay byte-equivalent.

## Linked Issues

- Closes #681

## Decomposition

| Helper | Flags | Used by |
|--------|-------|---------|
| \`_add_text_input_flags\` | \`--message-file\` / \`-F\`, \`--stdin\` | send + broadcast + reply (universal text input) |
| \`_add_task_file_flag\` | \`--task-file\` / \`-T\` | spawn (task brief input) |
| \`_add_attachments_flag\` | \`--attach\` / \`-a\` | send + broadcast (file attachments — not reply) |
| \`_add_message_source_flags\` (legacy) | composes all three | wide callers e.g. p_spawn that want the original 4-flag bundle |

## Call site changes

- \`p_send\` / \`p_broadcast\`: \`_add_text_input_flags\` + \`_add_attachments_flag\`
- \`p_reply\` (cli.py + tools/a2a.py): \`_add_text_input_flags\` only (correctly rejects \`--attach\` / \`--task-file\` like before)
- \`p_spawn\` (and any other wide bundle caller): unchanged — still uses \`_add_message_source_flags\`

## Test plan

Implemented with codex (synapse-codex-8121) using the parent's brief at \`/tmp/issue681-task.md\`. Test-First protocol confirmed:

- [x] **Red phase**: 3 import errors (helpers not yet defined) — expected
- [x] **Focused**: \`uv run pytest tests/test_message_source_flag_helpers_681.py -q\` → 6 passed
- [x] **Adjacent regression**: \`uv run pytest tests/test_send_message_file.py tests/test_reply_flag_parity_673.py tests/test_message_source_flag_helpers_681.py -q\` → 39 passed
- [x] **Type check**: \`uv run mypy synapse/\` → no issues, 116 source files
- [x] **Pre-commit hooks**: ruff (legacy alias) + ruff format + mypy all passed

## Net diff

\`+120 / -72\` (effective \`-35\` lines after the duplicated argparse blocks are extracted to helpers). \`cli.py\` shrinks by ~50 lines.

## Files

- \`synapse/tools/a2a_helpers.py\` — three narrow helpers + legacy compose
- \`synapse/cli.py\` — p_send / p_broadcast / p_reply migrated to narrow helpers
- \`synapse/tools/a2a.py\` — same migration on the tool-level argparse
- \`tests/test_message_source_flag_helpers_681.py\` — 6 cases covering each helper's flag set, the legacy 4-flag bundle, and reply parser rejecting \`--attach\`/\`--task-file\`
- \`CHANGELOG.md\` — \`[Unreleased] ### Refactored\` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **リファクタリング**
  * CLI メッセージ入力フラグ処理を改善。テキスト入力、タスクファイル、添付ファイルの処理を専用ヘルパーに分割し、コード保守性を向上。既存の互換性は保持されています。

* **テスト**
  * メッセージ ソース フラグ ハンドリングの回帰テストを追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->