### PR TITLE
docs: docstring polish — status constants migration + sanitiser scope (#683)

### DIFF
--- a/synapse/_pty_sanitize.py
+++ b/synapse/_pty_sanitize.py
@@ -1,11 +1,13 @@
-"""PTY context sanitisation helpers for permission notifications.
+"""PTY context sanitisation helpers.
 
-Permission notifications embed a tail of the agent's PTY buffer so the
-sender can decide whether to approve. The raw buffer can contain CSI
-escapes, line-overwrite fragments, C0/C1 control bytes, and
-mid-sequence truncation when `[-512:]` bisects a CSI. See issues #582
-and #586. This module strips those byte classes so downstream renders
-are readable and safe to persist.
+Originally introduced for permission notifications (#582/#586) which
+embed a tail of the agent's PTY buffer. The same sanitisation is now
+also applied at the A2A artifact persistence boundary (#664/PR #668)
+and the long-message file persistence boundary (#677/PR #678) so PTY
+scrape residue (CSI escapes, line-overwrite fragments, C0/C1 control
+bytes, mid-sequence truncation when `[-512:]` bisects a CSI) cannot
+leak into either history or A2A message files. Downstream renders
+remain readable and safe to persist.
 """
 
 from __future__ import annotations

--- a/synapse/long_message.py
+++ b/synapse/long_message.py
@@ -39,6 +39,10 @@ class LongMessageStore:
         message_dir: Directory for storing message files.
         threshold: Character count threshold for file storage.
         ttl: Time-to-live in seconds for stored files.
+        _last_cleanup_ts: Unix timestamp of the most recent
+            cleanup_expired() invocation; used by maybe_cleanup_expired()
+            to throttle to at most one cleanup per DEFAULT_CLEANUP_INTERVAL
+            seconds.
     """
 
     def __init__(

--- a/synapse/registry.py
+++ b/synapse/registry.py
@@ -200,7 +200,8 @@ class AgentRegistry:
             agent_id: Unique agent identifier.
             agent_type: Type of agent (claude, gemini, codex).
             port: Port number for HTTP endpoint.
-            status: Initial status (READY, WAITING, PROCESSING, or DONE).
+            status: Initial status — one of the constants in
+                ``synapse.status`` (defaults to ``PROCESSING``).
             tty_device: TTY device path (e.g., /dev/ttys001) for terminal jump.
             name: Custom name for the agent (optional).
             role: Role description for the agent (optional).


### PR DESCRIPTION
## Summary

Three docstrings left stale by recent state-machine and sanitiser refactors are now refreshed. Code logic unchanged. Implemented by codex (synapse-codex-8124).

## Linked Issues

- Closes #683

## Changes

| File | Fix |
|------|-----|
| \`synapse/registry.py:203\` | \`register()\` status arg docstring now defers to \`synapse.status\` constants instead of listing only 4 of the 8 valid status values, and notes the default (\`PROCESSING\`) explicitly |
| \`synapse/_pty_sanitize.py:1-9\` | module docstring extended to reflect that the sanitiser is now used at three boundaries: permission notifications (#582/#586), A2A artifact persistence (#664/PR #668), and long-message file persistence (#677/PR #678) |
| \`synapse/long_message.py:37-41\` | \`LongMessageStore\` Attributes section now lists \`_last_cleanup_ts\` with its throttling role |

## Test plan

- [x] \`uv run pytest tests/test_registry.py tests/test_long_message.py tests/test_long_message_sanitize_677.py -q\` → **73 passed**
- [x] \`uv run mypy synapse/\` → no issues, 116 source files
- [x] Pre-commit hooks: ruff (legacy alias) + ruff format + mypy all passed

No new tests required (docstring-only change). No CHANGELOG entry needed (Keep a Changelog regards docstring polish as non-tracked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)