### PR TITLE
test: add coverage for _format_artifact_text(use_markdown=True) (#685)

### DIFF
--- a/tests/test_a2a_compat_use_markdown_685.py
+++ b/tests/test_a2a_compat_use_markdown_685.py
@@ -1,0 +1,54 @@
+"""Regression tests for _format_artifact_text(use_markdown=True) (#685)."""
+
+from synapse.a2a_compat import Artifact, _format_artifact_text
+
+
+def test_code_artifact_uses_markdown_fence():
+    """use_markdown=True wraps code in ``` fences with language."""
+    artifact = Artifact(
+        type="code",
+        data={"content": "x = 1", "metadata": {"language": "python"}},
+    )
+
+    output = _format_artifact_text(artifact, use_markdown=True)
+
+    assert output == "```python\nx = 1\n```"
+
+
+def test_code_artifact_uses_brackets_when_use_markdown_false():
+    """Default (use_markdown=False) uses [Code: <lang>] prefix."""
+    artifact = Artifact(
+        type="code",
+        data={"content": "x = 1", "metadata": {"language": "python"}},
+    )
+
+    output = _format_artifact_text(artifact, use_markdown=False)
+
+    assert output == "[Code: python]\nx = 1"
+
+
+def test_use_markdown_path_strips_control_bytes_in_code():
+    """use_markdown=True still strips PTY control bytes from content."""
+    artifact = Artifact(
+        type="code",
+        data={
+            "content": "print(\x1b[31m'red'\x1b[0m)",
+            "metadata": {"language": "python"},
+        },
+    )
+
+    output = _format_artifact_text(artifact, use_markdown=True)
+
+    assert "\x1b[31m" not in output
+    assert "\x1b[0m" not in output
+    assert output == "```python\nprint('red')\n```"
+
+
+def test_text_artifact_unaffected_by_use_markdown_flag():
+    """use_markdown is code-only; text artifacts produce the same output."""
+    artifact = Artifact(type="text", data="multi\nline\ttext")
+
+    output_false = _format_artifact_text(artifact, use_markdown=False)
+    output_true = _format_artifact_text(artifact, use_markdown=True)
+
+    assert output_false == output_true == "multi\nline\ttext"


### PR DESCRIPTION
## Summary

\`_format_artifact_text(use_markdown=True)\` had no direct test coverage. Existing \`tests/test_a2a_compat_sanitize_664.py\` (5 cases from PR #668) only tested the default \`use_markdown=False\` path. PR #679's simplify sweep flagged this as a test gap. This PR is the dedicated follow-up — test-only, no production code change.

Implementation by codex (synapse-codex-8124).

## Linked Issues

- Closes #685

## Changes

New file \`tests/test_a2a_compat_use_markdown_685.py\` (4 cases):

| Test | Verifies |
|------|----------|
| \`test_code_artifact_uses_markdown_fence\` | \`use_markdown=True\` wraps code in \` ```<lang>\\n...\\n``` \` |
| \`test_code_artifact_uses_brackets_when_use_markdown_false\` | regression net for the default \`[Code: <lang>]\` format |
| \`test_use_markdown_path_strips_control_bytes_in_code\` | confirms PR #668 sanitisation applies to the markdown path too |
| \`test_text_artifact_unaffected_by_use_markdown_flag\` | text artifacts produce the same output regardless of the flag (use_markdown is code-only) |

## Test plan

- [x] \`uv run pytest tests/test_a2a_compat_use_markdown_685.py -q\` → **4 passed**
- [x] \`uv run pytest tests/test_a2a_compat.py tests/test_a2a_compat_sanitize_664.py -q\` → **85 passed** (no regression)
- [x] \`uv run mypy synapse/\` → clean (116 source files)
- [x] Pre-commit hooks: ruff (legacy alias) + ruff format passed (mypy: no python files to check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)