### PR TITLE
test: pure unit tests for _resolve_polling_endpoint (#686)

### DIFF
--- a/tests/test_resolve_polling_endpoint_686.py
+++ b/tests/test_resolve_polling_endpoint_686.py
@@ -1,0 +1,95 @@
+"""Pure unit tests for _resolve_polling_endpoint (#686, follow-up to PR #676 / #515).
+
+The helper at synapse/a2a_client.py:36 was extracted by PR #676 as a
+pure function deciding which (endpoint, uds_path, task_id) triple
+``send_to_local`` should poll for ``wait_for_completion``. It is
+already covered indirectly by ``tests/test_send_to_local_wait_strategy_515.py``
+through full ``send_to_local()`` invocations with mocked HTTP, but no
+test exercises the helper directly. These tests close that gap so a
+future regression in the input→output mapping fails fast without
+requiring the integration mocks.
+"""
+
+from synapse.a2a_client import _resolve_polling_endpoint
+
+
+def test_returns_sender_when_task_id_and_endpoint_present():
+    sender_info = {
+        "sender_endpoint": "http://localhost:8100",
+        "sender_uds_path": "/tmp/sender.sock",
+    }
+    endpoint, uds, task_id = _resolve_polling_endpoint(
+        sender_task_id="sender-task",
+        sender_info=sender_info,
+        target_endpoint="http://localhost:8124",
+        target_uds_path="/tmp/target.sock",
+        target_task_id="target-task",
+    )
+    assert endpoint == "http://localhost:8100"
+    assert uds == "/tmp/sender.sock"
+    assert task_id == "sender-task"
+
+
+def test_returns_target_when_sender_endpoint_missing():
+    """sender_task_id present but sender_info has no sender_endpoint
+    falls back to target polling — the silent-skip case PR #676 closed."""
+    sender_info = {"sender_endpoint": None, "sender_uds_path": "/tmp/sender.sock"}
+    endpoint, uds, task_id = _resolve_polling_endpoint(
+        sender_task_id="sender-task",
+        sender_info=sender_info,
+        target_endpoint="http://localhost:8124",
+        target_uds_path="/tmp/target.sock",
+        target_task_id="target-task",
+    )
+    assert endpoint == "http://localhost:8124"
+    assert uds == "/tmp/target.sock"
+    assert task_id == "target-task"
+
+
+def test_returns_target_when_no_sender_task_id():
+    """sender_task_id absent (workflow subprocess case from PR #513) falls
+    back to target polling regardless of what sender_info contains."""
+    sender_info = {
+        "sender_endpoint": "http://localhost:8100",
+        "sender_uds_path": "/tmp/sender.sock",
+    }
+    endpoint, uds, task_id = _resolve_polling_endpoint(
+        sender_task_id=None,
+        sender_info=sender_info,
+        target_endpoint="http://localhost:8124",
+        target_uds_path="/tmp/target.sock",
+        target_task_id="target-task",
+    )
+    assert endpoint == "http://localhost:8124"
+    assert uds == "/tmp/target.sock"
+    assert task_id == "target-task"
+
+
+def test_returns_target_when_sender_info_none():
+    endpoint, uds, task_id = _resolve_polling_endpoint(
+        sender_task_id="sender-task",
+        sender_info=None,
+        target_endpoint="http://localhost:8124",
+        target_uds_path="/tmp/target.sock",
+        target_task_id="target-task",
+    )
+    assert endpoint == "http://localhost:8124"
+    assert uds == "/tmp/target.sock"
+    assert task_id == "target-task"
+
+
+def test_sender_uds_path_passthrough():
+    """When the sender path is selected, the sender's uds_path (not the
+    target's) is returned alongside the sender endpoint."""
+    sender_info = {
+        "sender_endpoint": "http://localhost:8100",
+        "sender_uds_path": "/tmp/SENDER.sock",
+    }
+    _, uds, _ = _resolve_polling_endpoint(
+        sender_task_id="sender-task",
+        sender_info=sender_info,
+        target_endpoint="http://localhost:8124",
+        target_uds_path="/tmp/TARGET.sock",
+        target_task_id="target-task",
+    )
+    assert uds == "/tmp/SENDER.sock"


### PR DESCRIPTION
## Summary

PR #676 (#515) extracted \`_resolve_polling_endpoint\` as a pure function selecting the \`(endpoint, uds_path, task_id)\` triple to poll for \`wait_for_completion\`. It is already covered indirectly by \`tests/test_send_to_local_wait_strategy_515.py\` through \`send_to_local()\` invocations with mocked HTTP, but **no test exercises the helper directly**. This PR closes that gap so a future regression in the input → output mapping fails fast without requiring integration mocks.

## Linked Issues

- Closes #686

## Implementation note

This was originally delegated to \`synapse-codex-8124\` but the long-lived agent (~42h uptime) stalled on a **codex-CLI rate-limit reminder dialog** that pre-empts task processing — diagnosed via \`synapse status <agent> --debug-waiting\`, documented in the new memory \`feedback_codex_rate_limit_dialog_stuck.md\`. The parent finished the implementation to keep the small-improvement pipeline moving (5 trivial pure-function tests, ~3 minutes).

## Changes

New file \`tests/test_resolve_polling_endpoint_686.py\` (5 cases):

| Test | Verifies |
|------|----------|
| \`test_returns_sender_when_task_id_and_endpoint_present\` | both inputs → sender path |
| \`test_returns_target_when_sender_endpoint_missing\` | the silent-skip case PR #676 closed: sender_task_id present but sender_endpoint is None → target fallback |
| \`test_returns_target_when_no_sender_task_id\` | workflow subprocess case (PR #513): sender_task_id absent → target fallback |
| \`test_returns_target_when_sender_info_none\` | sender_info=None → target fallback |
| \`test_sender_uds_path_passthrough\` | sender's uds_path returned alongside sender endpoint, not target's |

Test-only PR. No production code or existing test changes.

## Test plan

- [x] \`uv run pytest tests/test_resolve_polling_endpoint_686.py -q\` → **5 passed**
- [x] \`uv run pytest tests/test_resolve_polling_endpoint_686.py tests/test_send_to_local_wait_strategy_515.py tests/test_a2a_client.py -q\` → **43 passed** (no regression in adjacent suites)
- [x] \`uv run mypy synapse/\` → no issues, 116 source files
- [x] Pre-commit hooks: ruff (legacy alias) + ruff format passed (mypy: no python files to check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)