### PR TITLE
feat(watchdog): detect codex CLI rate-limit dialog (#691)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `synapse watchdog check` now detects Codex CLI rate-limit model-switch dialogs from PTY debug output and surfaces a `rate_limit_dialog` alarm (#691).
 - `synapse reply` now accepts `--message-file` / `-F` and `--stdin` flags, matching `synapse send`. This lets long replies (or replies containing backticks / `$()` / `${}` shell metacharacters) be passed via file or pipe instead of as a positional argument that the shell may try to expand. Reply still uses fixed `priority=3` and `silent` response mode — other `send` flags were intentionally not mirrored because they conflict with reply semantics (#673).
 - `.github/PULL_REQUEST_TEMPLATE.md` enforcing the `Closes #<num>` / `Refs #<num>` keyword convention so issues auto-close on merge instead of orphaning. CLAUDE.md gains a "Closing shipped issues" section documenting backlog triage (#670).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `synapse watchdog check` now detects Codex CLI rate-limit model-switch dialogs from PTY debug output and surfaces a `rate_limit_dialog` alarm (#691).
+- `synapse watchdog check` now detects Codex CLI rate-limit model-switch dialogs from PTY debug output and surfaces a `rate_limit_dialog` alarm (#691). The detection is gated on `status == WAITING` so stale PTY content cannot trip the alarm in `READY` / `PROCESSING`, and the `/debug/pty` fetch is skipped for non-`WAITING` agents to avoid per-tick HTTP overhead.
 - `synapse reply` now accepts `--message-file` / `-F` and `--stdin` flags, matching `synapse send`. This lets long replies (or replies containing backticks / `$()` / `${}` shell metacharacters) be passed via file or pipe instead of as a positional argument that the shell may try to expand. Reply still uses fixed `priority=3` and `silent` response mode — other `send` flags were intentionally not mirrored because they conflict with reply semantics (#673).
 - `.github/PULL_REQUEST_TEMPLATE.md` enforcing the `Closes #<num>` / `Refs #<num>` keyword convention so issues auto-close on merge instead of orphaning. CLAUDE.md gains a "Closing shipped issues" section documenting backlog triage (#670).
 

--- a/synapse/commands/watchdog.py
+++ b/synapse/commands/watchdog.py
@@ -18,6 +18,7 @@ from synapse.history import HistoryManager
 from synapse.paths import get_history_db_path
 from synapse.port_manager import is_process_alive
 from synapse.registry import AgentRegistry
+from synapse.status import WAITING
 from synapse.watchdog import WatchdogReport, evaluate_agent
 
 _PTY_DEBUG_TIMEOUT = 1.5
@@ -114,7 +115,11 @@ def _collect_reports(now: float) -> list[WatchdogReport]:
 
     for agent_id, agent_info in sorted(_live_agents(registry).items()):
         history = _outbound_history_for_agent(history_manager, agent_id)
-        pty_tail = _fetch_debug_pty_tail(agent_info)
+        pty_tail = (
+            _fetch_debug_pty_tail(agent_info)
+            if str(agent_info.get("status")) == WAITING
+            else None
+        )
         reports.append(
             evaluate_agent(
                 agent_info=agent_info,

--- a/synapse/commands/watchdog.py
+++ b/synapse/commands/watchdog.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import argparse
 import json
 import time
+import urllib.error
+import urllib.request
 from dataclasses import asdict
 from typing import Any
 
@@ -17,6 +19,8 @@ from synapse.paths import get_history_db_path
 from synapse.port_manager import is_process_alive
 from synapse.registry import AgentRegistry
 from synapse.watchdog import WatchdogReport, evaluate_agent
+
+_PTY_DEBUG_TIMEOUT = 1.5
 
 
 def _format_duration(seconds: float | None) -> str:
@@ -45,6 +49,13 @@ def _metadata_sender_id(metadata: Any) -> str | None:
     return None
 
 
+def _report_to_dict(report: WatchdogReport) -> dict[str, Any]:
+    data = asdict(report)
+    if data.get("alarm_reason") is None:
+        data.pop("alarm_reason", None)
+    return data
+
+
 def _outbound_history_for_agent(
     history_manager: HistoryManager,
     agent_id: str,
@@ -55,6 +66,35 @@ def _outbound_history_for_agent(
         for observation in observations
         if _metadata_sender_id(observation.get("metadata")) == agent_id
     ]
+
+
+def _endpoint_for(info: dict[str, Any]) -> str | None:
+    endpoint = info.get("endpoint")
+    if isinstance(endpoint, str) and endpoint:
+        return endpoint.rstrip("/")
+    port = info.get("port")
+    if isinstance(port, int):
+        return f"http://localhost:{port}"
+    return None
+
+
+def _fetch_debug_pty_tail(info: dict[str, Any]) -> str | None:
+    endpoint = _endpoint_for(info)
+    if not endpoint:
+        return None
+
+    try:
+        with urllib.request.urlopen(
+            f"{endpoint}/debug/pty", timeout=_PTY_DEBUG_TIMEOUT
+        ) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except (OSError, TimeoutError, urllib.error.URLError, json.JSONDecodeError):
+        return None
+
+    display = payload.get("display")
+    if not isinstance(display, list):
+        return None
+    return "\n".join(str(line) for line in display)
 
 
 def _live_agents(registry: AgentRegistry) -> dict[str, dict[str, Any]]:
@@ -74,7 +114,15 @@ def _collect_reports(now: float) -> list[WatchdogReport]:
 
     for agent_id, agent_info in sorted(_live_agents(registry).items()):
         history = _outbound_history_for_agent(history_manager, agent_id)
-        reports.append(evaluate_agent(agent_info=agent_info, history=history, now=now))
+        pty_tail = _fetch_debug_pty_tail(agent_info)
+        reports.append(
+            evaluate_agent(
+                agent_info=agent_info,
+                history=history,
+                now=now,
+                pty_tail=pty_tail,
+            )
+        )
 
     return reports
 
@@ -108,7 +156,7 @@ def cmd_watchdog_check(args: argparse.Namespace) -> None:
         reports = [report for report in reports if report.alarm]
 
     if getattr(args, "json", False):
-        print(json.dumps([asdict(report) for report in reports], indent=2))
+        print(json.dumps([_report_to_dict(report) for report in reports], indent=2))
         return
 
     _print_table(reports)

--- a/synapse/watchdog.py
+++ b/synapse/watchdog.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
 
-from synapse.status import PROCESSING, RATE_LIMITED, READY, SENDING_REPLY
+from synapse.status import PROCESSING, RATE_LIMITED, READY, SENDING_REPLY, WAITING
 
 _THIRTY_MINUTES = 30 * 60
 
@@ -142,7 +142,7 @@ def _evaluate_alarm(
         ):
             return message, None
 
-    if _detect_rate_limit_dialog(pty_tail):
+    if status == WAITING and _detect_rate_limit_dialog(pty_tail):
         return RATE_LIMIT_DIALOG_ALARM, RATE_LIMIT_DIALOG_ALARM_REASON
 
     if (

--- a/synapse/watchdog.py
+++ b/synapse/watchdog.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
@@ -16,6 +17,15 @@ PROCESSING_STALL_SECONDS = _THIRTY_MINUTES
 OUTBOUND_IDLE_SECONDS = 10 * 60
 SPAWN_READY_GRACE_SECONDS = 60
 SPAWN_READY_WINDOW_SECONDS = 5 * 60
+RATE_LIMIT_DIALOG_ALARM = "rate_limit_dialog"
+RATE_LIMIT_DIALOG_ALARM_REASON = (
+    "PTY tail contains codex CLI rate-limit reminder dialog"
+)
+RATE_LIMIT_DIALOG_PATTERN = re.compile(
+    r"(?:Hide future rate limit reminders about switching models)"
+    r"|(?:Press enter to confirm.*?esc to go back)",
+    re.IGNORECASE | re.DOTALL,
+)
 
 
 @dataclass(frozen=True)
@@ -26,6 +36,7 @@ class WatchdogReport:
     same_status_seconds: float | None
     last_outbound_seconds_ago: float | None
     alarm: str | None
+    alarm_reason: str | None = None
 
 
 def _seconds_since(value: Any, now: float) -> float | None:
@@ -69,6 +80,13 @@ def _last_outbound_seconds_ago(
     return None
 
 
+def _detect_rate_limit_dialog(pty_tail: str | None) -> bool:
+    """Return True when PTY tail contains the codex rate-limit dialog."""
+    if not pty_tail:
+        return False
+    return bool(RATE_LIMIT_DIALOG_PATTERN.search(pty_tail))
+
+
 _DURATION_RULES: tuple[tuple[str, float, str], ...] = (
     (RATE_LIMITED, RATE_LIMITED_ALARM_SECONDS, "Rate-limited > 30m"),
     (SENDING_REPLY, SENDING_REPLY_ALARM_SECONDS, "Send stuck > 60s"),
@@ -80,6 +98,7 @@ def evaluate_agent(
     agent_info: dict[str, Any],
     history: list[dict[str, Any]],
     now: float,
+    pty_tail: str | None = None,
 ) -> WatchdogReport:
     """Evaluate one agent against the Stage 1 watchdog heuristics."""
     agent_id = str(agent_info.get("agent_id") or "")
@@ -88,11 +107,12 @@ def evaluate_agent(
     same_status_seconds = _seconds_since(agent_info.get("last_status_change_at"), now)
     last_outbound_seconds_ago = _last_outbound_seconds_ago(history, now)
 
-    alarm = _evaluate_alarm(
+    alarm, alarm_reason = _evaluate_alarm(
         status=status,
         same_status_seconds=same_status_seconds,
         uptime_seconds=uptime_seconds,
         last_outbound_seconds_ago=last_outbound_seconds_ago,
+        pty_tail=pty_tail,
     )
 
     return WatchdogReport(
@@ -102,6 +122,7 @@ def evaluate_agent(
         same_status_seconds=same_status_seconds,
         last_outbound_seconds_ago=last_outbound_seconds_ago,
         alarm=alarm,
+        alarm_reason=alarm_reason,
     )
 
 
@@ -111,14 +132,18 @@ def _evaluate_alarm(
     same_status_seconds: float | None,
     uptime_seconds: float | None,
     last_outbound_seconds_ago: float | None,
-) -> str | None:
+    pty_tail: str | None,
+) -> tuple[str | None, str | None]:
     for rule_status, threshold, message in _DURATION_RULES:
         if (
             status == rule_status
             and same_status_seconds is not None
             and same_status_seconds > threshold
         ):
-            return message
+            return message, None
+
+    if _detect_rate_limit_dialog(pty_tail):
+        return RATE_LIMIT_DIALOG_ALARM, RATE_LIMIT_DIALOG_ALARM_REASON
 
     if (
         status == PROCESSING
@@ -129,7 +154,7 @@ def _evaluate_alarm(
             or last_outbound_seconds_ago > OUTBOUND_IDLE_SECONDS
         )
     ):
-        return "Stuck-on-reply suspected"
+        return "Stuck-on-reply suspected", None
 
     if (
         status != READY
@@ -137,6 +162,6 @@ def _evaluate_alarm(
         and uptime_seconds is not None
         and SPAWN_READY_GRACE_SECONDS < uptime_seconds <= SPAWN_READY_WINDOW_SECONDS
     ):
-        return "Spawn never ready"
+        return "Spawn never ready", None
 
-    return None
+    return None, None

--- a/tests/test_watchdog_rate_limit_dialog_691.py
+++ b/tests/test_watchdog_rate_limit_dialog_691.py
@@ -1,0 +1,102 @@
+"""Tests for watchdog rate-limit dialog detection (#691)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from unittest.mock import patch
+
+from synapse.status import WAITING
+
+OBSERVED_PTY_TAIL = (
+    "1. <some-mini-model>           Small, fast, and cost-efficient model for simpler coding tasks.\n"
+    "2. Keep current model\n"
+    "3. Keep current model (never show again)  Hide future rate limit reminders about switching models.\n"
+    "Press enter to confirm or esc to go back"
+)
+
+
+def test_detect_rate_limit_dialog_matches_observed_pty_tail() -> None:
+    from synapse.watchdog import _detect_rate_limit_dialog
+
+    assert _detect_rate_limit_dialog(OBSERVED_PTY_TAIL) is True
+
+
+def test_detect_rate_limit_dialog_ignores_normal_codex_prompt() -> None:
+    from synapse.watchdog import _detect_rate_limit_dialog
+
+    normal_tail = "> Run /review on my current changes\n  gpt-5.4-mini medium · /..."
+    assert _detect_rate_limit_dialog(normal_tail) is False
+
+
+def test_detect_rate_limit_dialog_handles_none_or_empty() -> None:
+    from synapse.watchdog import _detect_rate_limit_dialog
+
+    assert _detect_rate_limit_dialog(None) is False
+    assert _detect_rate_limit_dialog("") is False
+
+
+def test_evaluate_agent_returns_rate_limit_dialog_alarm() -> None:
+    from synapse.watchdog import evaluate_agent
+
+    report = evaluate_agent(
+        agent_info={
+            "agent_id": "synapse-codex-8124",
+            "status": WAITING,
+            "registered_at": 1_776_800_000.0,
+            "last_status_change_at": 1_776_800_000.0,
+        },
+        history=[],
+        now=1_776_800_000.0,
+        pty_tail=OBSERVED_PTY_TAIL,
+    )
+
+    assert report.alarm == "rate_limit_dialog"
+    assert (
+        report.alarm_reason == "PTY tail contains codex CLI rate-limit reminder dialog"
+    )
+
+
+def test_alarm_only_filter_includes_rate_limit_dialog(capsys) -> None:
+    from synapse.commands.watchdog import cmd_watchdog_check
+    from synapse.watchdog import WatchdogReport
+
+    with (
+        patch("synapse.commands.watchdog.AgentRegistry") as registry_cls,
+        patch("synapse.commands.watchdog.HistoryManager") as history_cls,
+        patch("synapse.commands.watchdog.is_process_alive", return_value=True),
+        patch("synapse.commands.watchdog.evaluate_agent") as evaluate,
+    ):
+        registry_cls.return_value.list_agents.return_value = {
+            "synapse-codex-8124": {
+                "agent_id": "synapse-codex-8124",
+                "status": WAITING,
+                "registered_at": 1_776_800_000.0,
+                "last_status_change_at": 1_776_800_000.0,
+            }
+        }
+        history_cls.from_env.return_value.list_observations.return_value = []
+        evaluate.return_value = WatchdogReport(
+            "synapse-codex-8124",
+            WAITING,
+            100.0,
+            100.0,
+            None,
+            "rate_limit_dialog",
+            "PTY tail contains codex CLI rate-limit reminder dialog",
+        )
+
+        cmd_watchdog_check(argparse.Namespace(alarm_only=True, json=True))
+
+    rows = json.loads(capsys.readouterr().out)
+    assert rows == [
+        {
+            "agent_id": "synapse-codex-8124",
+            "status": WAITING,
+            "uptime_seconds": 100.0,
+            "same_status_seconds": 100.0,
+            "last_outbound_seconds_ago": None,
+            "alarm": "rate_limit_dialog",
+            "alarm_reason": "PTY tail contains codex CLI rate-limit reminder dialog",
+        }
+    ]

--- a/tests/test_watchdog_rate_limit_dialog_691.py
+++ b/tests/test_watchdog_rate_limit_dialog_691.py
@@ -6,7 +6,7 @@ import argparse
 import json
 from unittest.mock import patch
 
-from synapse.status import WAITING
+from synapse.status import PROCESSING, READY, WAITING
 
 OBSERVED_PTY_TAIL = (
     "1. <some-mini-model>           Small, fast, and cost-efficient model for simpler coding tasks.\n"
@@ -55,6 +55,53 @@ def test_evaluate_agent_returns_rate_limit_dialog_alarm() -> None:
     assert (
         report.alarm_reason == "PTY tail contains codex CLI rate-limit reminder dialog"
     )
+
+
+def test_evaluate_agent_skips_rate_limit_dialog_alarm_when_not_waiting() -> None:
+    from synapse.watchdog import evaluate_agent
+
+    for non_waiting_status in (READY, PROCESSING):
+        report = evaluate_agent(
+            agent_info={
+                "agent_id": "synapse-codex-8124",
+                "status": non_waiting_status,
+                "registered_at": 1_776_800_000.0,
+                "last_status_change_at": 1_776_800_000.0,
+            },
+            history=[],
+            now=1_776_800_000.0,
+            pty_tail=OBSERVED_PTY_TAIL,
+        )
+
+        assert report.alarm is None
+        assert report.alarm_reason is None
+
+
+def test_collect_reports_skips_pty_fetch_for_non_waiting_agents() -> None:
+    from synapse.commands.watchdog import _collect_reports
+
+    with (
+        patch("synapse.commands.watchdog.AgentRegistry") as registry_cls,
+        patch("synapse.commands.watchdog.HistoryManager") as history_cls,
+        patch("synapse.commands.watchdog.is_process_alive", return_value=True),
+        patch("synapse.commands.watchdog._fetch_debug_pty_tail") as fetch_pty,
+        patch("synapse.commands.watchdog.evaluate_agent") as evaluate,
+    ):
+        registry_cls.return_value.list_agents.return_value = {
+            "synapse-codex-8124": {
+                "agent_id": "synapse-codex-8124",
+                "status": PROCESSING,
+                "registered_at": 1_776_800_000.0,
+                "last_status_change_at": 1_776_800_000.0,
+            }
+        }
+        history_cls.from_env.return_value.list_observations.return_value = []
+        evaluate.return_value = object()
+
+        _collect_reports(now=1_776_800_000.0)
+
+    fetch_pty.assert_not_called()
+    assert evaluate.call_args.kwargs["pty_tail"] is None
 
 
 def test_alarm_only_filter_includes_rate_limit_dialog(capsys) -> None:


### PR DESCRIPTION
## Summary

Adds a content-based watchdog rule that detects when a codex agent has stalled on its CLI's interactive **model-selection rate-limit dialog**. Surfaces as a \`rate_limit_dialog\` alarm in \`synapse watchdog check\` output.

This PR was directly motivated by the very symptom it now detects — \`synapse-codex-8124\` (uptime 41h 52m) hit OpenAI's rate limit during the 2026-04-30 dev session, the codex CLI showed an interactive model-selection prompt, and synapse's existing watchdog rules (all duration-based) had no signal for it. Diagnosis required \`synapse status <agent> --debug-waiting\` to read the PTY tail manually. After this PR, \`synapse watchdog check --alarm-only\` flags the same condition automatically.

## Linked Issues

- Closes #691

## Implementation

- **\`synapse/watchdog.py\`**: new \`_detect_rate_limit_dialog()\` helper uses a regex over two distinctive substrings (\"Hide future rate limit reminders\" / \"Press enter to confirm … esc to go back\") and is wired through \`evaluate_agent\` / \`_evaluate_alarm\` with an \`alarm_reason\` field
- **\`synapse/commands/watchdog.py\`**: fetches the agent's PTY tail via its \`/debug/pty\` endpoint with a short timeout; on fetch failure (timeout / 404 / network), the content rule is skipped and other duration-based alarms continue to evaluate normally — no cascade failure
- JSON output now includes \`alarm_reason\` for any agent with an alarm; \`--alarm-only\` correctly surfaces \`rate_limit_dialog\`
- Existing duration-based rules (\`RATE_LIMITED > 30m\`, \`SENDING_REPLY > 60s\`, \`PROCESSING > 30m\`) unchanged

## Tests

New file \`tests/test_watchdog_rate_limit_dialog_691.py\` (5 cases):

| Test | Verifies |
|------|----------|
| \`test_detect_rate_limit_dialog_matches_observed_pty_tail\` | actual session-observed PTY tail produces detection |
| \`test_detect_rate_limit_dialog_ignores_normal_codex_prompt\` | no false positives on standard codex CLI footer |
| \`test_detect_rate_limit_dialog_handles_none_or_empty\` | None/empty input returns False (no exception) |
| \`test_evaluate_agent_returns_rate_limit_dialog_alarm\` | end-to-end: PTY tail with dialog → alarm field |
| \`test_alarm_only_filter_includes_rate_limit_dialog\` | --alarm-only surfaces this alarm correctly |

## Implementation note

This PR was implemented by codex (synapse-codex-8124) on **gpt-5.5 medium**. The agent first attempted on gpt-5.4-mini but was switched to the full model mid-cycle (the user noticed mini was risky for a watchdog refactor); on resume, the agent picked up its working-tree edits cleanly and finished the task with red→green→verify→CHANGELOG. **Recovered from the same rate-limit dialog this PR now detects** — the dogfooding loop closes neatly.

## Verification

- [x] Red phase: 5 failed (helper + \`pty_tail\` arg + \`alarm_reason\` missing) — confirmed test→failure mapping
- [x] \`uv run pytest tests/test_watchdog_rate_limit_dialog_691.py -q\` → **5 passed**
- [x] \`uv run pytest tests/test_watchdog_*.py -q\` → **14 passed** (no regression in adjacent watchdog suite)
- [x] \`uv run mypy synapse/\` → clean (116 source files)
- [x] Pre-commit hooks: ruff (legacy alias) + ruff format + mypy all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Watchdog チェックがエージェントの PTY デバッグ出力から Codex CLI のレート制限ダイアログを検出し、`rate_limit_dialog` アラームとして報告するようになりました。詳細な警告情報も同時に提供されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->