### PR TITLE
refactor(a2a_compat): replace list-as-mutable-bool with nonlocal bool

### DIFF
--- a/synapse/a2a_compat.py
+++ b/synapse/a2a_compat.py
@@ -1111,7 +1111,7 @@ def create_a2a_router(
     # was in SENDING_REPLY at the time. Drained by _on_status_change when
     # the agent leaves SENDING_REPLY so the preview is guaranteed to clear
     # eventually (CodeRabbit #699).
-    _pending_terminal_preview_clear = [False]
+    _pending_terminal_preview_clear: bool = False
 
     def _clear_terminal_task_preview() -> None:
         """Clear the current task preview after local task terminal transitions.
@@ -1123,14 +1123,15 @@ def create_a2a_router(
         defer the clear by setting a flag that ``_on_status_change`` drains
         when SENDING_REPLY exits.
         """
+        nonlocal _pending_terminal_preview_clear
         if registry is None or agent_id is None:
             return
         agent_info = registry.get_agent(agent_id)
         if agent_info and agent_info.get("status") == SENDING_REPLY:
-            _pending_terminal_preview_clear[0] = True
+            _pending_terminal_preview_clear = True
             return
         registry.update_current_task(agent_id, None)
-        _pending_terminal_preview_clear[0] = False
+        _pending_terminal_preview_clear = False
 
     def _drain_pending_terminal_preview_clear(old: str, new: str) -> None:
         """If a terminal clear was deferred during SENDING_REPLY, apply it now.
@@ -1139,14 +1140,15 @@ def create_a2a_router(
         of ``SENDING_REPLY`` (typically to READY after the outbound send
         completes, or to any other status if interrupted).
         """
+        nonlocal _pending_terminal_preview_clear
         if registry is None or agent_id is None:
             return
         if old != SENDING_REPLY or new == SENDING_REPLY:
             return
-        if not _pending_terminal_preview_clear[0]:
+        if not _pending_terminal_preview_clear:
             return
         registry.update_current_task(agent_id, None)
-        _pending_terminal_preview_clear[0] = False
+        _pending_terminal_preview_clear = False
 
     def _finalize_working_task(
         task_id: str, full_context: str, recent_context: str


### PR DESCRIPTION
## Summary

- Pre-0.33.0 polish on the `_pending_terminal_preview_clear` flag introduced in #699.
- Replaces the `[False]` list-as-mutable-bool workaround with a plain `bool` plus `nonlocal` declarations in the two closures that touch it.
- Both closures (`_clear_terminal_task_preview`, `_drain_pending_terminal_preview_clear`) live directly inside `create_a2a_router`, so `nonlocal` is strictly cleaner and removes the `[0]` indexing noise at every read/write site.

No behavior change; this is a stylistic simplification only.

## Test plan

- [x] `uv run pytest tests/test_send_keys_695.py tests/test_reply_to_404_690.py tests/test_current_task_preview_clear_689.py tests/test_a2a_compat.py -q` passes (99 tests)
- [x] `uv run mypy synapse/` clean (117 files)

Refs #699

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リファクタリング**
  * 内部フラグ管理システムの効率を改善し、コード保守性を強化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->