### PR TITLE
feat(watchdog): detect codex CLI edit-confirmation dialog (#694)

### DIFF
--- a/synapse/watchdog.py
+++ b/synapse/watchdog.py
@@ -26,6 +26,14 @@ RATE_LIMIT_DIALOG_PATTERN = re.compile(
     r"|(?:Press enter to confirm.*?esc to go back)",
     re.IGNORECASE | re.DOTALL,
 )
+EDIT_CONFIRMATION_DIALOG_ALARM = "edit_confirmation_dialog"
+EDIT_CONFIRMATION_DIALOG_ALARM_REASON = (
+    "PTY tail contains codex CLI edit-confirmation dialog"
+)
+EDIT_CONFIRMATION_DIALOG_PATTERN = re.compile(
+    r"\bWould you like to\b",
+    re.IGNORECASE,
+)
 
 
 @dataclass(frozen=True)
@@ -87,6 +95,13 @@ def _detect_rate_limit_dialog(pty_tail: str | None) -> bool:
     return bool(RATE_LIMIT_DIALOG_PATTERN.search(pty_tail))
 
 
+def _detect_edit_confirmation_dialog(pty_tail: str | None) -> bool:
+    """Return True when PTY tail contains the codex edit-confirmation dialog."""
+    if not pty_tail:
+        return False
+    return bool(EDIT_CONFIRMATION_DIALOG_PATTERN.search(pty_tail))
+
+
 _DURATION_RULES: tuple[tuple[str, float, str], ...] = (
     (RATE_LIMITED, RATE_LIMITED_ALARM_SECONDS, "Rate-limited > 30m"),
     (SENDING_REPLY, SENDING_REPLY_ALARM_SECONDS, "Send stuck > 60s"),
@@ -144,6 +159,9 @@ def _evaluate_alarm(
 
     if status == WAITING and _detect_rate_limit_dialog(pty_tail):
         return RATE_LIMIT_DIALOG_ALARM, RATE_LIMIT_DIALOG_ALARM_REASON
+
+    if status == WAITING and _detect_edit_confirmation_dialog(pty_tail):
+        return EDIT_CONFIRMATION_DIALOG_ALARM, EDIT_CONFIRMATION_DIALOG_ALARM_REASON
 
     if (
         status == PROCESSING

--- a/tests/test_codex_profile.py
+++ b/tests/test_codex_profile.py
@@ -42,6 +42,15 @@ class TestCodexWaitingDetection:
         )
         assert regex.search(overlay)
 
+    def test_matches_edit_confirmation_dialog_prefix(self, codex_profile: dict) -> None:
+        """Codex asks again before editing protected files such as
+        CHANGELOG.md even when spawned with full-auto style permissions.
+        The stable prefix must be enough to move PROCESSING -> WAITING."""
+        regex = re.compile(codex_profile["waiting_detection"]["regex"])
+        dialog = "Would you like to make the following edits?\n(custom content)"
+
+        assert regex.search(dialog)
+
     def test_matches_model_switch_modal(self, codex_profile: dict) -> None:
         """Rate-limit model-switch modal. Newer codex builds pop this up
         when the session is about to blow the API rate limit. Previously

--- a/tests/test_watchdog_rate_limit_dialog_691.py
+++ b/tests/test_watchdog_rate_limit_dialog_691.py
@@ -15,6 +15,16 @@ OBSERVED_PTY_TAIL = (
     "Press enter to confirm or esc to go back"
 )
 
+OBSERVED_EDIT_CONFIRMATION_TAIL = (
+    "Would you like to make the following edits?\n"
+    "\n"
+    "› 1. Yes, proceed (y)\n"
+    "  2. Yes, and don't ask again for these files (a)\n"
+    "  3. No, and tell Codex what to do differently (esc)\n"
+    "\n"
+    "  Press enter to confirm or esc to cancel"
+)
+
 
 def test_detect_rate_limit_dialog_matches_observed_pty_tail() -> None:
     from synapse.watchdog import _detect_rate_limit_dialog
@@ -34,6 +44,38 @@ def test_detect_rate_limit_dialog_handles_none_or_empty() -> None:
 
     assert _detect_rate_limit_dialog(None) is False
     assert _detect_rate_limit_dialog("") is False
+
+
+def test_detect_edit_confirmation_dialog_matches_observed_pty_tail() -> None:
+    from synapse.watchdog import _detect_edit_confirmation_dialog
+
+    assert _detect_edit_confirmation_dialog(OBSERVED_EDIT_CONFIRMATION_TAIL) is True
+
+
+def test_detect_edit_confirmation_dialog_uses_stable_prefix_only() -> None:
+    from synapse.watchdog import _detect_edit_confirmation_dialog
+
+    future_codex_tail = (
+        "Would you like to make the following edits?\n"
+        "  1. Apply all changes\n"
+        "  2. Review diff first\n"
+    )
+
+    assert _detect_edit_confirmation_dialog(future_codex_tail) is True
+
+
+def test_detect_edit_confirmation_dialog_ignores_normal_codex_prompt() -> None:
+    from synapse.watchdog import _detect_edit_confirmation_dialog
+
+    normal_tail = "> Edit CHANGELOG.md\n  gpt-5.4 medium"
+    assert _detect_edit_confirmation_dialog(normal_tail) is False
+
+
+def test_detect_edit_confirmation_dialog_handles_none_or_empty() -> None:
+    from synapse.watchdog import _detect_edit_confirmation_dialog
+
+    assert _detect_edit_confirmation_dialog(None) is False
+    assert _detect_edit_confirmation_dialog("") is False
 
 
 def test_evaluate_agent_returns_rate_limit_dialog_alarm() -> None:
@@ -57,6 +99,25 @@ def test_evaluate_agent_returns_rate_limit_dialog_alarm() -> None:
     )
 
 
+def test_evaluate_agent_returns_edit_confirmation_dialog_alarm() -> None:
+    from synapse.watchdog import evaluate_agent
+
+    report = evaluate_agent(
+        agent_info={
+            "agent_id": "synapse-codex-8124",
+            "status": WAITING,
+            "registered_at": 1_776_800_000.0,
+            "last_status_change_at": 1_776_800_000.0,
+        },
+        history=[],
+        now=1_776_800_000.0,
+        pty_tail=OBSERVED_EDIT_CONFIRMATION_TAIL,
+    )
+
+    assert report.alarm == "edit_confirmation_dialog"
+    assert report.alarm_reason == "PTY tail contains codex CLI edit-confirmation dialog"
+
+
 def test_evaluate_agent_skips_rate_limit_dialog_alarm_when_not_waiting() -> None:
     from synapse.watchdog import evaluate_agent
 
@@ -71,6 +132,26 @@ def test_evaluate_agent_skips_rate_limit_dialog_alarm_when_not_waiting() -> None
             history=[],
             now=1_776_800_000.0,
             pty_tail=OBSERVED_PTY_TAIL,
+        )
+
+        assert report.alarm is None
+        assert report.alarm_reason is None
+
+
+def test_evaluate_agent_skips_edit_confirmation_dialog_alarm_when_not_waiting() -> None:
+    from synapse.watchdog import evaluate_agent
+
+    for non_waiting_status in (READY, PROCESSING):
+        report = evaluate_agent(
+            agent_info={
+                "agent_id": "synapse-codex-8124",
+                "status": non_waiting_status,
+                "registered_at": 1_776_800_000.0,
+                "last_status_change_at": 1_776_800_000.0,
+            },
+            history=[],
+            now=1_776_800_000.0,
+            pty_tail=OBSERVED_EDIT_CONFIRMATION_TAIL,
         )
 
         assert report.alarm is None


### PR DESCRIPTION
## Summary
- add watchdog detection/alarm for Codex edit-confirmation dialogs
- cover the stable edit-confirmation prefix in watchdog and Codex profile regression tests

Closes #694

## Tests
- uv run pytest tests/test_watchdog_rate_limit_dialog_691.py tests/test_codex_profile.py -v
- env HOME=/tmp/synapse-test-home uv run pytest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 編集確認ダイアログの検出機能を追加しました。ウォッチドッグが待機状態中にこのダイアログを自動認識し、適切に対応できるようになります。

* **テスト**
  * 新機能の動作を検証するテストケースを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->