### PR TITLE
fix(observability): unify view source for status/list JSON (#696)

### DIFF
--- a/synapse/commands/_agent_view.py
+++ b/synapse/commands/_agent_view.py
@@ -1,0 +1,78 @@
+"""Shared agent view helpers for list/status commands."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+CANONICAL_JSON_FIELDS = (
+    "agent_id",
+    "status",
+    "current_task_preview",
+    "task_received_at",
+    "uptime_seconds",
+    "input_required_tasks",
+)
+
+
+def strip_status_annotations(status: Any) -> Any:
+    """Return the machine-readable status without human list annotations."""
+    if not isinstance(status, str):
+        return status
+    return status.replace(" [ORPHAN]", "")
+
+
+def build_agent_json_view(
+    agent: dict[str, Any],
+    *,
+    now: float,
+    include_fields: tuple[str, ...],
+) -> dict[str, Any]:
+    """Build the programmatic JSON view for an agent."""
+    entry = {field: agent.get(field) for field in include_fields}
+
+    if "status" in entry:
+        entry["status"] = strip_status_annotations(entry["status"])
+
+    if "uptime_seconds" in include_fields:
+        uptime = agent.get("uptime_seconds")
+        if uptime is None:
+            registered_at = agent.get("registered_at")
+            if isinstance(now, (int, float)) and isinstance(
+                registered_at, (int, float)
+            ):
+                uptime = now - registered_at
+        entry["uptime_seconds"] = uptime
+
+    if "current_task_preview" in include_fields:
+        entry["current_task_preview"] = agent.get("current_task_preview")
+    if "task_received_at" in include_fields:
+        entry["task_received_at"] = agent.get("task_received_at")
+    if "input_required_tasks" in include_fields:
+        entry["input_required_tasks"] = agent.get("input_required_tasks") or []
+
+    return entry
+
+
+def resolve_agent_from_snapshot(
+    agents: list[dict[str, Any]],
+    target: str,
+) -> dict[str, Any] | None:
+    """Resolve a target from a preloaded agent list using registry priority rules."""
+    for info in agents:
+        if info.get("name") == target:
+            return info
+
+    for info in agents:
+        if info.get("agent_id") == target:
+            return info
+
+    if match := re.match(r"^([\w-]+)-(\d+)$", target):
+        agent_type, port_str = match.groups()
+        port = int(port_str)
+        for info in agents:
+            if info.get("agent_type") == agent_type and info.get("port") == port:
+                return info
+
+    type_matches = [info for info in agents if info.get("agent_type") == target]
+    return type_matches[0] if len(type_matches) == 1 else None

--- a/synapse/commands/list.py
+++ b/synapse/commands/list.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from threading import Event
 from typing import TYPE_CHECKING, Any, Protocol
 
+from synapse.commands._agent_view import build_agent_json_view
 from synapse.commands.cleanup import opportunistic_cleanup_idle_orphans
 from synapse.file_safety import FileSafetyManager
 from synapse.port_manager import PORT_RANGES
@@ -167,6 +168,7 @@ class ListCommand:
                 "working_dir": working_dir_short,
                 "working_dir_full": working_dir_full,
                 "endpoint": info.get("endpoint", "-"),
+                "registered_at": info.get("registered_at"),
                 "tty_device": info.get("tty_device"),
                 "zellij_pane_id": info.get("zellij_pane_id"),
                 "current_task_preview": info.get("current_task_preview"),
@@ -661,6 +663,7 @@ class ListCommand:
         "transport",
         "current_task_preview",
         "task_received_at",
+        "uptime_seconds",
         "summary",
         "is_orphan",
         "spawned_by",
@@ -677,8 +680,13 @@ class ListCommand:
         agents, _stale_locks, show_file_safety = self._get_agent_data(registry)
 
         result = []
+        now = self._time.time()
         for agent in agents:
-            entry = {k: agent.get(k) for k in self._JSON_FIELDS}
+            entry = build_agent_json_view(
+                agent,
+                now=now,
+                include_fields=self._JSON_FIELDS,
+            )
             if "renderer_available" in agent:
                 entry["renderer_available"] = agent.get("renderer_available")
             # Use full path for working_dir in JSON (short name is for TUI only)

--- a/synapse/commands/status.py
+++ b/synapse/commands/status.py
@@ -10,8 +10,15 @@ from collections.abc import Callable
 from io import StringIO
 from typing import IO, TYPE_CHECKING, Any
 
+from synapse.commands._agent_view import (
+    CANONICAL_JSON_FIELDS,
+    build_agent_json_view,
+    resolve_agent_from_snapshot,
+)
 from synapse.commands.renderers.rich_renderer import format_elapsed
 from synapse.commands.waiting_debug import _format_counter, _http_get_json
+from synapse.registry import is_port_open, is_process_running
+from synapse.status import PROCESSING
 from synapse.utils import format_renderer_suffix
 
 if TYPE_CHECKING:
@@ -30,12 +37,18 @@ class StatusCommand:
         file_safety_manager: FileSafetyManager | None = None,
         output: IO[str] | None = None,
         debug_waiting_fetcher: Callable[..., dict[str, Any]] | None = None,
+        is_process_alive: Callable[[int], bool] = is_process_running,
+        is_agent_port_open: Callable[..., bool] = is_port_open,
+        time_module: Any = time,
     ) -> None:
         self._registry = registry
         self._history_manager = history_manager
         self._file_safety_manager = file_safety_manager
         self._output = output or StringIO()
         self._debug_waiting_fetcher = debug_waiting_fetcher or _http_get_json
+        self._is_process_alive = is_process_alive
+        self._is_port_open = is_agent_port_open
+        self._time = time_module
 
     def _write(self, text: str) -> None:
         self._output.write(text)
@@ -52,7 +65,11 @@ class StatusCommand:
             target: Agent name, ID, type-port, or type to resolve.
             json_output: If True, output as JSON.
         """
-        info = self._registry.resolve_agent(target)
+        info = (
+            self._resolve_json_agent(target)
+            if json_output
+            else self._registry.resolve_agent(target)
+        )
 
         if info is None:
             if json_output:
@@ -70,24 +87,36 @@ class StatusCommand:
 
     def _render_json(self, info: dict[str, Any]) -> None:
         """Render agent status as JSON."""
-        data: dict[str, Any] = {
-            "agent_id": info.get("agent_id"),
-            "agent_type": info.get("agent_type"),
-            "name": info.get("name"),
-            "role": info.get("role"),
-            "port": info.get("port"),
-            "status": info.get("status"),
-            "pid": info.get("pid"),
-            "working_dir": info.get("working_dir"),
-            "endpoint": info.get("endpoint"),
-        }
+        data: dict[str, Any] = build_agent_json_view(
+            info,
+            now=self._time.time(),
+            include_fields=(
+                "agent_id",
+                "agent_type",
+                "name",
+                "role",
+                "port",
+                "status",
+                "pid",
+                "working_dir",
+                "endpoint",
+                *CANONICAL_JSON_FIELDS[1:],
+            ),
+        )
+        data.update(
+            {
+                "agent_id": info.get("agent_id"),
+                "agent_type": info.get("agent_type"),
+                "name": info.get("name"),
+                "role": info.get("role"),
+                "port": info.get("port"),
+                "pid": info.get("pid"),
+                "working_dir": info.get("working_dir"),
+                "endpoint": info.get("endpoint"),
+            }
+        )
         if "renderer_available" in info:
             data["renderer_available"] = info.get("renderer_available")
-
-        # Uptime
-        registered_at = info.get("registered_at")
-        if registered_at:
-            data["uptime_seconds"] = time.time() - registered_at
 
         # Current task
         preview = info.get("current_task_preview")
@@ -95,7 +124,9 @@ class StatusCommand:
         if preview:
             data["current_task"] = {
                 "preview": preview,
-                "elapsed_seconds": (time.time() - received_at) if received_at else None,
+                "elapsed_seconds": (
+                    self._time.time() - received_at if received_at else None
+                ),
             }
 
         # History
@@ -104,10 +135,35 @@ class StatusCommand:
         # File locks
         data["file_locks"] = self._get_file_locks(info)
 
-        # input_required tasks awaiting parent approval (#651)
-        data["input_required_tasks"] = info.get("input_required_tasks") or []
-
         self._writeln(json.dumps(data, indent=2))
+
+    def _resolve_json_agent(self, target: str) -> dict[str, Any] | None:
+        """Resolve an agent from the same live/list snapshot used by list JSON."""
+        agents = []
+        for agent_id, info in self._registry.list_agents().items():
+            if self._is_agent_alive(agent_id, info):
+                agents.append(dict(info, agent_id=info.get("agent_id") or agent_id))
+        return resolve_agent_from_snapshot(agents, target)
+
+    def _is_agent_alive(self, agent_id: str, info: dict[str, Any]) -> bool:
+        pid = info.get("pid")
+        port = info.get("port")
+
+        if pid and not self._is_process_alive(pid):
+            self._registry.unregister(agent_id)
+            return False
+
+        if info.get("status", "-") == PROCESSING or not port:
+            return True
+
+        if self._is_port_open("localhost", port, timeout=0.5):
+            return True
+        self._time.sleep(0.2)
+        if self._is_port_open("localhost", port, timeout=1.0):
+            return True
+
+        self._registry.unregister(agent_id)
+        return False
 
     def _render_text(self, info: dict[str, Any]) -> None:
         """Render agent status as formatted text."""

--- a/tests/test_cmd_list_json.py
+++ b/tests/test_cmd_list_json.py
@@ -129,10 +129,11 @@ class TestListJson:
                 "transport": "UDS→",
                 "current_task_preview": "Review issue #380",
                 "task_received_at": 1710000000.0,
+                "uptime_seconds": None,
                 "summary": None,
                 "is_orphan": None,
                 "spawned_by": None,
-                "input_required_tasks": None,
+                "input_required_tasks": [],
                 "renderer_available": False,
             }
         ]
@@ -256,10 +257,11 @@ class TestListJson:
                 "transport": "-",
                 "current_task_preview": None,
                 "task_received_at": None,
+                "uptime_seconds": None,
                 "summary": None,
                 "is_orphan": None,
                 "spawned_by": None,
-                "input_required_tasks": None,
+                "input_required_tasks": [],
                 "editing_file": "tests/test_cmd_list_json.py",
             }
         ]

--- a/tests/test_cmd_status.py
+++ b/tests/test_cmd_status.py
@@ -41,8 +41,10 @@ def _make_command(
     mock_registry = MagicMock()
     if agent_info:
         mock_registry.resolve_agent.return_value = agent_info
+        mock_registry.list_agents.return_value = {agent_info["agent_id"]: agent_info}
     else:
         mock_registry.resolve_agent.return_value = None
+        mock_registry.list_agents.return_value = {}
 
     mock_history = MagicMock()
     mock_history.list_observations.return_value = history_items or []
@@ -56,6 +58,8 @@ def _make_command(
         history_manager=mock_history,
         file_safety_manager=mock_file_safety,
         output=output,
+        is_process_alive=lambda pid: True,
+        is_agent_port_open=lambda *args, **kwargs: True,
     )
     return cmd, output
 

--- a/tests/test_status_unification.py
+++ b/tests/test_status_unification.py
@@ -1,11 +1,18 @@
 """Tests for status unification (READY/PROCESSING system)."""
 
+import argparse
+import json
 import shutil
 import tempfile
+import time
+from io import StringIO
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
+from synapse.commands.list import ListCommand
+from synapse.commands.status import StatusCommand
 from synapse.registry import AgentRegistry
 
 
@@ -115,3 +122,133 @@ class TestStatusUnification:
 
         assert agents["synapse-claude-8100"]["status"] == "READY"
         assert agents["synapse-claude-8101"]["status"] == "PROCESSING"
+
+
+class TestStatusListJsonViewUnification:
+    """Regression tests for status/list JSON view divergence (#696)."""
+
+    def _list_command(
+        self, registry: AgentRegistry, time_module: object | None = None
+    ) -> ListCommand:
+        return ListCommand(
+            registry_factory=lambda: registry,
+            is_process_alive=lambda pid: True,
+            is_port_open=lambda *args, **kwargs: True,
+            clear_screen=lambda: None,
+            time_module=time_module
+            or MagicMock(time=time.time, sleep=lambda _seconds: None),
+            print_func=MagicMock(),
+        )
+
+    def test_status_and_list_json_share_current_task_and_uptime_fields(
+        self, temp_registry: AgentRegistry
+    ) -> None:
+        """The same agent should expose identical canonical JSON fields."""
+        agent_id = "synapse-codex-8122"
+        now = 1777619000.0
+        temp_registry.register(
+            agent_id,
+            "codex",
+            8122,
+            status="PROCESSING",
+            name="fix-696",
+            role="fix status/list divergence",
+            spawned_by="synapse-claude-8104",
+        )
+
+        info = temp_registry.get_agent(agent_id)
+        assert info is not None
+        info.update(
+            {
+                "registered_at": now - 45.0,
+                "current_task_preview": "Investigate status/list JSON",
+                "task_received_at": now - 12.0,
+            }
+        )
+        (temp_registry.registry_dir / f"{agent_id}.json").write_text(json.dumps(info))
+
+        status_out = StringIO()
+        with patch("synapse.commands.status.time.time", return_value=now):
+            StatusCommand(registry=temp_registry, output=status_out).run(
+                agent_id, json_output=True
+            )
+        status_payload = json.loads(status_out.getvalue())
+
+        list_cmd = self._list_command(
+            temp_registry,
+            time_module=MagicMock(time=lambda: now, sleep=lambda _seconds: None),
+        )
+        list_cmd.run_json(argparse.Namespace())
+        list_payload = json.loads(list_cmd._print.call_args.args[0])[0]
+
+        fields = (
+            "agent_id",
+            "status",
+            "current_task_preview",
+            "task_received_at",
+            "uptime_seconds",
+            "input_required_tasks",
+        )
+        assert {field: status_payload.get(field) for field in fields} == {
+            field: list_payload.get(field) for field in fields
+        }
+        assert status_payload["current_task_preview"] == "Investigate status/list JSON"
+        assert status_payload["uptime_seconds"] == pytest.approx(45.0)
+
+    def test_status_json_resolves_from_same_live_agent_snapshot_as_list(
+        self, temp_registry: AgentRegistry
+    ) -> None:
+        """Status JSON should not resolve through a different registry view."""
+        agent_id = "synapse-codex-8122"
+        old_now = time.time() - 3600
+        new_now = time.time()
+        temp_registry.register(agent_id, "codex", 8122, status="PROCESSING")
+
+        old_info = temp_registry.get_agent(agent_id)
+        assert old_info is not None
+        old_info.update(
+            {
+                "registered_at": old_now,
+                "current_task_preview": None,
+                "task_received_at": None,
+            }
+        )
+        fresh_info = dict(old_info)
+        fresh_info.update(
+            {
+                "registered_at": new_now,
+                "current_task_preview": "Fresh task preview",
+                "task_received_at": new_now,
+            }
+        )
+
+        class DivergentRegistry:
+            def list_agents(self) -> dict[str, dict]:
+                return {agent_id: fresh_info}
+
+            def resolve_agent(self, target: str) -> dict | None:
+                assert target == agent_id
+                return old_info
+
+            def get_orphans(self, agents: dict[str, dict] | None = None) -> dict:
+                return {}
+
+            def get_transport_display(self, agent_id: str) -> str | None:
+                return None
+
+        registry = DivergentRegistry()
+        list_cmd = self._list_command(registry)  # type: ignore[arg-type]
+        list_cmd.run_json(argparse.Namespace())
+        list_payload = json.loads(list_cmd._print.call_args.args[0])[0]
+
+        status_out = StringIO()
+        StatusCommand(registry=registry, output=status_out).run(  # type: ignore[arg-type]
+            agent_id,
+            json_output=True,
+        )
+        status_payload = json.loads(status_out.getvalue())
+
+        assert (
+            status_payload["current_task_preview"]
+            == list_payload["current_task_preview"]
+        )


### PR DESCRIPTION
Summary:
- add a shared JSON view helper for canonical status/list fields
- make status --json resolve from the live list snapshot instead of resolve_agent()
- expose current_task_preview, task_received_at, uptime_seconds, and input_required_tasks consistently in both JSON views

Closes #696

Tests:
- uv run pytest tests/test_status_unification.py tests/test_cmd_status.py tests/test_cmd_list_json.py tests/test_input_required_visibility_651.py -v
- env HOME=/tmp/synapse-test-home uv run pytest
- uv run ruff check synapse/commands/_agent_view.py synapse/commands/list.py synapse/commands/status.py tests/test_status_unification.py tests/test_cmd_status.py tests/test_cmd_list_json.py
- manual: uv run synapse list --json and uv run synapse status synapse-codex-8122 --json matched current_task_preview/status/task_received_at/input_required_tasks; uptime_seconds differed only by elapsed time between separate CLI calls

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * エージェント一覧とステータス出力のJSON形式にアップタイム秒数フィールドを追加しました。
  * エージェント情報の取得ロジックを最適化し、複数の解決方法に対応しました。
  * コマンド間のJSON出力フィールドの一貫性を向上させました。

* **テスト**
  * 出力一貫性に関する回帰テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->