### PR TITLE
fix(worktree): retry on auto-generated name collision (#704)

### DIFF
--- a/synapse/worktree.py
+++ b/synapse/worktree.py
@@ -287,6 +287,7 @@ def get_default_remote_branch() -> str:
 
 _WORKTREE_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]*$")
 _WORKTREE_NAME_MAX_LEN = 100
+MAX_AUTO_NAME_ATTEMPTS = 8
 
 
 def _validate_worktree_name(name: str) -> str:
@@ -308,6 +309,47 @@ def _validate_worktree_name(name: str) -> str:
             "only alphanumerics, hyphens, dots, and underscores are allowed"
         )
     return name
+
+
+def _worktree_name_exhausted_error() -> RuntimeError:
+    return RuntimeError(
+        "Could not allocate a unique worktree name after "
+        f"{MAX_AUTO_NAME_ATTEMPTS} attempts. "
+        "This usually means stale worktree directories or branches have "
+        "accumulated under .synapse/worktrees/. "
+        "Run 'git worktree list' to inspect, then prune stale worktrees with "
+        "'git worktree remove <path>' or 'git worktree prune'."
+    )
+
+
+def _worktree_directory_exists_error(worktree_dir: Path) -> RuntimeError:
+    return RuntimeError(
+        f"Worktree directory already exists: {worktree_dir}. "
+        f"Run 'git worktree remove {worktree_dir}' to clean it up, "
+        "or pass a different --name."
+    )
+
+
+def _allocate_worktree_name(git_root: Path, name: str | None) -> tuple[str, Path, str]:
+    """Return a validated unique worktree name, directory, and branch."""
+    worktrees_dir = git_root / ".synapse" / "worktrees"
+
+    if name is not None:
+        validated_name = _validate_worktree_name(name)
+        worktree_dir = worktrees_dir / validated_name
+        if worktree_dir.exists():
+            raise _worktree_directory_exists_error(worktree_dir)
+        return validated_name, worktree_dir, f"worktree-{validated_name}"
+
+    for _ in range(MAX_AUTO_NAME_ATTEMPTS):
+        candidate = generate_worktree_name()
+        worktree_dir = worktrees_dir / candidate
+        branch_name = f"worktree-{candidate}"
+        if worktree_dir.exists() or _ref_exists(branch_name):
+            continue
+        return candidate, worktree_dir, branch_name
+
+    raise _worktree_name_exhausted_error()
 
 
 def create_worktree(
@@ -344,13 +386,7 @@ def create_worktree(
     else:
         base_branch = get_default_remote_branch()
 
-    name = generate_worktree_name() if name is None else _validate_worktree_name(name)
-
-    worktree_dir = git_root / ".synapse" / "worktrees" / name
-    branch_name = f"worktree-{name}"
-
-    if worktree_dir.exists():
-        raise RuntimeError(f"Worktree directory already exists: {worktree_dir}")
+    name, worktree_dir, branch_name = _allocate_worktree_name(git_root, name)
 
     # Ensure parent directory exists
     worktree_dir.parent.mkdir(parents=True, exist_ok=True)

--- a/synapse/worktree.py
+++ b/synapse/worktree.py
@@ -330,6 +330,30 @@ def _worktree_directory_exists_error(worktree_dir: Path) -> RuntimeError:
     )
 
 
+def _worktree_branch_exists_error(branch_name: str) -> RuntimeError:
+    return RuntimeError(
+        f"Worktree branch already exists: {branch_name}. "
+        f"Run 'git branch -D {branch_name}' to delete it, "
+        "or pass a different --name."
+    )
+
+
+# Substrings git emits in stderr when `git worktree add` fails because the
+# target path or branch ref is already in use. These map to the same
+# collision conditions _allocate_worktree_name pre-checks against, so
+# encountering them after a successful pre-check signals a TOCTOU race
+# (e.g. a parallel spawn raced ahead between the check and the add).
+_WORKTREE_ADD_COLLISION_MARKERS = (
+    "already exists",  # "fatal: '<path>' already exists"
+    "already checked out",  # "fatal: '<branch>' is already checked out"
+    "already used by worktree",  # "fatal: '<branch>' is already used by worktree"
+)
+
+
+def _is_worktree_add_collision(stderr: str) -> bool:
+    return any(marker in stderr for marker in _WORKTREE_ADD_COLLISION_MARKERS)
+
+
 def _allocate_worktree_name(git_root: Path, name: str | None) -> tuple[str, Path, str]:
     """Return a validated unique worktree name, directory, and branch."""
     worktrees_dir = git_root / ".synapse" / "worktrees"
@@ -337,9 +361,12 @@ def _allocate_worktree_name(git_root: Path, name: str | None) -> tuple[str, Path
     if name is not None:
         validated_name = _validate_worktree_name(name)
         worktree_dir = worktrees_dir / validated_name
+        branch_name = f"worktree-{validated_name}"
         if worktree_dir.exists():
             raise _worktree_directory_exists_error(worktree_dir)
-        return validated_name, worktree_dir, f"worktree-{validated_name}"
+        if _ref_exists(branch_name):
+            raise _worktree_branch_exists_error(branch_name)
+        return validated_name, worktree_dir, branch_name
 
     for _ in range(MAX_AUTO_NAME_ATTEMPTS):
         candidate = generate_worktree_name()
@@ -386,17 +413,45 @@ def create_worktree(
     else:
         base_branch = get_default_remote_branch()
 
+    requested_name = name
     name, worktree_dir, branch_name = _allocate_worktree_name(git_root, name)
 
     # Ensure parent directory exists
     worktree_dir.parent.mkdir(parents=True, exist_ok=True)
 
-    result = subprocess.run(
-        ["git", "worktree", "add", str(worktree_dir), "-b", branch_name, base_branch],
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0:
+    # When name is auto-generated, the pre-checks in _allocate_worktree_name
+    # are advisory only — a parallel `synapse spawn --worktree` can still
+    # race in between the check and `git worktree add`. Retry the full
+    # allocate-then-add cycle when git fails with a collision marker so
+    # one losing racer falls back to a fresh candidate instead of dying.
+    # User-specified names propagate the failure as before; the caller
+    # picked a specific name and we do not silently substitute another.
+    auto_attempts_left = MAX_AUTO_NAME_ATTEMPTS - 1 if requested_name is None else 0
+    while True:
+        result = subprocess.run(
+            [
+                "git",
+                "worktree",
+                "add",
+                str(worktree_dir),
+                "-b",
+                branch_name,
+                base_branch,
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            break
+        if (
+            requested_name is None
+            and auto_attempts_left > 0
+            and _is_worktree_add_collision(result.stderr)
+        ):
+            auto_attempts_left -= 1
+            name, worktree_dir, branch_name = _allocate_worktree_name(git_root, None)
+            worktree_dir.parent.mkdir(parents=True, exist_ok=True)
+            continue
         raise RuntimeError(
             f"Failed to create worktree '{name}': {result.stderr.strip()}"
         )

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -245,12 +245,14 @@ class TestCreateWorktree:
 
     @patch("synapse.worktree.get_default_remote_branch", return_value="origin/main")
     @patch("synapse.worktree.get_main_repo_root", return_value=Path("/repo"))
+    @patch("synapse.worktree._ref_exists", return_value=False)
     @patch("subprocess.run")
     @patch("pathlib.Path.mkdir")
     def test_create_worktree_with_name(
         self,
         mock_mkdir: MagicMock,
         mock_run: MagicMock,
+        mock_ref_exists: MagicMock,
         mock_main_root: MagicMock,
         mock_remote: MagicMock,
     ) -> None:
@@ -455,6 +457,123 @@ class TestCreateWorktree:
         assert info.name == "calm-owl"
         assert info.branch == "worktree-calm-owl"
         assert mock_run.call_args[0][0][5] == "worktree-calm-owl"
+
+    @patch("synapse.worktree.get_default_remote_branch", return_value="origin/main")
+    @patch("synapse.worktree.get_main_repo_root")
+    def test_user_specified_branch_collision_raises_actionable(
+        self,
+        mock_main_root: MagicMock,
+        mock_remote: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        # Pre-checks should reject an explicit --name whose branch already
+        # exists, so the caller gets the same actionable hint as the
+        # directory-collision path instead of a generic git failure.
+        repo = tmp_path / "repo"
+        mock_main_root.return_value = repo
+
+        with patch("synapse.worktree._ref_exists", return_value=True):
+            with pytest.raises(RuntimeError) as exc_info:
+                create_worktree(name="taken-branch")
+
+        message = str(exc_info.value)
+        assert "Worktree branch already exists: worktree-taken-branch" in message
+        assert "git branch -D worktree-taken-branch" in message
+        assert "pass a different --name" in message
+
+    @patch("synapse.worktree.get_default_remote_branch", return_value="origin/main")
+    @patch("synapse.worktree.get_main_repo_root")
+    @patch("subprocess.run")
+    def test_auto_generated_name_retries_on_git_add_collision(
+        self,
+        mock_run: MagicMock,
+        mock_main_root: MagicMock,
+        mock_remote: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        # TOCTOU: a parallel spawn races between pre-checks and `git
+        # worktree add`. The losing racer must fall back to a fresh
+        # candidate when git reports a path/branch collision, not die.
+        repo = tmp_path / "repo"
+        mock_main_root.return_value = repo
+        mock_run.side_effect = [
+            MagicMock(
+                returncode=128,
+                stdout="",
+                stderr="fatal: '.synapse/worktrees/bold-fox' already exists",
+            ),
+            MagicMock(returncode=0, stdout="", stderr=""),
+        ]
+
+        with patch(
+            "synapse.worktree.generate_worktree_name",
+            side_effect=["bold-fox", "calm-owl"],
+        ):
+            with patch("synapse.worktree._ref_exists", return_value=False):
+                info = create_worktree()
+
+        assert info.name == "calm-owl"
+        assert info.branch == "worktree-calm-owl"
+        assert mock_run.call_count == 2
+        assert mock_run.call_args_list[1][0][0][5] == "worktree-calm-owl"
+
+    @patch("synapse.worktree.get_default_remote_branch", return_value="origin/main")
+    @patch("synapse.worktree.get_main_repo_root")
+    @patch("subprocess.run")
+    def test_user_specified_name_does_not_retry_on_git_add_collision(
+        self,
+        mock_run: MagicMock,
+        mock_main_root: MagicMock,
+        mock_remote: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        # Explicit --name must not be silently swapped for another name on
+        # post-precheck collision; the caller picked it deliberately.
+        repo = tmp_path / "repo"
+        mock_main_root.return_value = repo
+        mock_run.return_value = MagicMock(
+            returncode=128,
+            stdout="",
+            stderr="fatal: '.synapse/worktrees/explicit-name' already exists",
+        )
+
+        with patch("synapse.worktree._ref_exists", return_value=False):
+            with pytest.raises(RuntimeError, match="Failed to create worktree"):
+                create_worktree(name="explicit-name")
+
+        assert mock_run.call_count == 1
+
+    @patch("synapse.worktree.get_default_remote_branch", return_value="origin/main")
+    @patch("synapse.worktree.get_main_repo_root")
+    @patch("subprocess.run")
+    def test_auto_generated_git_add_retry_exhausts(
+        self,
+        mock_run: MagicMock,
+        mock_main_root: MagicMock,
+        mock_remote: MagicMock,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Every retry races and loses. After MAX_AUTO_NAME_ATTEMPTS we
+        # surface the last git failure rather than spinning forever.
+        repo = tmp_path / "repo"
+        mock_main_root.return_value = repo
+        monkeypatch.setattr("synapse.worktree.MAX_AUTO_NAME_ATTEMPTS", 3, raising=False)
+        mock_run.return_value = MagicMock(
+            returncode=128,
+            stdout="",
+            stderr="fatal: 'worktree-x' is already used by worktree at /tmp/x",
+        )
+
+        with patch(
+            "synapse.worktree.generate_worktree_name",
+            side_effect=["a", "b", "c"],
+        ):
+            with patch("synapse.worktree._ref_exists", return_value=False):
+                with pytest.raises(RuntimeError, match="Failed to create worktree"):
+                    create_worktree()
+
+        assert mock_run.call_count == 3
 
     @patch("synapse.worktree.get_default_remote_branch", return_value="origin/main")
     @patch("synapse.worktree.get_main_repo_root", return_value=Path("/repo"))

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -214,12 +214,14 @@ class TestGenerateWorktreeName:
 class TestCreateWorktree:
     @patch("synapse.worktree.get_default_remote_branch", return_value="origin/main")
     @patch("synapse.worktree.get_main_repo_root", return_value=Path("/repo"))
+    @patch("synapse.worktree._ref_exists", return_value=False)
     @patch("subprocess.run")
     @patch("pathlib.Path.mkdir")
     def test_create_worktree_auto_name(
         self,
         mock_mkdir: MagicMock,
         mock_run: MagicMock,
+        mock_ref_exists: MagicMock,
         mock_main_root: MagicMock,
         mock_remote: MagicMock,
     ) -> None:
@@ -262,12 +264,14 @@ class TestCreateWorktree:
         assert info.path == Path("/repo/.synapse/worktrees/feature-auth")
 
     @patch("synapse.worktree.get_main_repo_root", return_value=Path("/repo"))
+    @patch("synapse.worktree._ref_exists", return_value=False)
     @patch("subprocess.run")
     @patch("pathlib.Path.mkdir")
     def test_create_worktree_with_custom_base_branch(
         self,
         mock_mkdir: MagicMock,
         mock_run: MagicMock,
+        mock_ref_exists: MagicMock,
         mock_main_root: MagicMock,
     ) -> None:
         """When base_branch is provided, it should be used instead of get_default_remote_branch."""
@@ -287,12 +291,14 @@ class TestCreateWorktree:
 
     @patch("synapse.worktree.get_default_remote_branch", return_value="origin/main")
     @patch("synapse.worktree.get_main_repo_root", return_value=Path("/repo"))
+    @patch("synapse.worktree._ref_exists", return_value=False)
     @patch("subprocess.run")
     @patch("pathlib.Path.mkdir")
     def test_create_worktree_base_branch_none_uses_default(
         self,
         mock_mkdir: MagicMock,
         mock_run: MagicMock,
+        mock_ref_exists: MagicMock,
         mock_main_root: MagicMock,
         mock_remote: MagicMock,
     ) -> None:
@@ -339,6 +345,118 @@ class TestCreateWorktree:
                 create_worktree(name="existing-wt")
 
     @patch("synapse.worktree.get_default_remote_branch", return_value="origin/main")
+    @patch("synapse.worktree.get_main_repo_root")
+    @patch("subprocess.run")
+    def test_auto_generated_name_retries_on_directory_collision(
+        self,
+        mock_run: MagicMock,
+        mock_main_root: MagicMock,
+        mock_remote: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        repo = tmp_path / "repo"
+        (repo / ".synapse" / "worktrees" / "bold-fox").mkdir(parents=True)
+        mock_main_root.return_value = repo
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch(
+            "synapse.worktree.generate_worktree_name",
+            side_effect=["bold-fox", "calm-owl"],
+        ):
+            with patch("synapse.worktree._ref_exists", return_value=False):
+                info = create_worktree()
+
+        assert info.name == "calm-owl"
+        assert info.path == repo / ".synapse" / "worktrees" / "calm-owl"
+        assert info.branch == "worktree-calm-owl"
+        assert mock_run.call_args[0][0] == [
+            "git",
+            "worktree",
+            "add",
+            str(repo / ".synapse" / "worktrees" / "calm-owl"),
+            "-b",
+            "worktree-calm-owl",
+            "origin/main",
+        ]
+
+    @patch("synapse.worktree.get_default_remote_branch", return_value="origin/main")
+    @patch("synapse.worktree.get_main_repo_root")
+    @patch("subprocess.run")
+    def test_auto_generated_name_exhaustion_raises_actionable(
+        self,
+        mock_run: MagicMock,
+        mock_main_root: MagicMock,
+        mock_remote: MagicMock,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        repo = tmp_path / "repo"
+        for name in ["bold-fox", "calm-owl", "safe-goat"]:
+            (repo / ".synapse" / "worktrees" / name).mkdir(parents=True)
+        mock_main_root.return_value = repo
+        monkeypatch.setattr("synapse.worktree.MAX_AUTO_NAME_ATTEMPTS", 3, raising=False)
+
+        with patch(
+            "synapse.worktree.generate_worktree_name",
+            side_effect=["bold-fox", "calm-owl", "safe-goat"],
+        ):
+            with patch("synapse.worktree._ref_exists", return_value=False):
+                with pytest.raises(RuntimeError) as exc_info:
+                    create_worktree()
+
+        message = str(exc_info.value)
+        assert "Could not allocate a unique worktree name after 3 attempts" in message
+        assert "git worktree list" in message
+        assert "git worktree prune" in message
+        mock_run.assert_not_called()
+
+    @patch("synapse.worktree.get_default_remote_branch", return_value="origin/main")
+    @patch("synapse.worktree.get_main_repo_root")
+    def test_user_specified_name_collision_raises_actionable(
+        self,
+        mock_main_root: MagicMock,
+        mock_remote: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        repo = tmp_path / "repo"
+        worktree_dir = repo / ".synapse" / "worktrees" / "existing-wt"
+        worktree_dir.mkdir(parents=True)
+        mock_main_root.return_value = repo
+
+        with pytest.raises(RuntimeError) as exc_info:
+            create_worktree(name="existing-wt")
+
+        message = str(exc_info.value)
+        assert f"Worktree directory already exists: {worktree_dir}" in message
+        assert f"git worktree remove {worktree_dir}" in message
+        assert "pass a different --name" in message
+
+    @patch("synapse.worktree.get_default_remote_branch", return_value="origin/main")
+    @patch("synapse.worktree.get_main_repo_root")
+    @patch("subprocess.run")
+    def test_auto_generated_name_retries_on_branch_collision(
+        self,
+        mock_run: MagicMock,
+        mock_main_root: MagicMock,
+        mock_remote: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        repo = tmp_path / "repo"
+        mock_main_root.return_value = repo
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch(
+            "synapse.worktree.generate_worktree_name",
+            side_effect=["bold-fox", "calm-owl"],
+        ):
+            with patch("synapse.worktree._ref_exists", side_effect=[True, False]):
+                info = create_worktree()
+
+        assert info.name == "calm-owl"
+        assert info.branch == "worktree-calm-owl"
+        assert mock_run.call_args[0][0][5] == "worktree-calm-owl"
+
+    @patch("synapse.worktree.get_default_remote_branch", return_value="origin/main")
     @patch("synapse.worktree.get_main_repo_root", return_value=Path("/repo"))
     @patch("subprocess.run")
     @patch("pathlib.Path.mkdir")
@@ -360,12 +478,14 @@ class TestCreateWorktree:
 
     @patch("synapse.worktree.get_default_remote_branch", return_value="origin/main")
     @patch("synapse.worktree.get_main_repo_root", return_value=Path("/repo"))
+    @patch("synapse.worktree._ref_exists", return_value=False)
     @patch("subprocess.run")
     @patch("pathlib.Path.mkdir")
     def test_nested_worktree_resolves_to_main_repo_root(
         self,
         mock_mkdir: MagicMock,
         mock_run: MagicMock,
+        mock_ref_exists: MagicMock,
         mock_main_root: MagicMock,
         mock_remote: MagicMock,
     ) -> None:
@@ -393,12 +513,14 @@ class TestCreateWorktree:
 
     @patch("synapse.worktree.get_default_remote_branch", return_value="origin/main")
     @patch("synapse.worktree.get_main_repo_root", return_value=Path("/repo"))
+    @patch("synapse.worktree._ref_exists", return_value=False)
     @patch("subprocess.run")
     @patch("pathlib.Path.mkdir")
     def test_worktree_creation_from_repo_root_is_unchanged(
         self,
         mock_mkdir: MagicMock,
         mock_run: MagicMock,
+        mock_ref_exists: MagicMock,
         mock_main_root: MagicMock,
         mock_remote: MagicMock,
     ) -> None:


### PR DESCRIPTION
## Summary
- Retry auto-generated worktree names when either the target directory or worktree branch already exists.
- Keep explicit --name collisions strict, but add cleanup guidance to the error message.
- Add regression tests for directory collisions, branch collisions, exhaustion, and explicit-name errors.

Closes #704

## Tests
- uv run pytest tests/test_worktree.py -k "auto_generated_name or user_specified_name_collision" -v
- uv run pytest tests/test_worktree.py -v
- env HOME=/tmp/synapse-test-home uv run pytest


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ワークツリー名の競合検出を改善。ファイルシステムとGit参照の両方を確認して競合を検出するようになりました。

* **新機能**
  * 自動名生成で名前が競合した場合、再試行機能を追加。制限回数内で利用可能な名前が見つかるまで自動的に別の名前を試します。利用可能な名前がない場合は、より詳細なエラーメッセージが表示されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->