### PR TITLE
chore(gitignore): ignore .synapse/ and .claude/worktrees/ runtime artifacts (#713)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,10 @@ venv/
 .synapse/*.db-wal
 .synapse/waiting_debug.jsonl
 .synapse/waiting_debug.*
+.synapse/tasks/
+.synapse/wiki/
+.synapse/wiki.md
+.synapse/worktrees/
 
 # OS
 .DS_Store
@@ -61,3 +65,4 @@ mcp-*.png
 
 # Synapse runtime artifacts
 .claude/scheduled_tasks.lock
+.claude/worktrees/


### PR DESCRIPTION
## Summary

- Add the runtime-only paths that synapse-a2a / claude-code create during normal use (`.synapse/tasks/`, `.synapse/wiki/`, `.synapse/wiki.md`, `.synapse/worktrees/`, `.claude/worktrees/`) so they stop appearing as `??` in `git status`.
- No tracked files are affected: pre-existing committed files under `.synapse/` (settings/agent definitions, DB files, default/learning/proactive instruction sources) and the existing `.claude/worktrees/elastic-black` gitlink remain visible — gitignore patterns do not hide already-tracked paths.

## Verification

`git check-ignore -v` confirms each new pattern matches its intended target:

```
.gitignore:46:.synapse/tasks/        .synapse/tasks/foo.md
.gitignore:47:.synapse/wiki/         .synapse/wiki/index.md
.gitignore:48:.synapse/wiki.md       .synapse/wiki.md
.gitignore:49:.synapse/worktrees/    .synapse/worktrees/foo
.gitignore:68:.claude/worktrees/     .claude/worktrees/focused-raman-809768/
```

And tracked files probed (`.synapse/default.md`, `.synapse/settings.json`, `.synapse/agents/claude-agent.agent`, `.claude/settings.json`, `.claude/worktrees/elastic-black`) return no match — they stay tracked.

After the change, `git status --short` is clean (only `M .gitignore` itself).

## Linked Issues

Closes #713

## Test plan

- [x] `git status --short` clean after change (only `M .gitignore`)
- [x] `git check-ignore -v` confirms new patterns match runtime paths
- [x] `git check-ignore -v` confirms pre-existing tracked files are NOT masked
- [x] `pytest -q` green (no source-code changes; sanity check only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * .gitignoreファイルを更新し、5つの新しいエントリを除外リストに追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->