### PR TITLE
fix(kill): skip auto-merge when worktree branch has open PR (#714)

### DIFF
--- a/synapse/worktree.py
+++ b/synapse/worktree.py
@@ -11,6 +11,7 @@ branch named ``worktree-<name>``.
 from __future__ import annotations
 
 import filecmp
+import json
 import logging
 import random
 import re
@@ -19,6 +20,8 @@ import subprocess
 import time
 from dataclasses import dataclass
 from pathlib import Path
+
+_GH_PR_LIST_TIMEOUT_SECS = 5
 
 logger = logging.getLogger(__name__)
 
@@ -584,6 +587,59 @@ def has_worktree_changes(info: WorktreeInfo) -> bool:
     )
 
 
+def _branch_has_open_pr(branch: str) -> int | None:
+    """Return the number of an open GitHub PR whose head is ``branch``, else None.
+
+    Uses ``gh pr list --head <branch> --state open --json number`` so we can
+    skip local auto-merge for branches already managed by a PR (issue #714).
+
+    Fail-open contract: any failure mode (gh missing, timeout, non-zero exit,
+    malformed JSON) returns ``None`` so that callers fall back to the existing
+    merge behaviour rather than blocking ``synapse kill`` on a remote check.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "gh",
+                "pr",
+                "list",
+                "--head",
+                branch,
+                "--state",
+                "open",
+                "--json",
+                "number",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=_GH_PR_LIST_TIMEOUT_SECS,
+        )
+        if result.returncode != 0:
+            logger.debug(
+                "gh pr list returncode=%d for %s: %s",
+                result.returncode,
+                branch,
+                result.stderr.strip(),
+            )
+            return None
+        prs = json.loads(result.stdout)
+        number = prs[0]["number"]
+        if not isinstance(number, int):
+            return None
+        return number
+    except (
+        FileNotFoundError,
+        subprocess.TimeoutExpired,
+        OSError,
+        json.JSONDecodeError,
+        KeyError,
+        IndexError,
+        TypeError,
+    ):
+        logger.debug("gh pr list unavailable for %s", branch, exc_info=True)
+        return None
+
+
 def merge_worktree(
     info: WorktreeInfo,
     auto_commit_wip: bool = True,
@@ -650,6 +706,21 @@ def merge_worktree(
         commits = True
 
     if not commits:
+        return True
+
+    pr_number = _branch_has_open_pr(info.branch)
+    if pr_number is not None:
+        print(
+            f"[Synapse] Skipping local merge for {info.branch} "
+            f"(managed by PR #{pr_number})."
+        )
+        print(f"  Merge will happen via GitHub when PR #{pr_number} is approved.")
+        print("  Branch preserved locally for reference.")
+        logger.info(
+            "event=worktree_merge_skipped branch=%s pr=%d",
+            info.branch,
+            pr_number,
+        )
         return True
 
     git_root = get_git_root()

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -1233,12 +1233,14 @@ class TestMergeWorktree:
             created_at=1000.0,
         )
 
+    @patch("synapse.worktree._branch_has_open_pr", return_value=None)
     @patch("synapse.worktree.get_git_root", return_value=Path("/repo"))
     @patch("subprocess.run")
     def test_merge_success(
         self,
         mock_run: MagicMock,
         mock_git_root: MagicMock,
+        mock_pr_check: MagicMock,
     ) -> None:
         """Successful merge should return True."""
         info = self._make_info()
@@ -1252,12 +1254,14 @@ class TestMergeWorktree:
         assert "--no-edit" in call_args[0][0]
         assert call_args[1].get("cwd") == str(Path("/repo"))
 
+    @patch("synapse.worktree._branch_has_open_pr", return_value=None)
     @patch("synapse.worktree.get_git_root", return_value=Path("/repo"))
     @patch("subprocess.run")
     def test_merge_auto_commit_wip(
         self,
         mock_run: MagicMock,
         mock_git_root: MagicMock,
+        mock_pr_check: MagicMock,
     ) -> None:
         """Should auto-commit uncommitted changes before merging."""
         info = self._make_info()
@@ -1273,12 +1277,14 @@ class TestMergeWorktree:
         assert "-u" in first_call[0][0]
         assert first_call[1].get("cwd") == str(info.path)
 
+    @patch("synapse.worktree._branch_has_open_pr", return_value=None)
     @patch("synapse.worktree.get_git_root", return_value=Path("/repo"))
     @patch("subprocess.run")
     def test_merge_skip_wip_when_disabled(
         self,
         mock_run: MagicMock,
         mock_git_root: MagicMock,
+        mock_pr_check: MagicMock,
     ) -> None:
         """Should not auto-commit when auto_commit_wip=False."""
         info = self._make_info()
@@ -1291,12 +1297,14 @@ class TestMergeWorktree:
         assert mock_run.call_count == 1
         assert "merge" in mock_run.call_args[0][0]
 
+    @patch("synapse.worktree._branch_has_open_pr", return_value=None)
     @patch("synapse.worktree.get_git_root", return_value=Path("/repo"))
     @patch("subprocess.run")
     def test_merge_conflict(
         self,
         mock_run: MagicMock,
         mock_git_root: MagicMock,
+        mock_pr_check: MagicMock,
     ) -> None:
         """On conflict, should abort merge and return False."""
         info = self._make_info()
@@ -1319,6 +1327,127 @@ class TestMergeWorktree:
         info = self._make_info()
         result = merge_worktree(info, _has_uncommitted=False, _has_commits=False)
         assert result is True
+
+    @patch("synapse.worktree._branch_has_open_pr", return_value=711)
+    @patch("synapse.worktree.get_git_root", return_value=Path("/repo"))
+    @patch("subprocess.run")
+    def test_cleanup_skips_merge_when_open_pr_exists(
+        self,
+        mock_run: MagicMock,
+        mock_git_root: MagicMock,
+        mock_pr_check: MagicMock,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """If the worktree branch is the head of an open PR, skip auto-merge.
+
+        Issue #714: ``synapse kill`` should not try to merge branches that are
+        already managed by a PR — they will be merged via GitHub. Reporting
+        a local merge conflict in that case misleads the user.
+        """
+        info = self._make_info()
+        result = merge_worktree(info, _has_uncommitted=False, _has_commits=True)
+        assert result is True
+        mock_run.assert_not_called()
+        mock_pr_check.assert_called_once_with(info.branch)
+        captured = capsys.readouterr()
+        assert "Skipping local merge" in captured.out
+        assert info.branch in captured.out
+        assert "PR #711" in captured.out
+
+    @patch("synapse.worktree._branch_has_open_pr", return_value=None)
+    @patch("synapse.worktree.get_git_root", return_value=Path("/repo"))
+    @patch("subprocess.run")
+    def test_cleanup_attempts_merge_when_no_pr_exists(
+        self,
+        mock_run: MagicMock,
+        mock_git_root: MagicMock,
+        mock_pr_check: MagicMock,
+    ) -> None:
+        """No open PR ⇒ existing auto-merge behaviour must run unchanged."""
+        info = self._make_info()
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        result = merge_worktree(info, _has_uncommitted=False, _has_commits=True)
+        assert result is True
+        mock_run.assert_called_once()
+        assert "merge" in mock_run.call_args[0][0]
+        mock_pr_check.assert_called_once_with(info.branch)
+
+    @patch("synapse.worktree._branch_has_open_pr", return_value=None)
+    @patch("synapse.worktree.get_git_root", return_value=Path("/repo"))
+    @patch("subprocess.run")
+    def test_cleanup_attempts_merge_when_gh_unavailable(
+        self,
+        mock_run: MagicMock,
+        mock_git_root: MagicMock,
+        mock_pr_check: MagicMock,
+    ) -> None:
+        """gh missing/timeout/error ⇒ fail-open: fall back to current merge logic.
+
+        ``_branch_has_open_pr`` is responsible for swallowing ``FileNotFoundError``
+        and ``subprocess.TimeoutExpired`` and returning ``None`` so that ``kill``
+        never hangs or crashes when ``gh`` is unavailable.
+        """
+        info = self._make_info()
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        result = merge_worktree(info, _has_uncommitted=False, _has_commits=True)
+        assert result is True
+        mock_run.assert_called_once()
+
+
+class TestBranchHasOpenPr:
+    """Tests for the gh-backed PR detection helper."""
+
+    def test_returns_pr_number_when_open_pr_exists(self) -> None:
+        from synapse.worktree import _branch_has_open_pr
+
+        completed = MagicMock(returncode=0, stdout='[{"number": 711}]', stderr="")
+        with patch("subprocess.run", return_value=completed) as mock_run:
+            assert _branch_has_open_pr("worktree-safe-goat") == 711
+        cmd = mock_run.call_args[0][0]
+        assert cmd[0] == "gh"
+        assert "pr" in cmd and "list" in cmd
+        assert "--head" in cmd
+        assert "worktree-safe-goat" in cmd
+        assert "--state" in cmd
+        assert "open" in cmd
+
+    def test_returns_none_when_no_open_pr(self) -> None:
+        from synapse.worktree import _branch_has_open_pr
+
+        completed = MagicMock(returncode=0, stdout="[]", stderr="")
+        with patch("subprocess.run", return_value=completed):
+            assert _branch_has_open_pr("worktree-foo") is None
+
+    def test_returns_none_when_gh_missing(self) -> None:
+        from synapse.worktree import _branch_has_open_pr
+
+        with patch("subprocess.run", side_effect=FileNotFoundError("gh")):
+            assert _branch_has_open_pr("worktree-foo") is None
+
+    def test_returns_none_on_timeout(self) -> None:
+        import subprocess as sp
+
+        from synapse.worktree import _branch_has_open_pr
+
+        with patch(
+            "subprocess.run",
+            side_effect=sp.TimeoutExpired(cmd="gh", timeout=5),
+        ):
+            assert _branch_has_open_pr("worktree-foo") is None
+
+    def test_returns_none_on_nonzero_exit(self) -> None:
+        from synapse.worktree import _branch_has_open_pr
+
+        completed = MagicMock(returncode=1, stdout="", stderr="not authenticated")
+        with patch("subprocess.run", return_value=completed):
+            assert _branch_has_open_pr("worktree-foo") is None
+
+    def test_returns_none_on_malformed_json(self) -> None:
+        from synapse.worktree import _branch_has_open_pr
+
+        completed = MagicMock(returncode=0, stdout="not json", stderr="")
+        with patch("subprocess.run", return_value=completed):
+            assert _branch_has_open_pr("worktree-foo") is None
 
 
 # ============================================================


### PR DESCRIPTION
## Summary
- `synapse kill <agent>` previously tried to merge any worktree branch into local `main`, even when that branch was already the head of an open GitHub PR. On conflict it printed a misleading recovery hint (`Resolve manually: git merge <branch>`) although the PR is the canonical merge path.
- This PR adds a pre-check: if `gh pr list --head <branch> --state open` returns ≥1 PR, the local auto-merge is skipped and an informational message points to the PR.
- Failure-mode contract for the new helper is **fail-open**: missing `gh`, 5s timeout, non-zero exit, or malformed JSON → fall back to existing merge behaviour so `kill` is never blocked or hung on a remote check.

## Implementation
- `synapse/worktree.py`: added `_branch_has_open_pr(branch) -> int | None` and gated `merge_worktree` on it (after WIP commit, before `git merge`).
- New informational output:
  ```
  [Synapse] Skipping local merge for worktree-X (managed by PR #N).
    Merge will happen via GitHub when PR #N is approved.
    Branch preserved locally for reference.
  ```

## Test plan
- [x] `tests/test_worktree.py` — 3 new tests on the merge path (skip-when-PR / merge-when-no-PR / merge-when-gh-unavailable) and 6 unit tests on `_branch_has_open_pr` covering each fail-open branch (gh missing, timeout, non-zero exit, malformed JSON, empty list, success).
- [x] All 91 tests in `tests/test_worktree.py` pass.
- [x] Full `pytest` (4454 tests) — 4447 pass; 7 unrelated pre-existing failures (file-safety env handling, learning-mode injection, settings, send-ready-delay test-order flake) confirmed via `git stash` to exist on `main`. None touch worktree/kill paths.

## Linked Issues
Closes #714

🤖 Generated with [Claude Code](https://claude.com/claude-code)