### PR TITLE
fix(spawn): make port allocation atomic to fix parallel-spawn race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Parallel `synapse spawn` no longer races on port allocation. Two simultaneous spawns of the same profile (e.g. `synapse spawn claude --worktree` × 2 in parallel) could both receive the same free port from `PortManager.get_available_port` because port discovery and registry write were not in the same critical section — the second spawn then overwrote the first's `synapse-{type}-{port}.json` registry entry, leaving the first agent visible as `READY` in some views but mis-labeled with the second agent's name and worktree, and leaving the first worktree as a physical orphan on disk. The new `PortManager.allocate_and_register` API performs free-port discovery and a placeholder registry write inside a single `AgentRegistry.registry_write_lock` (cross-process `fcntl.flock`) critical section, so parallel spawns serialize at the lock and observe each other's reservations. The `cli.py` spawn path now reserves the placeholder before worktree creation and rolls it back if worktree creation fails. The legacy `register()` signature is preserved (it is now a thin wrapper around the lock-aware `_register_locked`) and `get_available_port` is unchanged for backward compatibility. Closes #715.
+
 ## [0.34.0] - 2026-05-02
 
 This release closes a cluster of issues exposed during real multi-agent dogfooding: the Codex CLI 0.128 deprecation that broke `synapse spawn codex` (#705), a watchdog blind spot for codex's edit-confirmation dialog (#694/#707), divergence between `synapse status --json` and `synapse list --json` (#696/#708), and a worktree name-collision crash on auto-generated names (#704/#711).

--- a/synapse/cli.py
+++ b/synapse/cli.py
@@ -113,6 +113,7 @@ from synapse.controller import TerminalController
 from synapse.logging_config import setup_logging
 from synapse.port_manager import (
     PORT_RANGES,
+    PortExhaustionError,
     PortManager,
     is_process_alive,
 )
@@ -2720,20 +2721,31 @@ def main() -> None:
             skill_set_arg = skill_set_arg or saved.skill_set
 
         explicit_port = port is not None
+        placeholder_agent_id: str | None = None
 
-        # Auto-select available port if not specified
+        # Auto-select available port if not specified. allocate_and_register
+        # holds registry_write_lock across free-port discovery + placeholder
+        # write so two parallel spawns can't both pick the same free port
+        # (issue #715).
         if port is None:
             registry = AgentRegistry()
             port_manager = PortManager(registry)
-            port = port_manager.get_available_port(profile)
-
-            if port is None:
+            try:
+                port, placeholder_agent_id = port_manager.allocate_and_register(
+                    profile, name=name
+                )
+            except PortExhaustionError:
                 print(port_manager.format_exhaustion_error(profile))
+                sys.exit(1)
+            except NameConflictError as e:
+                print(f"Error: {e}", file=sys.stderr)
                 sys.exit(1)
 
         assert port is not None  # Type narrowing for mypy/ty
 
-        # Create worktree if requested and set env vars
+        # Create worktree if requested and set env vars. If worktree creation
+        # fails after we reserved a port, drop the placeholder so the port
+        # isn't held by a dead reservation.
         if worktree_arg:
             from synapse.worktree import create_worktree as _create_wt
 
@@ -2741,6 +2753,8 @@ def main() -> None:
             try:
                 wt_info = _create_wt(name=wt_name)
             except (RuntimeError, ValueError) as e:
+                if placeholder_agent_id is not None:
+                    AgentRegistry().unregister(placeholder_agent_id)
                 print(f"Error creating worktree: {e}", file=sys.stderr)
                 sys.exit(1)
             os.chdir(wt_info.path)
@@ -2770,10 +2784,20 @@ def main() -> None:
                 if explicit_port or e.errno != errno.EADDRINUSE:
                     raise
 
+                # The port we held is unusable (orphan listener appeared after
+                # our placeholder write). Drop the stale placeholder and
+                # atomically reserve a fresh one.
                 registry = AgentRegistry()
                 port_manager = PortManager(registry)
-                next_port = port_manager.get_available_port(profile)
-                if next_port is None or next_port == port:
+                if placeholder_agent_id is not None:
+                    registry.unregister(placeholder_agent_id)
+                try:
+                    next_port, placeholder_agent_id = (
+                        port_manager.allocate_and_register(profile, name=name)
+                    )
+                except (PortExhaustionError, NameConflictError):
+                    raise e from None
+                if next_port == port:
                     raise
                 port = next_port
         return

--- a/synapse/port_manager.py
+++ b/synapse/port_manager.py
@@ -1,15 +1,28 @@
 """Port management for Synapse A2A multi-instance support."""
 
 import logging
+import os
 import socket
+import time
 from typing import TYPE_CHECKING
 
-from synapse.registry import is_process_running
+from synapse.registry import is_process_running, resolve_uds_path
+from synapse.status import PROCESSING
 
 if TYPE_CHECKING:
     from synapse.registry import AgentRegistry
 
 logger = logging.getLogger(__name__)
+
+
+class PortExhaustionError(RuntimeError):
+    """Raised when no free port is available in an agent type's port range.
+
+    Distinguished from a generic registry write error so callers (cli.py
+    spawn path) can present the existing exhaustion-help text without
+    catching unrelated runtime errors.
+    """
+
 
 # Port range definitions (agent_type -> (start, end) inclusive)
 PORT_RANGES: dict[str, tuple[int, int]] = {
@@ -137,6 +150,120 @@ class PortManager:
 
             return port
 
+        return None
+
+    def allocate_and_register(
+        self,
+        agent_type: str,
+        *,
+        name: str | None = None,
+        pid: int | None = None,
+    ) -> tuple[int, str]:
+        """Atomically reserve a free port and write a placeholder registry entry.
+
+        Holds ``AgentRegistry.registry_write_lock`` (a cross-process flock)
+        for both free-port discovery AND the placeholder write, eliminating
+        the issue #715 race window in which two parallel spawns could both
+        receive the same free port from ``get_available_port`` and then race
+        to overwrite each other's registry file.
+
+        The placeholder is committed with ``status=PROCESSING`` and the
+        caller's pid (defaults to ``os.getpid()``). The full register call
+        with worktree metadata, role, etc. happens later via
+        ``AgentRegistry.update_*`` once setup completes.
+
+        Args:
+            agent_type: Agent type whose port range to draw from.
+            name: Optional custom name (validated for collisions inside the lock).
+            pid: PID to record (defaults to current process). Pre-set for tests.
+
+        Returns:
+            Tuple of (allocated_port, agent_id).
+
+        Raises:
+            PortExhaustionError: All ports in range are taken or have orphan listeners.
+            NameConflictError: ``name`` collides with an existing entry.
+        """
+        if pid is None:
+            pid = os.getpid()
+        start_port, end_port = get_port_range(agent_type)
+
+        with self.registry.registry_write_lock():
+            agents = self.registry.list_agents()
+            free_port = self._find_free_port_locked(
+                agent_type, start_port, end_port, agents
+            )
+            if free_port is None:
+                raise PortExhaustionError(
+                    f"All ports in range {start_port}-{end_port} are in use "
+                    f"for '{agent_type}'."
+                )
+
+            agent_id = self.registry.get_agent_id(agent_type, free_port)
+            now = time.time()
+            data: dict = {
+                "agent_id": agent_id,
+                "agent_type": agent_type,
+                "port": free_port,
+                "status": PROCESSING,
+                "status_updated_at": now,
+                "last_status_change_at": now,
+                "registered_at": now,
+                "pid": pid,
+                "working_dir": os.getcwd(),
+                "endpoint": f"http://localhost:{free_port}",
+                "uds_path": str(resolve_uds_path(agent_id)),
+            }
+            if name:
+                data["name"] = name
+
+            self.registry._register_locked(agent_id, data, name=name)
+            return free_port, agent_id
+
+    def _find_free_port_locked(
+        self,
+        agent_type: str,
+        start_port: int,
+        end_port: int,
+        agents: dict[str, dict],
+    ) -> int | None:
+        """Find the first port in [start_port, end_port] that is not held by a
+        live registered agent and not held by an orphan listener.
+
+        MUST be called with ``registry.registry_write_lock`` held — otherwise
+        the snapshot of ``agents`` becomes stale before the caller writes.
+
+        Mirrors the policy of ``get_available_port`` (skip live, clean dead,
+        skip orphan listener, take the first remaining), but operates on a
+        caller-supplied agents snapshot so the entire decision is consistent
+        with the lock-held registry view.
+        """
+        del agent_type  # only used by callers for range derivation
+        for port in range(start_port, end_port + 1):
+            registered = [
+                (agent_id, info)
+                for agent_id, info in agents.items()
+                if info.get("port") == port
+            ]
+            live_registered = False
+            for agent_id, info in registered:
+                pid = info.get("pid")
+                if pid and is_process_alive(pid):
+                    live_registered = True
+                    break
+                self.registry.unregister(agent_id)
+                agents.pop(agent_id, None)
+            if live_registered:
+                continue
+            if not is_port_available(port):
+                logger.warning(
+                    "Detected orphan listener on port %s with no live registry "
+                    "entry. Run 'synapse doctor --clean' to inspect and clean "
+                    "up orphan processes.",
+                    port,
+                )
+                continue
+            return port
         return None
 
     def get_running_instances(self, agent_type: str) -> list[dict]:

--- a/synapse/registry.py
+++ b/synapse/registry.py
@@ -88,8 +88,17 @@ class AgentRegistry:
         self._lock_file = self.registry_dir / ".registry.lock"
 
     @contextmanager
-    def _registry_write_lock(self) -> Iterator[None]:
-        """Cross-process lock for registry-wide write operations."""
+    def registry_write_lock(self) -> Iterator[None]:
+        """Cross-process lock (fcntl.flock) for registry-wide write operations.
+
+        Public so port allocation (PortManager.allocate_and_register) can
+        synchronize free-port discovery and placeholder registration as a
+        single atomic step — preventing the parallel-spawn race in #715.
+
+        The flock is per-fd and not re-entrant via re-acquisition on the same
+        path: callers that already hold this lock must use ``_register_locked``
+        instead of ``register``.
+        """
         self.registry_dir.mkdir(parents=True, exist_ok=True)
         with open(self._lock_file, "a+") as lock_file:
             try:
@@ -263,12 +272,26 @@ class AgentRegistry:
         if renderer_available is not None:
             data["renderer_available"] = renderer_available
 
+        with self.registry_write_lock():
+            return self._register_locked(agent_id, data, name=name)
+
+    def _register_locked(
+        self,
+        agent_id: str,
+        data: dict,
+        *,
+        name: str | None = None,
+    ) -> Path:
+        """Write a fully-built registry entry assuming the caller already holds
+        ``registry_write_lock``. Used by ``register`` and by
+        ``PortManager.allocate_and_register`` to atomically combine free-port
+        discovery and placeholder registration in a single critical section.
+        """
         file_path = self.registry_dir / f"{agent_id}.json"
-        with self._registry_write_lock():
-            if name and self._is_name_taken_locked(name, exclude_agent_id=agent_id):
-                raise NameConflictError(f"name '{name}' is already taken")
-            self._write_json_atomic(file_path, data)
-            self._verify_registered_file(file_path, agent_id)
+        if name and self._is_name_taken_locked(name, exclude_agent_id=agent_id):
+            raise NameConflictError(f"name '{name}' is already taken")
+        self._write_json_atomic(file_path, data)
+        self._verify_registered_file(file_path, agent_id)
 
         self._register_atexit_cleanup(agent_id)
 
@@ -353,7 +376,7 @@ class AgentRegistry:
         """
         file_path = self.registry_dir / f"{agent_id}.json"
         try:
-            with self._registry_write_lock():
+            with self.registry_write_lock():
                 if not file_path.exists():
                     return False
 

--- a/tests/test_agent_shortcut.py
+++ b/tests/test_agent_shortcut.py
@@ -37,7 +37,7 @@ def _run_main(monkeypatch: pytest.MonkeyPatch, argv: list[str]) -> MagicMock:
 
     mock_run = MagicMock()
     mock_port_mgr = MagicMock()
-    mock_port_mgr.get_available_port.return_value = 8100
+    mock_port_mgr.allocate_and_register.return_value = (8100, "synapse-claude-8100")
 
     with (
         patch("synapse.cli.cmd_run_interactive", mock_run),
@@ -157,7 +157,10 @@ def test_auto_selected_port_retries_on_bind_conflict(
         ]
     )
     mock_port_mgr = MagicMock()
-    mock_port_mgr.get_available_port.side_effect = [8100, 8101]
+    mock_port_mgr.allocate_and_register.side_effect = [
+        (8100, "synapse-claude-8100"),
+        (8101, "synapse-claude-8101"),
+    ]
 
     with (
         patch("synapse.cli.cmd_run_interactive", mock_run),

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -43,7 +43,7 @@ class TestCliMain:
     ):
         """synapse claude should trigger interactive mode."""
         mock_pm_inst = mock_pm.return_value
-        mock_pm_inst.get_available_port.return_value = 8100
+        mock_pm_inst.allocate_and_register.return_value = (8100, "synapse-claude-8100")
 
         with patch.object(sys, "argv", ["synapse", "claude"]):
             main()
@@ -96,7 +96,7 @@ class TestCliMain:
     ):
         """synapse claude -- --model opus should pass tool args."""
         mock_pm_inst = mock_pm.return_value
-        mock_pm_inst.get_available_port.return_value = 8100
+        mock_pm_inst.allocate_and_register.return_value = (8100, "synapse-claude-8100")
 
         with patch.object(sys, "argv", ["synapse", "claude", "--", "--model", "opus"]):
             main()
@@ -538,7 +538,7 @@ class TestCliMain:
     ):
         """synapse claude --name my-claude --role reviewer should pass name/role."""
         mock_pm_inst = mock_pm.return_value
-        mock_pm_inst.get_available_port.return_value = 8100
+        mock_pm_inst.allocate_and_register.return_value = (8100, "synapse-claude-8100")
 
         with patch.object(
             sys,
@@ -569,7 +569,7 @@ class TestCliMain:
     ):
         """synapse claude --no-setup should skip interactive setup."""
         mock_pm_inst = mock_pm.return_value
-        mock_pm_inst.get_available_port.return_value = 8100
+        mock_pm_inst.allocate_and_register.return_value = (8100, "synapse-claude-8100")
 
         with patch.object(sys, "argv", ["synapse", "claude", "--no-setup"]):
             main()
@@ -633,7 +633,7 @@ class TestCliMain:
     ):
         """--agent should resolve saved agent defaults for shortcut mode."""
         mock_pm_inst = mock_pm.return_value
-        mock_pm_inst.get_available_port.return_value = 8100
+        mock_pm_inst.allocate_and_register.return_value = (8100, "synapse-claude-8100")
         mock_store = mock_store_cls.return_value
         mock_store.resolve.return_value = SimpleNamespace(
             profile="claude",

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -450,7 +450,7 @@ def test_atomic_updates_use_registry_write_lock(registry):
         entered += 1
         yield
 
-    registry._registry_write_lock = fake_lock  # type: ignore[method-assign]
+    registry.registry_write_lock = fake_lock  # type: ignore[method-assign]
 
     assert registry.update_status(agent_id, "READY") is True
     assert registry.update_transport(agent_id, "UDS→") is True

--- a/tests/test_spawn_port_race_715.py
+++ b/tests/test_spawn_port_race_715.py
@@ -1,0 +1,271 @@
+"""Regression tests for issue #715 — parallel spawn port allocation race.
+
+These tests reproduce the race window where two parallel spawns can both
+receive the same free port from PortManager.get_available_port() and then
+both attempt to AgentRegistry.register() against the same port file, with
+the second write silently overwriting the first.
+
+The fix is an atomic API (PortManager.allocate_and_register) that takes
+AgentRegistry.registry_write_lock() (cross-process flock) for both the
+free-port discovery and the placeholder registration.
+
+multiprocessing.Process is required: threading would run a single fcntl
+flock holder in-process so the cross-process serialization being tested
+would be a no-op.
+"""
+
+from __future__ import annotations
+
+import multiprocessing as mp
+import os
+
+import pytest
+
+from synapse.port_manager import PORT_RANGES, PortManager
+from synapse.registry import AgentRegistry, NameConflictError
+
+# macOS defaults to "spawn" since Python 3.8; force it explicitly so the test
+# behaves identically on Linux too. "spawn" re-imports modules in the child,
+# so worker functions must live at module level (below) and configuration
+# must travel via env vars or pickled args.
+_MP_CTX = mp.get_context("spawn")
+
+
+@pytest.fixture
+def registry_dir(tmp_path, monkeypatch):
+    """Per-test registry dir, propagated to children via SYNAPSE_REGISTRY_DIR.
+
+    The env var is what AgentRegistry consults via get_registry_dir(); using
+    monkeypatch ensures cleanup even if the test fails. Children inherit the
+    parent's environment under the "spawn" start method.
+    """
+    reg_dir = tmp_path / "registry"
+    reg_dir.mkdir()
+    monkeypatch.setenv("SYNAPSE_REGISTRY_DIR", str(reg_dir))
+    return reg_dir
+
+
+# --- Module-level worker functions (required for "spawn" start method) ---
+
+
+def _worker_allocate(
+    agent_type: str,
+    name: str | None,
+    parent_pid: int,
+    barrier: mp.Barrier,
+    queue: mp.Queue,
+) -> None:
+    """Child: wait at the barrier so all children call the API simultaneously,
+    then attempt allocate_and_register and report (port, agent_id, error).
+
+    The placeholder entry is registered with ``parent_pid`` (the test process's
+    pid) instead of the child's, so the registry view models a real spawn:
+    the spawn parent process owns the agent_id and keeps it alive, the
+    short-lived child only performs the atomic reservation. Without this the
+    child's ``atexit`` would delete the placeholder when the child exits.
+    """
+    try:
+        # The child registers an atexit handler in _register_locked that
+        # unregisters the entry on interpreter shutdown — for a real spawn
+        # the parent process holds the agent for its lifetime, so the
+        # entries persist. Suppress atexit in this short-lived test child
+        # so the placeholder survives child exit for the parent to verify.
+        import atexit
+
+        atexit.register = lambda *a, **kw: None  # type: ignore[assignment]
+        barrier.wait(timeout=10)
+        registry = AgentRegistry()
+        port_manager = PortManager(registry)
+        port, agent_id = port_manager.allocate_and_register(
+            agent_type, name=name, pid=parent_pid
+        )
+        queue.put(("ok", port, agent_id, None))
+    except Exception as e:  # noqa: BLE001 — propagating any failure to parent
+        queue.put(("err", None, None, f"{type(e).__name__}: {e}"))
+
+
+def _worker_register_same_name(
+    agent_id: str,
+    agent_type: str,
+    port: int,
+    name: str,
+    barrier: mp.Barrier,
+    queue: mp.Queue,
+) -> None:
+    """Child: race two registrations with the same custom name; exactly one
+    must succeed (NameConflictError for the other)."""
+    try:
+        barrier.wait(timeout=10)
+        registry = AgentRegistry()
+        registry.register(agent_id, agent_type, port, name=name)
+        queue.put(("ok", None))
+    except NameConflictError as e:
+        queue.put(("name_conflict", str(e)))
+    except Exception as e:  # noqa: BLE001
+        queue.put(("err", f"{type(e).__name__}: {e}"))
+
+
+# --- Helpers ---
+
+
+def _run_parallel(targets: list[tuple], barrier_parties: int) -> list:
+    """Run a set of (fn, args) child processes synchronized at a barrier and
+    return their queue-reported results in completion order.
+
+    Each tuple is (fn, args_without_barrier_or_queue). The barrier and the
+    queue are appended automatically.
+    """
+    barrier = _MP_CTX.Barrier(barrier_parties)
+    queue = _MP_CTX.Queue()
+    procs = [
+        _MP_CTX.Process(target=fn, args=(*args, barrier, queue)) for fn, args in targets
+    ]
+    for p in procs:
+        p.start()
+    for p in procs:
+        p.join(timeout=20)
+        assert not p.is_alive(), f"child {p.pid} did not exit cleanly"
+    results = []
+    while not queue.empty():
+        results.append(queue.get_nowait())
+    return results
+
+
+# --- Tests ---
+
+
+class TestSequentialAllocation:
+    """Sanity test: sequential allocate_and_register should give distinct ports."""
+
+    def test_sequential_allocation_distinct_ports(self, registry_dir):
+        registry = AgentRegistry()
+        port_manager = PortManager(registry)
+
+        port_a, id_a = port_manager.allocate_and_register("claude", pid=os.getpid())
+        port_b, id_b = port_manager.allocate_and_register("claude", pid=os.getpid())
+
+        assert port_a != port_b
+        start, end = PORT_RANGES["claude"]
+        assert start <= port_a <= end
+        assert start <= port_b <= end
+        agents = registry.list_agents()
+        assert id_a in agents
+        assert id_b in agents
+        assert agents[id_a]["port"] == port_a
+        assert agents[id_b]["port"] == port_b
+
+
+class TestParallelSpawnRace:
+    """The core regression: two parallel spawns must NOT collide on the same port."""
+
+    def test_parallel_spawn_two_processes_get_distinct_ports(self, registry_dir):
+        ppid = os.getpid()
+        results = _run_parallel(
+            targets=[
+                (_worker_allocate, ("claude", None, ppid)),
+                (_worker_allocate, ("claude", None, ppid)),
+            ],
+            barrier_parties=2,
+        )
+        assert len(results) == 2
+        for tag, _, _, err in results:
+            assert tag == "ok", f"unexpected child failure: {err}"
+
+        ports = sorted(r[1] for r in results)
+        ids = {r[2] for r in results}
+
+        assert ports[0] != ports[1], (
+            f"port-allocation race regressed: both children got the same "
+            f"port {ports[0]}"
+        )
+        start, end = PORT_RANGES["claude"]
+        assert all(start <= p <= end for p in ports)
+
+        # Both placeholder entries must persist in the shared registry.
+        registry = AgentRegistry()
+        agents = registry.list_agents()
+        assert ids.issubset(agents.keys()), (
+            f"registry lost a placeholder entry — saw {set(agents.keys())} "
+            f"expected {ids}"
+        )
+        assert len({agents[i]["port"] for i in ids}) == 2
+
+    def test_parallel_spawn_exhaustion_one_succeeds_one_fails(self, registry_dir):
+        """With 9 of 10 dummy ports pre-occupied, exactly 1 of 2 parallel
+        children must succeed; the other must fail with PortExhaustionError."""
+        from synapse.port_manager import PortExhaustionError  # noqa: F401
+
+        registry = AgentRegistry()
+        start, end = PORT_RANGES["dummy"]
+        # Pre-register 9 of the 10 dummy ports with this process's pid
+        # (PortManager treats them as "live" and skips them).
+        for port in range(start, end):  # 8190..8198 (9 ports)
+            registry.register(
+                f"synapse-dummy-{port}", "dummy", port, status="PROCESSING"
+            )
+
+        ppid = os.getpid()
+        results = _run_parallel(
+            targets=[
+                (_worker_allocate, ("dummy", None, ppid)),
+                (_worker_allocate, ("dummy", None, ppid)),
+            ],
+            barrier_parties=2,
+        )
+
+        oks = [r for r in results if r[0] == "ok"]
+        errs = [r for r in results if r[0] == "err"]
+        assert len(oks) == 1, f"expected exactly 1 success, got {results}"
+        assert len(errs) == 1, f"expected exactly 1 failure, got {results}"
+        assert "PortExhaustion" in errs[0][3], (
+            f"expected PortExhaustionError, got: {errs[0][3]}"
+        )
+        # The successful port is the one remaining free port.
+        assert oks[0][1] == end  # 8199
+
+
+class TestRegisterLockSerialization:
+    """Existing behavior regression: same-name parallel register → exactly one wins."""
+
+    def test_register_lock_serializes_writes(self, registry_dir):
+        results = _run_parallel(
+            targets=[
+                (
+                    _worker_register_same_name,
+                    ("synapse-claude-8100", "claude", 8100, "duplicate-name"),
+                ),
+                (
+                    _worker_register_same_name,
+                    ("synapse-claude-8101", "claude", 8101, "duplicate-name"),
+                ),
+            ],
+            barrier_parties=2,
+        )
+        oks = [r for r in results if r[0] == "ok"]
+        conflicts = [r for r in results if r[0] == "name_conflict"]
+        assert len(oks) == 1, f"expected 1 success, got {results}"
+        assert len(conflicts) == 1, f"expected 1 NameConflictError, got {results}"
+
+
+class TestLegacyCompatibility:
+    """The public register() signature must remain byte-compatible — direct
+    callers (other modules, tests) pass agent_id/agent_type/port positionally
+    and rely on the function taking the lock internally."""
+
+    def test_legacy_register_signature_unchanged(self, registry_dir):
+        registry = AgentRegistry()
+
+        # Positional + keyword combination used throughout the codebase.
+        path = registry.register(
+            "synapse-claude-8108",
+            "claude",
+            8108,
+            status="PROCESSING",
+            name="legacy-caller",
+            role="tester",
+        )
+        assert path.exists()
+        agents = registry.list_agents()
+        assert "synapse-claude-8108" in agents
+        assert agents["synapse-claude-8108"]["name"] == "legacy-caller"
+        assert agents["synapse-claude-8108"]["role"] == "tester"


### PR DESCRIPTION
Closes #715

## Summary

- Two parallel `synapse spawn` invocations could both receive the same free port from `PortManager.get_available_port`, then race to overwrite the same `synapse-{type}-{port}.json` registry entry — silently losing one agent and leaving its worktree as a physical orphan.
- Fix: new `PortManager.allocate_and_register` performs free-port discovery and a placeholder registry write inside a single `AgentRegistry.registry_write_lock` (cross-process `fcntl.flock`) critical section, so parallel spawns serialize at the lock and observe each other's reservations.
- `cli.py` spawn path now reserves the placeholder before worktree creation and rolls it back on worktree-creation failure; legacy `register()` signature and `get_available_port` are unchanged for backward compatibility.

## Design notes

- `_registry_write_lock` is renamed to public `registry_write_lock` so `PortManager` can take it. The original `register()` is now a thin wrapper around a new lock-aware `_register_locked` so callers that already hold the lock (the new `allocate_and_register`) avoid a non-re-entrant flock re-acquisition.
- The free-port loop inside the lock mirrors `get_available_port`'s policy exactly (live agent skip, dead-pid cleanup, orphan-listener `is_port_available` probe, then take the first remaining port). Putting the socket probe inside the lock costs ≤10ms worst case (10 ports × ~1ms `socket.bind`) which is negligible against spawn cadence; the alternative of moving it outside would re-introduce a TOCTOU window.

## Test plan

- [x] `tests/test_spawn_port_race_715.py` — 5 new `multiprocessing.Process`-based tests cover sequential allocation, parallel distinct-ports (the regression), parallel exhaustion, register-lock serialization, and legacy-register signature compatibility. Threading would not exercise cross-process flock — multiprocessing is required.
- [x] Targeted suites green: `pytest tests/test_spawn_port_race_715.py tests/test_port_manager.py tests/test_registry.py tests/test_cli_main.py tests/test_agent_shortcut.py` → 125 passed.
- [x] `mypy synapse/` clean (118 source files).
- [x] Full pytest excluding 4 pre-existing-fail files (test_file_safety, test_settings, test_learning_mode, test_send_ready_delay_467 — verified red on clean main, separate from this PR) → 4297 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)