### PR TITLE
release: 0.35.0 — parallel-spawn port race + kill auto-merge skip + gitignore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.35.0] - 2026-05-02
+
+This release fixes a cluster of multi-agent dogfooding bugs surfaced while shipping 0.34.0: a port-allocation race that silently lost one of two parallel spawns (#715), a misleading `synapse kill` recovery hint when the worktree branch already had an open PR (#714), and runtime artifacts under `.synapse/` and `.claude/worktrees/` that polluted `git status` (#713).
+
+### Changed
+
+- `.gitignore` now ignores the runtime-only paths that synapse-a2a / claude-code create during normal use (`.synapse/tasks/`, `.synapse/wiki/`, `.synapse/wiki.md`, `.synapse/worktrees/`, `.claude/worktrees/`) so they no longer appear as untracked entries in `git status`. Pre-existing committed files under `.synapse/` (settings/agent definitions, DB files, instruction sources) and the existing `.claude/worktrees/elastic-black` gitlink remain visible because gitignore patterns do not hide already-tracked paths. Closes #713.
+
 ### Fixed
 
 - Parallel `synapse spawn` no longer races on port allocation. Two simultaneous spawns of the same profile (e.g. `synapse spawn claude --worktree` × 2 in parallel) could both receive the same free port from `PortManager.get_available_port` because port discovery and registry write were not in the same critical section — the second spawn then overwrote the first's `synapse-{type}-{port}.json` registry entry, leaving the first agent visible as `READY` in some views but mis-labeled with the second agent's name and worktree, and leaving the first worktree as a physical orphan on disk. The new `PortManager.allocate_and_register` API performs free-port discovery and a placeholder registry write inside a single `AgentRegistry.registry_write_lock` (cross-process `fcntl.flock`) critical section, so parallel spawns serialize at the lock and observe each other's reservations. The `cli.py` spawn path now reserves the placeholder before worktree creation and rolls it back if worktree creation fails. The legacy `register()` signature is preserved (it is now a thin wrapper around the lock-aware `_register_locked`) and `get_available_port` is unchanged for backward compatibility. Closes #715.
+- `synapse kill <agent>` no longer attempts to merge a worktree branch into local `main` when that branch is already the head of an open GitHub PR. The previous behaviour printed a misleading recovery hint (`Resolve manually: git merge <branch>`) on conflict even though the PR is the canonical merge path; the new pre-check uses `gh pr list --head <branch> --state open` and skips the local auto-merge when ≥1 open PR is found, surfacing an informational message that points at the PR. The new `_branch_has_open_pr` helper is **fail-open**: missing `gh`, 5s timeout, non-zero exit, or malformed JSON falls back to the existing merge behaviour, so `kill` is never blocked or hung on a remote check. Closes #714.
 
 ## [0.34.0] - 2026-05-02
 
@@ -3688,7 +3697,8 @@ See v0.3.14 for reply PTY injection, CURRENT column, and history default changes
 - External agent connectivity vision document
 - PyPI publishing instructions
 
-[Unreleased]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.34.0...HEAD
+[Unreleased]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.35.0...HEAD
+[0.35.0]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.34.0...v0.35.0
 [0.34.0]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.33.0...v0.34.0
 [0.33.0]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.32.0...v0.33.0
 [0.32.0]: https://github.com/s-hiraoku/synapse-a2a/compare/v0.31.0...v0.32.0

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ site_url: https://s-hiraoku.github.io/synapse-a2a/
 site_description: Multi-agent collaboration framework using Google A2A Protocol
 site_author: s-hiraoku
 repo_url: https://github.com/s-hiraoku/synapse-a2a
-repo_name: s-hiraoku/synapse-a2a v0.34.0
+repo_name: s-hiraoku/synapse-a2a v0.35.0
 docs_dir: site-docs
 
 theme:

--- a/plugins/synapse-a2a/.claude-plugin/plugin.json
+++ b/plugins/synapse-a2a/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synapse-a2a",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "description": "Complete plugin for Synapse A2A multi-agent framework including inter-agent communication, file safety, and history management",
   "author": {
     "name": "s-hiraoku",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "synapse-a2a"
-version = "0.34.0"
+version = "0.35.0"
 description = "Agent-to-Agent communication protocol for CLI agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/site-docs/changelog.md
+++ b/site-docs/changelog.md
@@ -4,6 +4,14 @@ For the complete changelog, see [CHANGELOG.md on GitHub](https://github.com/s-hi
 
 ## Recent Highlights
 
+### v0.35.0
+
+The 0.35.0 release fixes a cluster of multi-agent dogfooding bugs surfaced while shipping 0.34.0: a port-allocation race that silently lost one of two parallel spawns (#715), a misleading `synapse kill` recovery hint when the worktree branch already had an open PR (#714), and runtime artifacts under `.synapse/` and `.claude/worktrees/` that polluted `git status` (#713).
+
+- **Changed**: `.gitignore` now ignores the runtime-only paths that synapse-a2a / claude-code create during normal use (`.synapse/tasks/`, `.synapse/wiki/`, `.synapse/wiki.md`, `.synapse/worktrees/`, `.claude/worktrees/`) so they no longer appear as `??` entries in `git status` (#713). Pre-existing committed files under `.synapse/` and the existing `.claude/worktrees/elastic-black` gitlink remain visible because gitignore patterns do not hide already-tracked paths.
+- **Fixed**: Parallel `synapse spawn` no longer races on port allocation (#715). Two simultaneous spawns of the same profile could both receive the same free port from `PortManager.get_available_port` because port discovery and registry write ran outside the same critical section — the second spawn then overwrote the first's registry entry, leaving the first agent's worktree as a physical orphan. The new `PortManager.allocate_and_register` performs free-port discovery and a placeholder registry write inside a single `AgentRegistry.registry_write_lock` (cross-process `fcntl.flock`) critical section, so parallel spawns serialize at the lock. The `cli.py` spawn path also rolls the placeholder back if worktree creation fails downstream. Legacy `register()` and `get_available_port` are unchanged for backward compatibility.
+- **Fixed**: `synapse kill <agent>` no longer attempts a local auto-merge when the worktree branch already has an open PR (#714). A new `_branch_has_open_pr` pre-check (fail-open on missing `gh` / timeout / non-zero exit / malformed JSON) skips the merge and surfaces an informational message pointing at the PR. The previous misleading `Resolve manually: git merge <branch>` recovery hint no longer fires when the PR is the canonical merge path.
+
 ### v0.34.0
 
 The 0.34.0 release closes a cluster of issues exposed during real multi-agent dogfooding: the Codex CLI 0.128 deprecation that broke `synapse spawn codex` (#705), a watchdog blind spot for codex's edit-confirmation dialog (#694/#707), divergence between `synapse status --json` and `synapse list --json` (#696/#708), and a worktree name-collision crash on auto-generated names that surfaced when `.synapse/worktrees/` had accumulated stale entries (#704/#711).

--- a/site-docs/concepts/a2a-protocol.md
+++ b/site-docs/concepts/a2a-protocol.md
@@ -17,7 +17,7 @@ Every A2A agent publishes a discovery document at `/.well-known/agent.json`:
   "name": "synapse-claude-8100",
   "description": "Claude Code agent managed by Synapse A2A",
   "url": "http://localhost:8100",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "capabilities": {
     "streaming": false,
     "pushNotifications": false

--- a/site-docs/getting-started/installation.md
+++ b/site-docs/getting-started/installation.md
@@ -58,7 +58,7 @@
 synapse --version
 ```
 
-You should see the version number (e.g., `0.34.0`).
+You should see the version number (e.g., `0.35.0`).
 
 ## Initialize Configuration
 
@@ -88,7 +88,7 @@ gh skill install s-hiraoku/synapse-a2a synapse-manager
 gh skill install s-hiraoku/synapse-a2a synapse-reinst
 
 # Optional: pin to a release tag so updates are explicit
-gh skill install s-hiraoku/synapse-a2a synapse-a2a --pin v0.34.0
+gh skill install s-hiraoku/synapse-a2a synapse-a2a --pin v0.35.0
 
 # Optional: target a specific agent runtime
 gh skill install s-hiraoku/synapse-a2a synapse-a2a --agent claude-code

--- a/uv.lock
+++ b/uv.lock
@@ -1439,7 +1439,7 @@ wheels = [
 
 [[package]]
 name = "synapse-a2a"
-version = "0.34.0"
+version = "0.35.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

- Bumps `pyproject.toml` / `plugins/synapse-a2a/.claude-plugin/plugin.json` / `mkdocs.yml` / `site-docs/getting-started/installation.md` / `site-docs/concepts/a2a-protocol.md` to **0.35.0**, refreshes `uv.lock` accordingly.
- Promotes `[Unreleased]` to `[0.35.0] - 2026-05-02` in `CHANGELOG.md` and adds matching entries for #713 (gitignore) and #714 (kill auto-merge skip) that landed alongside #715 but were missing from the working CHANGELOG section. Updates the reference-link footer (`[Unreleased]` → `compare/v0.35.0...HEAD`, new `[0.35.0]` link).
- Mirrors the v0.35.0 highlights to `site-docs/changelog.md` for the Pages site.

## Headlines (all dogfooding bugs surfaced while shipping 0.34.0)

- **#715 — parallel-spawn port-allocation race**: two simultaneous `synapse spawn claude --worktree` could both receive the same free port from `PortManager.get_available_port` because port discovery and registry write were not in the same critical section, silently overwriting one of the registry entries and leaving its worktree as a physical orphan. The new `PortManager.allocate_and_register` runs free-port discovery + placeholder registry write inside one `AgentRegistry.registry_write_lock` (cross-process `fcntl.flock`) critical section. Legacy `register()` and `get_available_port` are unchanged for backward compatibility.
- **#714 — `synapse kill` auto-merge skip**: when the worktree branch is already the head of an open GitHub PR, the local `git merge` (and its misleading "Resolve manually" recovery hint on conflict) is skipped in favor of an informational message pointing at the PR. The new `_branch_has_open_pr` helper is fail-open on missing `gh` / 5s timeout / non-zero exit / malformed JSON.
- **#713 — gitignore runtime artifacts**: `.synapse/tasks/`, `.synapse/wiki/`, `.synapse/wiki.md`, `.synapse/worktrees/`, and `.claude/worktrees/` are now ignored so they no longer pollute `git status`. Pre-existing committed files under `.synapse/` and the existing `.claude/worktrees/elastic-black` gitlink remain visible.

## Linked Issues

Refs #715
Refs #714
Refs #713

(Each of #715/#714/#713 was already auto-closed by its own implementation PR — #718, #717, #716 respectively. This PR only ships the version bump + release notes that bundle them.)

## Test plan

- [x] `pytest -q` was clean on every constituent PR (#716/#717/#718) before merge to main; this release PR touches only metadata (CHANGELOG, version files, `uv.lock`, mkdocs config, site-docs prose) — no `synapse/` source changes.
- [ ] CI matrix (Python 3.10–3.14) on this PR
- [ ] CodeRabbit review
- [ ] Auto-Resolve Mechanical Conflicts workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート v0.35.0

* **バグ修正**
  * 並列実行時のポート割り当て競合状態を解決
  * 既存のプルリクエストがある場合のマージ提案ロジックを改善

* **変更**
  * ランタイムのみのワークツリーパスをgitから除外するようにアップデート

<!-- end of auto-generated comment: release notes by coderabbit.ai -->