### PR TITLE
[codex] Fix env isolation and add Codex plugin metadata

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "synapse-a2a",
+  "interface": {
+    "displayName": "Synapse A2A"
+  },
+  "plugins": [
+    {
+      "name": "synapse-a2a",
+      "source": {
+        "source": "local",
+        "path": "./plugins/synapse-a2a"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -573,6 +573,7 @@ Synapse ships with 6 built-in skill sets (defined in `.synapse/skill_sets.json`)
 plugins/
 └── synapse-a2a/
     ├── .claude-plugin/plugin.json
+    ├── .codex-plugin/plugin.json
     ├── README.md
     └── skills/
         ├── synapse-a2a/
@@ -586,7 +587,8 @@ plugins/
 
 See [plugins/synapse-a2a/README.md](plugins/synapse-a2a/README.md) for details.
 
-> **Note**: Codex and Gemini don't support plugins, but you can place expanded skills in the `.agents/skills/` directory to enable these features.
+Codex can discover the repo-local plugin through `.agents/plugins/marketplace.json`.
+Gemini can use the expanded skills in the `.agents/skills/` directory.
 
 ---
 

--- a/plugins/synapse-a2a/.codex-plugin/plugin.json
+++ b/plugins/synapse-a2a/.codex-plugin/plugin.json
@@ -1,0 +1,29 @@
+{
+  "name": "synapse-a2a",
+  "version": "0.35.0",
+  "description": "Complete plugin for Synapse A2A multi-agent framework including inter-agent communication, file safety, and history management",
+  "author": {
+    "name": "s-hiraoku",
+    "email": "s.hiraoku@gmail.com"
+  },
+  "homepage": "https://github.com/s-hiraoku/synapse-a2a",
+  "repository": "https://github.com/s-hiraoku/synapse-a2a",
+  "license": "MIT",
+  "keywords": ["multi-agent", "a2a", "collaboration"],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Synapse A2A",
+    "shortDescription": "Multi-agent communication workflows for Codex.",
+    "longDescription": "Synapse A2A provides skills for coordinating agents, managing file safety, and using Synapse messaging workflows from Codex.",
+    "developerName": "s-hiraoku",
+    "category": "Productivity",
+    "capabilities": ["Interactive", "Write"],
+    "websiteURL": "https://github.com/s-hiraoku/synapse-a2a",
+    "defaultPrompt": [
+      "Send a Synapse message to another agent.",
+      "Coordinate a multi-agent implementation.",
+      "Check Synapse file-safety status."
+    ],
+    "brandColor": "#2563EB"
+  }
+}

--- a/synapse/commands/renderers/rich_renderer.py
+++ b/synapse/commands/renderers/rich_renderer.py
@@ -106,9 +106,9 @@ class RichRenderer:
     DEFAULT_COLUMNS = [
         "ID",
         "NAME",
-        "STATUS",
-        "CURRENT",
         "TRANSPORT",
+        "CURRENT",
+        "STATUS",
         "WORKING_DIR",
         "EDITING_FILE",
     ]

--- a/synapse/file_safety.py
+++ b/synapse/file_safety.py
@@ -125,11 +125,26 @@ class FileSafetyManager:
         Returns:
             FileSafetyManager instance with settings from env/config
         """
-        # Resolve DB path (env > settings > arg > default)
+        # Resolve DB path (env > project settings > arg > user settings > default).
+        # A caller-provided path is usually a deliberate test/runtime override; do not
+        # let ambient user-global settings leak into that case.
         env_db_path = os.environ.get("SYNAPSE_FILE_SAFETY_DB_PATH", "").strip()
         if not env_db_path:
-            env_db_path = cls._get_setting("SYNAPSE_FILE_SAFETY_DB_PATH", "").strip()
-        resolved_db_path = env_db_path or db_path
+            env_db_path = cls._get_setting(
+                "SYNAPSE_FILE_SAFETY_DB_PATH",
+                "",
+                include_user=False,
+            ).strip()
+        if env_db_path:
+            resolved_db_path = env_db_path
+        elif db_path:
+            resolved_db_path = db_path
+        else:
+            resolved_db_path = cls._get_setting(
+                "SYNAPSE_FILE_SAFETY_DB_PATH",
+                "",
+                include_project=False,
+            ).strip()
 
         # Check enabled status
         env_enabled = os.environ.get("SYNAPSE_FILE_SAFETY_ENABLED", "").lower()
@@ -155,12 +170,21 @@ class FileSafetyManager:
         )
 
     @staticmethod
-    def _get_setting(key: str, default: str = "") -> str:
+    def _get_setting(
+        key: str,
+        default: str = "",
+        *,
+        include_project: bool = True,
+        include_user: bool = True,
+    ) -> str:
         """Get a setting value from .synapse/settings.json."""
-        for settings_path in [
-            Path.cwd() / ".synapse" / "settings.json",
-            Path.home() / ".synapse" / "settings.json",
-        ]:
+        settings_paths = []
+        if include_project:
+            settings_paths.append(Path.cwd() / ".synapse" / "settings.json")
+        if include_user:
+            settings_paths.append(Path.home() / ".synapse" / "settings.json")
+
+        for settings_path in settings_paths:
             if settings_path.exists():
                 try:
                     with open(settings_path, encoding="utf-8") as f:

--- a/synapse/settings.py
+++ b/synapse/settings.py
@@ -641,13 +641,20 @@ class SynapseSettings:
             """Check if value is a string ending with .md (filename only, no existence check)."""
             return isinstance(value, str) and value.endswith(".md")
 
-        def add_if_exists(filename: str) -> None:
+        def add_if_exists(filename: str, *, include_ambient_user: bool = True) -> None:
             """Add file to paths if it exists in project or user directory."""
             project_path = Path.cwd() / ".synapse" / filename
             user_path = home / ".synapse" / filename
-            if not (project_path.exists() or user_path.exists()):
+            include_user_path = user_dir is not None or include_ambient_user
+            if not (
+                project_path.exists() or (include_user_path and user_path.exists())
+            ):
                 return
-            display_path = self._get_file_display_path(filename, user_dir)
+            display_path = self._get_file_display_path(
+                filename,
+                user_dir,
+                include_user=include_user_path,
+            )
             if display_path:
                 paths.append(display_path)
 
@@ -664,27 +671,31 @@ class SynapseSettings:
 
         # File safety
         if self._is_file_safety_enabled():
-            add_if_exists("file-safety.md")
+            add_if_exists("file-safety.md", include_ambient_user=False)
 
         if self._is_wiki_enabled():
-            add_if_exists("wiki.md")
+            add_if_exists("wiki.md", include_ambient_user=False)
 
         # Learning mode (either flag enables learning.md injection)
         if self._is_any_learning_enabled():
-            add_if_exists("learning.md")
+            add_if_exists("learning.md", include_ambient_user=False)
 
         # Shared memory
         if self._is_shared_memory_enabled():
-            add_if_exists("shared-memory.md")
+            add_if_exists("shared-memory.md", include_ambient_user=False)
 
         # Proactive mode
         if self._is_proactive_mode_enabled():
-            add_if_exists("proactive.md")
+            add_if_exists("proactive.md", include_ambient_user=False)
 
         return paths
 
     def _get_file_display_path(
-        self, filename: str, user_dir: Path | None = None
+        self,
+        filename: str,
+        user_dir: Path | None = None,
+        *,
+        include_user: bool = True,
     ) -> str | None:
         """
         Get the display path for an instruction file.
@@ -701,10 +712,9 @@ class SynapseSettings:
             or None if file doesn't exist in either location.
         """
         home = user_dir or Path.home()
-        locations = [
-            (Path.cwd() / ".synapse" / filename, f".synapse/{filename}"),
-            (home / ".synapse" / filename, f"~/.synapse/{filename}"),
-        ]
+        locations = [(Path.cwd() / ".synapse" / filename, f".synapse/{filename}")]
+        if include_user:
+            locations.append((home / ".synapse" / filename, f"~/.synapse/{filename}"))
 
         for path, display in locations:
             if path.exists():
@@ -790,22 +800,34 @@ class SynapseSettings:
             Instruction with optional content appended.
         """
         if self._is_file_safety_enabled():
-            file_safety_content = self._load_instruction_file("file-safety.md")
+            file_safety_content = self._load_instruction_file(
+                "file-safety.md",
+                include_user=False,
+            )
             if file_safety_content:
                 instruction = instruction + "\n\n" + file_safety_content
 
         if self._is_any_learning_enabled():
-            learning_content = self._load_instruction_file("learning.md")
+            learning_content = self._load_instruction_file(
+                "learning.md",
+                include_user=False,
+            )
             if learning_content:
                 instruction = instruction + "\n\n" + learning_content
 
         if self._is_shared_memory_enabled():
-            memory_content = self._load_instruction_file("shared-memory.md")
+            memory_content = self._load_instruction_file(
+                "shared-memory.md",
+                include_user=False,
+            )
             if memory_content:
                 instruction = instruction + "\n\n" + memory_content
 
         if self._is_proactive_mode_enabled():
-            proactive_content = self._load_instruction_file("proactive.md")
+            proactive_content = self._load_instruction_file(
+                "proactive.md",
+                include_user=False,
+            )
             if proactive_content:
                 instruction = instruction + "\n\n" + proactive_content
 
@@ -849,7 +871,11 @@ class SynapseSettings:
         return text
 
     def _load_instruction_file(
-        self, filename: str, *, user_dir: Path | None = None
+        self,
+        filename: str,
+        *,
+        user_dir: Path | None = None,
+        include_user: bool = True,
     ) -> str:
         """
         Load instruction content from a file in .synapse directory.
@@ -866,10 +892,9 @@ class SynapseSettings:
             File content if found, empty string otherwise.
         """
         home = user_dir if user_dir is not None else Path.home()
-        search_paths = [
-            Path.cwd() / ".synapse" / filename,
-            home / ".synapse" / filename,
-        ]
+        search_paths = [Path.cwd() / ".synapse" / filename]
+        if include_user:
+            search_paths.append(home / ".synapse" / filename)
 
         for path in search_paths:
             if path.exists():


### PR DESCRIPTION
## Summary
- respect explicit file-safety DB paths ahead of ambient user settings
- keep optional instruction files project-local so user-global files do not leak into tests or temporary projects
- reorder default list columns so transport and elapsed current-task text remain visible in narrow output
- add Codex plugin metadata and a repo-local marketplace entry for the existing Synapse A2A plugin

## Validation
- uv run ruff check synapse/ tests/
- uv run pytest tests/test_file_safety.py::TestFileSafetyFromEnv::test_from_env_db_path_falls_back_to_arg tests/test_file_safety.py::TestFileSafetyFromEnv::test_from_env_malformed_settings tests/test_learning_mode.py::TestLearningModeInstructionInjection::test_learning_instruction_not_appended_when_disabled tests/test_rich_renderer.py::TestRichRendererMultipleAgents::test_multiple_agents_with_different_transport_states tests/test_rich_renderer.py::TestRichRendererStableLayout::test_current_preview_pre_truncated_before_elapsed tests/test_settings.py::TestInstructionFilePaths::test_file_in_project_directory_only tests/test_settings.py::TestInstructionFilePaths::test_file_not_found_in_either_location -q
- python3 -m json.tool .agents/plugins/marketplace.json
- python3 -m json.tool plugins/synapse-a2a/.codex-plugin/plugin.json
- uv run pytest tests/test_skill_structure.py tests/test_site_docs.py -q

## Notes
- This PR is based on main.
- Leftover local changes that were not useful for this PR were intentionally excluded: generated .rig logs, local .codex config, AGENTS.md symlink conversion, .serena generated config, and broken .agents/skills sync rewrites.