### PR TITLE
[codex] Refactor A2A artifact formatting

### DIFF
--- a/synapse/a2a_compat.py
+++ b/synapse/a2a_compat.py
@@ -33,6 +33,7 @@ from synapse._pty_sanitize import (
     tail_printable,
 )
 from synapse.a2a_client import get_client
+from synapse.a2a_formatting import format_artifact_text as _format_artifact_text
 from synapse.auth import require_auth
 from synapse.config import (
     AGENT_READY_TIMEOUT,
@@ -282,37 +283,6 @@ def map_synapse_status_to_a2a(synapse_status: str) -> TaskState:
         "NOT_STARTED": "submitted",
     }
     return mapping.get(synapse_status, "working")
-
-
-def _format_artifact_text(artifact: "Artifact", use_markdown: bool = False) -> str:
-    """Format an artifact as text for history or response.
-
-    Args:
-        artifact: The Artifact to format
-        use_markdown: If True, format code blocks with markdown fences
-
-    Returns:
-        Formatted text representation of the artifact
-    """
-    if artifact.type == "code":
-        code_data = artifact.data if isinstance(artifact.data, dict) else {}
-        language = code_data.get("metadata", {}).get("language", "text")
-        content = code_data.get("content", str(artifact.data))
-        prefix = f"```{language}\n" if use_markdown else f"[Code: {language}]\n"
-        suffix = "\n```" if use_markdown else ""
-        text = f"{prefix}{content}{suffix}"
-    elif artifact.type == "text":
-        if isinstance(artifact.data, str):
-            text = artifact.data
-        else:
-            text = str(artifact.data.get("content", artifact.data))
-    else:
-        text = f"[{artifact.type}] {artifact.data}"
-
-    # Sanitize once at the single exit so PTY scrape residue (ANSI escapes,
-    # C0/C1 control bytes) cannot leak into history or A2A output regardless
-    # of artifact type. See PR #668 (#664) and #678 (#677, route C).
-    return strip_control_bytes(text)
 
 
 def _save_task_to_history(

--- a/synapse/a2a_formatting.py
+++ b/synapse/a2a_formatting.py
@@ -1,0 +1,42 @@
+"""Pure formatting helpers for A2A compatibility output."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from synapse._pty_sanitize import strip_control_bytes
+
+
+class ArtifactLike(Protocol):
+    """Minimal artifact interface needed for text formatting."""
+
+    type: str
+    data: object
+
+
+def format_artifact_text(artifact: ArtifactLike, use_markdown: bool = False) -> str:
+    """Format an artifact as text for history or response."""
+    if artifact.type == "code":
+        code_data = artifact.data if isinstance(artifact.data, dict) else {}
+        metadata = code_data.get("metadata", {})
+        language = (
+            metadata.get("language", "text") if isinstance(metadata, dict) else "text"
+        )
+        content = code_data.get("content", str(artifact.data))
+        prefix = f"```{language}\n" if use_markdown else f"[Code: {language}]\n"
+        suffix = "\n```" if use_markdown else ""
+        text = f"{prefix}{content}{suffix}"
+    elif artifact.type == "text":
+        if isinstance(artifact.data, str):
+            text = artifact.data
+        elif isinstance(artifact.data, dict):
+            text = str(artifact.data.get("content", artifact.data))
+        else:
+            text = str(artifact.data)
+    else:
+        text = f"[{artifact.type}] {artifact.data}"
+
+    # Sanitize once at the single exit so PTY scrape residue (ANSI escapes,
+    # C0/C1 control bytes) cannot leak into history or A2A output regardless
+    # of artifact type. See PR #668 (#664) and #678 (#677, route C).
+    return strip_control_bytes(text)


### PR DESCRIPTION
## Summary
- move pure artifact text formatting out of the A2A compatibility router module
- keep the existing _format_artifact_text import surface for compatibility
- leave route handler, permission, and task behavior unchanged

## Validation
- uv run pytest tests/test_a2a_compat.py tests/test_a2a_compat_sanitize_664.py tests/test_a2a_compat_use_markdown_685.py tests/test_a2a_helpers_660.py -q
- uv run ruff check synapse/a2a_formatting.py synapse/a2a_compat.py tests/test_a2a_compat.py tests/test_a2a_compat_sanitize_664.py tests/test_a2a_compat_use_markdown_685.py tests/test_a2a_helpers_660.py
- uv run mypy synapse/a2a_formatting.py synapse/a2a_compat.py