### PR TITLE
docs: clarify reply targets for pasted A2A text

### DIFF
--- a/.agents/skills/synapse-a2a/SKILL.md
+++ b/.agents/skills/synapse-a2a/SKILL.md
@@ -258,7 +258,7 @@ Choose based on whether you need the result:
 When you receive a task from a manager:
 
 ### On Task Receipt
-1. Start work immediately (`[REPLY EXPECTED]` requires a reply; otherwise no reply needed)
+1. Start work immediately (`[REPLY EXPECTED]` requires `synapse reply`; user-pasted `A2A:` text has no reply target, so respond with `synapse send` instead)
 2. Check shared knowledge: `synapse memory search "<task topic>"`
 3. Lock files before editing (**skip if SYNAPSE_WORKTREE_PATH is set**): `synapse file-safety lock <file> $SYNAPSE_AGENT_ID`
 

--- a/.agents/skills/synapse-a2a/SKILL.md
+++ b/.agents/skills/synapse-a2a/SKILL.md
@@ -258,7 +258,7 @@ Choose based on whether you need the result:
 When you receive a task from a manager:
 
 ### On Task Receipt
-1. Start work immediately (`[REPLY EXPECTED]` requires `synapse reply`; user-pasted `A2A:` text has no reply target, so respond with `synapse send` instead)
+1. Start work immediately (`synapse reply` is valid for Synapse-tracked messages with a registered reply target, including `[REPLY EXPECTED]` and `--response`; otherwise user-pasted `A2A:` text has no reply target, so respond with `synapse send` instead)
 2. Check shared knowledge: `synapse memory search "<task topic>"`
 3. Lock files before editing (**skip if SYNAPSE_WORKTREE_PATH is set**): `synapse file-safety lock <file> $SYNAPSE_AGENT_ID`
 

--- a/.claude/skills/synapse-a2a/SKILL.md
+++ b/.claude/skills/synapse-a2a/SKILL.md
@@ -258,7 +258,7 @@ Choose based on whether you need the result:
 When you receive a task from a manager:
 
 ### On Task Receipt
-1. Start work immediately (`[REPLY EXPECTED]` requires a reply; otherwise no reply needed)
+1. Start work immediately (`[REPLY EXPECTED]` requires `synapse reply`; user-pasted `A2A:` text has no reply target, so respond with `synapse send` instead)
 2. Check shared knowledge: `synapse memory search "<task topic>"`
 3. Lock files before editing (**skip if SYNAPSE_WORKTREE_PATH is set**): `synapse file-safety lock <file> $SYNAPSE_AGENT_ID`
 

--- a/.claude/skills/synapse-a2a/SKILL.md
+++ b/.claude/skills/synapse-a2a/SKILL.md
@@ -258,7 +258,7 @@ Choose based on whether you need the result:
 When you receive a task from a manager:
 
 ### On Task Receipt
-1. Start work immediately (`[REPLY EXPECTED]` requires `synapse reply`; user-pasted `A2A:` text has no reply target, so respond with `synapse send` instead)
+1. Start work immediately (`synapse reply` is valid for Synapse-tracked messages with a registered reply target, including `[REPLY EXPECTED]` and `--response`; otherwise user-pasted `A2A:` text has no reply target, so respond with `synapse send` instead)
 2. Check shared knowledge: `synapse memory search "<task topic>"`
 3. Lock files before editing (**skip if SYNAPSE_WORKTREE_PATH is set**): `synapse file-safety lock <file> $SYNAPSE_AGENT_ID`
 

--- a/guides/a2a-communication.md
+++ b/guides/a2a-communication.md
@@ -158,6 +158,8 @@ synapse reply --message-file /tmp/reply.md   # ファイルから読み込み（
 echo "long reply..." | synapse reply --stdin # 標準入力から読み込み
 ```
 
+`synapse reply` は Synapse が追跡している受信メッセージ（`[REPLY EXPECTED]` 付き、または `synapse send --wait` / `--notify` で作成されたもの）に対してのみ有効です。ユーザーが手動で貼り付けた `A2A:` テキストには返信先が登録されていないため、返信する場合は `synapse reply` ではなく `synapse send <sender> "<message>"` を使用してください。
+
 > **長文返信 / shell 展開回避**: `--message-file` (`-F`) と `--stdin` は `synapse send` と同じセマンティクスで、バックティックやコードブロックを含む返信を shell 展開警告なしに送れます。`synapse send` の他のフラグ（`--priority`、`--wait` / `--notify` / `--silent`、`--attach`）は意図的にミラーされておらず、返信は常に priority 3 / silent モードで送信されます。
 
 **返信追跡の永続化**: Synapseは返信先（`in_reply_to`）の情報を `~/.a2a/reply/` ディレクトリに永続化します。エージェントが再起動しても、最後に受信したメッセージへの返信が可能です。

--- a/plugins/synapse-a2a/skills/synapse-a2a/SKILL.md
+++ b/plugins/synapse-a2a/skills/synapse-a2a/SKILL.md
@@ -258,7 +258,7 @@ Choose based on whether you need the result:
 When you receive a task from a manager:
 
 ### On Task Receipt
-1. Start work immediately (`[REPLY EXPECTED]` requires a reply; otherwise no reply needed)
+1. Start work immediately (`[REPLY EXPECTED]` requires `synapse reply`; user-pasted `A2A:` text has no reply target, so respond with `synapse send` instead)
 2. Check shared knowledge: `synapse memory search "<task topic>"`
 3. Lock files before editing (**skip if SYNAPSE_WORKTREE_PATH is set**): `synapse file-safety lock <file> $SYNAPSE_AGENT_ID`
 

--- a/plugins/synapse-a2a/skills/synapse-a2a/SKILL.md
+++ b/plugins/synapse-a2a/skills/synapse-a2a/SKILL.md
@@ -258,7 +258,7 @@ Choose based on whether you need the result:
 When you receive a task from a manager:
 
 ### On Task Receipt
-1. Start work immediately (`[REPLY EXPECTED]` requires `synapse reply`; user-pasted `A2A:` text has no reply target, so respond with `synapse send` instead)
+1. Start work immediately (`synapse reply` is valid for Synapse-tracked messages with a registered reply target, including `[REPLY EXPECTED]` and `--response`; otherwise user-pasted `A2A:` text has no reply target, so respond with `synapse send` instead)
 2. Check shared knowledge: `synapse memory search "<task topic>"`
 3. Lock files before editing (**skip if SYNAPSE_WORKTREE_PATH is set**): `synapse file-safety lock <file> $SYNAPSE_AGENT_ID`
 

--- a/site-docs/guide/communication.md
+++ b/site-docs/guide/communication.md
@@ -139,7 +139,10 @@ If sender information is not fully available, it falls back to:
 synapse reply "Here are my findings..."
 ```
 
-Reply automatically routes to the last sender. Tasks started with `--wait` or `--notify` that complete without an explicit `synapse reply` are automatically marked as `MISSING_REPLY`. Tasks sent with `--silent` do not require a reply.
+`synapse reply` is only valid for a Synapse-tracked incoming message, such as one marked `[REPLY EXPECTED]` or one created by `synapse send --wait` / `--notify`. Reply automatically routes to the last tracked sender. Tasks started with `--wait` or `--notify` that complete without an explicit `synapse reply` are automatically marked as `MISSING_REPLY`. Tasks sent with `--silent` do not require a reply.
+
+!!! warning "Manually pasted A2A text"
+    If a user-pasted `A2A:` text block appears in your terminal, Synapse has no reply target for it. To respond, use `synapse send`, not `synapse reply`, and address the sender explicitly.
 
 ### Reply to Specific Sender
 

--- a/tests/test_site_docs.py
+++ b/tests/test_site_docs.py
@@ -266,6 +266,14 @@ def test_communication_guide_does_not_document_missing_reply_fail_flag() -> None
     assert "Use `--fail`" not in guide
 
 
+def test_communication_guide_clarifies_manual_a2a_text_uses_send() -> None:
+    guide = _read("site-docs/guide/communication.md")
+
+    assert "Synapse-tracked incoming message" in guide
+    assert "user-pasted `A2A:` text" in guide
+    assert "use `synapse send`, not `synapse reply`" in guide
+
+
 def test_file_safety_docs_match_current_locks_flags() -> None:
     cli_ref = _read("site-docs/reference/cli.md")
     guide = _read("site-docs/guide/file-safety.md")


### PR DESCRIPTION
Summary
- Clarify that synapse reply only works for Synapse-tracked incoming messages
- Document that user-pasted A2A text should be answered with synapse send
- Add a site-doc regression check for the clarification

Tests
- uv run pytest tests/test_site_docs.py -v

Closes #185

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **ドキュメント**
  * A2A通信ガイドおよび各種SKILLドキュメントを更新：synapse replyはSynapseで追跡された受信（[REPLY EXPECTED]や--wait/--notify、--response）に限定され、手動貼り付けのA2Aテキストには返信先が登録されないためその場合はsynapse sendを使う旨を明確化。--wait/--notify未返信はMISSING_REPLY、--silentは返信不要と追記。

* **テスト**
  * サイトドキュメントに「手動A2Aはsendを使う」ことを確認するテストを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->