### PR TITLE
ci: require product readiness gates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Install dependencies
         run: uv sync --group dev
 
+      - name: Build package
+        run: uv build
+
       - name: Lint with ruff
         run: |
           uv run ruff check synapse/ tests/
@@ -38,7 +41,6 @@ jobs:
 
       - name: Type check with mypy
         run: uv run mypy synapse/
-        continue-on-error: true
 
       - name: Run tests
         run: uv run pytest -v

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -1,0 +1,53 @@
+"""Tests for the default CI workflow quality gates."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+WORKFLOW_PATH = (
+    Path(__file__).resolve().parents[1] / ".github" / "workflows" / "test.yml"
+)
+
+
+def _load_workflow() -> dict[str, Any]:
+    assert WORKFLOW_PATH.exists(), f"workflow not found: {WORKFLOW_PATH}"
+    raw = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    if True in raw and "on" not in raw:
+        raw["on"] = raw.pop(True)
+    return raw
+
+
+def _test_job_steps(wf: dict[str, Any] | None = None) -> list[dict[str, Any]]:
+    if wf is None:
+        wf = _load_workflow()
+    assert "jobs" in wf, "test.yml must define jobs"
+    jobs = wf["jobs"]
+    assert "test" in jobs, "test.yml must define a 'test' job"
+    return jobs["test"]["steps"]
+
+
+def test_mypy_is_required_in_default_ci() -> None:
+    """Type checking should block merges once mypy is kept green."""
+    mypy_steps = [
+        step
+        for step in _test_job_steps()
+        if "mypy" in step.get("name", "").lower()
+        or "uv run mypy synapse/" in str(step.get("run", ""))
+    ]
+    assert mypy_steps, "test.yml must run mypy"
+    assert mypy_steps[0].get("continue-on-error") is not True
+
+
+def test_default_ci_builds_package() -> None:
+    """PR CI should catch packaging metadata and wheel/sdist regressions."""
+    steps_text = "\n".join(str(step.get("run", "")) for step in _test_job_steps())
+    assert "uv build" in steps_text
+
+
+def test_default_ci_requires_test_job_name() -> None:
+    with pytest.raises(AssertionError, match="test.yml must define a 'test' job"):
+        _test_job_steps({"jobs": {"renamed": {"steps": []}}})


### PR DESCRIPTION
## Summary

- Make the default Test workflow run `uv build` so PR CI catches packaging regressions before release.
- Make the mypy step a required gate now that the codebase keeps `uv run mypy synapse/` green.
- Add workflow tests that lock these product-readiness checks in place.

## Linked Issues

- No linked issue; this is a product-readiness CI hardening change from the project evaluation pass.

## Test plan

- [x] `UV_CACHE_DIR=/private/tmp/uv-cache uv run pytest tests/test_ci_workflow.py tests/test_live_e2e_ci_workflow.py -q`
- [x] `UV_CACHE_DIR=/private/tmp/uv-cache uv run ruff check tests/test_ci_workflow.py`
- [x] `UV_CACHE_DIR=/private/tmp/uv-cache uv run ruff format tests/test_ci_workflow.py --check`
- [x] `UV_CACHE_DIR=/private/tmp/uv-cache uv build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * CI ワークフローの品質確認テストを追加しました。

* **Chores**
  * ビルドプロセスを CI パイプラインに統合しました。
  * 型チェックが失敗した場合、ビルドが失敗するよう厳格化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->